### PR TITLE
ImageTag & persistent storage permission fix

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.0
+version: 0.25.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       - name: api-db
         securityContext:
           {{- toYaml .Values.apiDB.securityContext | nindent 10 }}
-        image: "{{ .Values.apiDB.image.repository }}:{{ .Values.apiDB.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.apiDB.image.repository }}:{{ coalesce .Values.apiDB.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.apiDB.image.pullPolicy }}
         env:
         - name: MARIADB_PASSWORD

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - name: api
         securityContext:
           {{- toYaml .Values.api.securityContext | nindent 10 }}
-        image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.api.image.pullPolicy }}
         env:
         - name: API_DB_HOST

--- a/charts/lagoon-core/templates/auth-server.deployment.yaml
+++ b/charts/lagoon-core/templates/auth-server.deployment.yaml
@@ -32,7 +32,7 @@ spec:
       - name: auth-server
         securityContext:
           {{- toYaml .Values.authServer.securityContext | nindent 10 }}
-        image: "{{ .Values.authServer.image.repository }}:{{ .Values.authServer.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.authServer.image.repository }}:{{ coalesce .Values.authServer.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.authServer.image.pullPolicy }}
         env:
         - name: JWTSECRET

--- a/charts/lagoon-core/templates/auto-idler.deployment.yaml
+++ b/charts/lagoon-core/templates/auto-idler.deployment.yaml
@@ -30,7 +30,7 @@ spec:
       - name: auto-idler
         securityContext:
           {{- toYaml .Values.autoIdler.securityContext | nindent 10 }}
-        image: "{{ .Values.autoIdler.image.repository }}:{{ .Values.autoIdler.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.autoIdler.image.repository }}:{{ coalesce .Values.autoIdler.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.autoIdler.image.pullPolicy }}
         env:
         - name: ELASTICSEARCH_URL

--- a/charts/lagoon-core/templates/backup-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/backup-handler.deployment.yaml
@@ -32,7 +32,7 @@ spec:
       - name: backup-handler
         securityContext:
           {{- toYaml .Values.backupHandler.securityContext | nindent 10 }}
-        image: "{{ .Values.backupHandler.image.repository }}:{{ .Values.backupHandler.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.backupHandler.image.repository }}:{{ coalesce .Values.backupHandler.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.backupHandler.image.pullPolicy }}
         command:
         - "sh"

--- a/charts/lagoon-core/templates/broker.statefulset.yaml
+++ b/charts/lagoon-core/templates/broker.statefulset.yaml
@@ -33,7 +33,7 @@ spec:
       - name: broker
         securityContext:
           {{- toYaml .Values.broker.securityContext | nindent 10 }}
-        image: "{{ .Values.broker.image.repository }}:{{ .Values.broker.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.broker.image.repository }}:{{ coalesce .Values.broker.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.broker.image.pullPolicy }}
         command:
         - sh

--- a/charts/lagoon-core/templates/controllerhandler.deployment.yaml
+++ b/charts/lagoon-core/templates/controllerhandler.deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: controllerhandler
         securityContext:
           {{- toYaml .Values.controllerhandler.securityContext | nindent 10 }}
-        image: "{{ .Values.controllerhandler.image.repository }}:{{ .Values.controllerhandler.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.controllerhandler.image.repository }}:{{ coalesce .Values.controllerhandler.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.controllerhandler.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-core/templates/drush-alias.deployment.yaml
+++ b/charts/lagoon-core/templates/drush-alias.deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - name: drush-alias
         securityContext:
           {{- toYaml .Values.drushAlias.securityContext | nindent 10 }}
-        image: "{{ .Values.drushAlias.image.repository }}:{{ .Values.drushAlias.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.drushAlias.image.repository }}:{{ coalesce .Values.drushAlias.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.drushAlias.image.pullPolicy }}
         ports:
         - name: http-8080

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       - name: keycloak-db
         securityContext:
           {{- toYaml .Values.keycloakDB.securityContext | nindent 10 }}
-        image: "{{ .Values.keycloakDB.image.repository }}:{{ .Values.keycloakDB.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.keycloakDB.image.repository }}:{{ coalesce .Values.keycloakDB.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.keycloakDB.image.pullPolicy }}
         env:
         - name: MARIADB_PASSWORD

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -28,7 +28,7 @@ spec:
       - name: keycloak
         securityContext:
           {{- toYaml .Values.keycloak.securityContext | nindent 10 }}
-        image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.keycloak.image.repository }}:{{ coalesce .Values.keycloak.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.keycloak.image.pullPolicy }}
         env:
         - name: JAVA_OPTS

--- a/charts/lagoon-core/templates/logs-db-curator.deployment.yaml
+++ b/charts/lagoon-core/templates/logs-db-curator.deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - name: logs-db-curator
         securityContext:
           {{- toYaml .Values.logsDBCurator.securityContext | nindent 10 }}
-        image: "{{ .Values.logsDBCurator.image.repository }}:{{ .Values.logsDBCurator.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.logsDBCurator.image.repository }}:{{ coalesce .Values.logsDBCurator.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.logsDBCurator.image.pullPolicy }}
         env:
         - name: ELASTICSEARCH_HOST

