### PR TITLE
Enable Linting without check-version, and only release on tag push

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,6 @@
 name: Lint and Test Charts
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   lint-test:
@@ -29,4 +29,11 @@ jobs:
       with:
         image: smlx/chart-testing:v3.0.0-patch.2
         command: install
+        config: ct.yaml
+
+    - name: Show changed charts
+      uses: helm/chart-testing-action@v1.0.0
+      with:
+        image: smlx/chart-testing:v3.0.0-patch.2
+        command: list-changed
         config: ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release Charts
 
 on:
   push:
-    branches:
-    - main
+    tags:
+      - lagoon-*
 
 jobs:
   release:
@@ -14,6 +14,17 @@ jobs:
 
     - name: Fetch history
       run: git fetch --prune --unshallow
+
+    - name: Override check-version-increment
+      run: sed -i "/^check-version-increment/ s/false/true/" ct.yaml
+
+    - name: Run chart-testing (lint)
+      id: lint
+      uses: helm/chart-testing-action@v1.0.0
+      with:
+        image: smlx/chart-testing:v3.0.0-patch.2
+        command: lint
+        config: ct.yaml
 
     - name: Configure Git
       run: |

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,7 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
 target-branch: main
+check-version-increment: false
 chart-dirs:
 - charts
 chart-repos:


### PR DESCRIPTION
This PR removes the `check-version-increment` step from linting - which means that linting will run on every push or pull request

Instead the `check-version-increment` step runs ahead of a release, which will only be triggered on a tag push - so if you tag a release and the chart version isn't changed, the release will fail.  You'll have to push a new chart version and retag.

It's not currently smart enough to know what or how to tag charts - having multiple charts in the same repo makes this harder.