### PR TITLE
add API_HOST back to api, load harbor password from secret

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.28.0
+version: 0.28.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -66,10 +66,13 @@ spec:
         - name: GITLAB_API_TOKEN
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.harborAdminPassword }}
+        - name: API_HOST
+          value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}
         - name: HARBOR_ADMIN_PASSWORD
-          value: {{ . | quote }}
-        {{- end }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.api.fullname" . }}
+              key: HARBOR_ADMIN_PASSWORD
         - name: HARBOR_URL
           value: {{ required "A valid .Values.harborURL required!" .Values.harborURL | quote }}
         - name: JWTSECRET

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -66,8 +66,6 @@ spec:
         - name: GITLAB_API_TOKEN
           value: {{ . | quote }}
         {{- end }}
-        - name: API_HOST
-          value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}
         - name: HARBOR_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- realized that the api actually needs API_HOST after all
- harbor password is stored in a secret so we can load it from there.