--- a/charts/lagoon-core/templates/logs2email.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2email.deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: logs2email
         securityContext:
           {{- toYaml .Values.logs2email.securityContext | nindent 10 }}
-        image: "{{ .Values.logs2email.image.repository }}:{{ .Values.logs2email.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.logs2email.image.repository }}:{{ coalesce .Values.logs2email.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.logs2email.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-core/templates/logs2microsoftteams.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2microsoftteams.deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: logs2microsoftteams
         securityContext:
           {{- toYaml .Values.logs2microsoftteams.securityContext | nindent 10 }}
-        image: "{{ .Values.logs2microsoftteams.image.repository }}:{{ .Values.logs2microsoftteams.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.logs2microsoftteams.image.repository }}:{{ coalesce .Values.logs2microsoftteams.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.logs2microsoftteams.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-core/templates/logs2rocketchat.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2rocketchat.deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: logs2rocketchat
         securityContext:
           {{- toYaml .Values.logs2rocketchat.securityContext | nindent 10 }}
-        image: "{{ .Values.logs2rocketchat.image.repository }}:{{ .Values.logs2rocketchat.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.logs2rocketchat.image.repository }}:{{ coalesce .Values.logs2rocketchat.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.logs2rocketchat.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-core/templates/logs2slack.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2slack.deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: logs2slack
         securityContext:
           {{- toYaml .Values.logs2slack.securityContext | nindent 10 }}
-        image: "{{ .Values.logs2slack.image.repository }}:{{ .Values.logs2slack.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.logs2slack.image.repository }}:{{ coalesce .Values.logs2slack.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.logs2slack.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-core/templates/ssh-portal.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.deployment.yaml
@@ -27,7 +27,7 @@ spec:
       - name: ssh-portal
         securityContext:
           {{- toYaml .Values.sshPortal.securityContext | nindent 10 }}
-        image: "{{ .Values.sshPortal.image.repository }}:{{ .Values.sshPortal.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.sshPortal.image.repository }}:{{ coalesce .Values.sshPortal.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.sshPortal.image.pullPolicy }}
         command:
         - "/ssh-portal"

--- a/charts/lagoon-core/templates/ssh.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh.deployment.yaml
@@ -25,7 +25,7 @@ spec:
       - name: ssh
         securityContext:
           {{- toYaml .Values.ssh.securityContext | nindent 10 }}
-        image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.ssh.image.repository }}:{{ coalesce .Values.ssh.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.ssh.image.pullPolicy }}
         env:
         - name: API_DB_HOST

--- a/charts/lagoon-core/templates/ui.deployment.yaml
+++ b/charts/lagoon-core/templates/ui.deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - name: ui
         securityContext:
           {{- toYaml .Values.ui.securityContext | nindent 10 }}
-        image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.ui.image.repository }}:{{ coalesce .Values.ui.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
         env:
         - name: GRAPHQL_API

--- a/charts/lagoon-core/templates/webhook-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/webhook-handler.deployment.yaml
@@ -32,7 +32,7 @@ spec:
       - name: webhook-handler
         securityContext:
           {{- toYaml .Values.webhookHandler.securityContext | nindent 10 }}
-        image: "{{ .Values.webhookHandler.image.repository }}:{{ .Values.webhookHandler.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.webhookHandler.image.repository }}:{{ coalesce .Values.webhookHandler.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.webhookHandler.image.pullPolicy }}
         env:
         - name: RABBITMQ_HOST

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: webhooks2tasks
         securityContext:
           {{- toYaml .Values.webhooks2tasks.securityContext | nindent 10 }}
-        image: "{{ .Values.webhooks2tasks.image.repository }}:{{ .Values.webhooks2tasks.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.webhooks2tasks.image.repository }}:{{ coalesce .Values.webhooks2tasks.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.webhooks2tasks.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -115,6 +115,10 @@ apiDB:
       --quick --add-locks --no-autocommit --single-transaction --all-databases"
     backup.appuio.ch/file-extension: .api-db.sql
 
+  podSecurityContext:
+    runAsUser: 100
+    fsGroup: 0
+
 apiRedis:
   image:
     repository: amazeeiolagoon/api-redis
@@ -169,6 +173,10 @@ keycloakDB:
       /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines
       --quick --add-locks --no-autocommit --single-transaction --all-databases"
     backup.appuio.ch/file-extension: .keycloak-db.sql
+
+  podSecurityContext:
+    runAsUser: 100
+    fsGroup: 0
 
 broker:
   replicaCount: 3

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -63,6 +63,10 @@ imagePullSecrets: []
 podSecurityContext:
   runAsUser: 100
 
+# this default image tag is set for all services and can be overridden
+# on the service level, if not set is uses chart appVersion
+imageTag: ""
+
 # the following services are part of the lagoon-core chart
 
 api:


### PR DESCRIPTION
- allow to globaly overwrite imageTag 
- define `fsGroup: 0` for `api-d`b and `keycloak-db` this makes sure the persistent storage actually has the file permissions correctly (writeable for group)

