### PR TITLE
Enforce version bump in lint

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
 target-branch: main
-check-version-increment: false
 chart-dirs:
 - charts
 chart-repos:


### PR DESCRIPTION
Reverts the last of the functional changes made in #93, most of which have already been reverted.