### PR TITLE
Add Backwards Compatibility Support for Harbor v1 API

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.28.1
+version: 0.29.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -71,6 +71,8 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.api.fullname" . }}
               key: HARBOR_ADMIN_PASSWORD
+        - name: HARBOR_API_VERSION
+          value: {{ required "A valid .Values.harborAPIVersion required!" .Values.harborURL | quote }}
         - name: HARBOR_URL
           value: {{ required "A valid .Values.harborURL required!" .Values.harborURL | quote }}
         - name: JWTSECRET

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -72,7 +72,7 @@ spec:
               name: {{ include "lagoon-core.api.fullname" . }}
               key: HARBOR_ADMIN_PASSWORD
         - name: HARBOR_API_VERSION
-          value: {{ .Values.harborAPIVersion | default "v2.0" | quote }}
+          value: {{ .Values.harborAPIVersion | quote }}
         - name: HARBOR_URL
           value: {{ required "A valid .Values.harborURL required!" .Values.harborURL | quote }}
         - name: JWTSECRET

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -72,7 +72,7 @@ spec:
               name: {{ include "lagoon-core.api.fullname" . }}
               key: HARBOR_ADMIN_PASSWORD
         - name: HARBOR_API_VERSION
-          value: {{ required "A valid .Values.harborAPIVersion required!" .Values.harborAPIVersion | quote }}
+          value: {{ .Values.harborAPIVersion | default "v2.0" | quote }}
         - name: HARBOR_URL
           value: {{ required "A valid .Values.harborURL required!" .Values.harborURL | quote }}
         - name: JWTSECRET

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -72,7 +72,7 @@ spec:
               name: {{ include "lagoon-core.api.fullname" . }}
               key: HARBOR_ADMIN_PASSWORD
         - name: HARBOR_API_VERSION
-          value: {{ required "A valid .Values.harborAPIVersion required!" .Values.harborURL | quote }}
+          value: {{ required "A valid .Values.harborAPIVersion required!" .Values.harborAPIVersion | quote }}
         - name: HARBOR_URL
           value: {{ required "A valid .Values.harborURL required!" .Values.harborURL | quote }}
         - name: JWTSECRET

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -1,20 +1,18 @@
 # These values must be set on install, as they don't have sensible defaults.
 
 # elasticsearchHost:
-# harborURL:
 # harborAdminPassword:
-# harborAPIVersion:
+# harborURL:
 # kibanaURL:
 # registry:
-# sshHostKeyRSA:
 # sshHostKeyED25519:
+# sshHostKeyRSA:
+# s3BAASSecretAccessKey:
+# s3BAASAccessKeyID:
 # s3FilesAccessKeyID:
 # s3FilesBucket:
 # s3FilesHost:
 # s3SecretAccessKey:
-# s3BAASAccessKeyID:
-# s3BAASSecretAccessKey:
-
 
 # These values are optional.
 
@@ -23,17 +21,18 @@
 # These values are optional depending on the services Lagoon is integrated with
 # in your environment.
 
-# s3Region:
-# gitlabAPIURL:
 # gitlabAPIToken:
-# bitbucketAPIURL:
+# gitlabAPIURL:
 # bitbucketAPIToken:
+# bitbucketAPIURL:
+# s3Region:
 
 # These values may be set on install, otherwise the chart tries to guess
 # sensible defaults.
 
-# lagoonAPIURL: https://api.example.com/graphql
+# harborAPIVersion: "v2.0"
 # keycloakAPIURL: https://keycloak.example.com/auth
+# lagoonAPIURL: https://api.example.com/graphql
 # lagoonUIURL: https://ui.example.com/
 # lagoonWebhookURL: https://webhook-handler.example.com/
 
@@ -42,11 +41,11 @@
 # apiDBPassword:
 # harborAdminPassword:
 # jwtSecret:
-# keycloakAPIClientSecret:
 # keycloakAdminPassword:
+# keycloakAPIClientSecret:
 # keycloakAuthServerClientSecret:
-# keycloakLagoonAdminPassword:
 # keycloakDBPassword:
+# keycloakLagoonAdminPassword:
 # logsDBAdminPassword:
 # rabbitMQPassword:
 # redisPassword:
@@ -56,9 +55,9 @@
 elasticsearchScheme: https
 elasticsearchHostPort: 9200
 
-rabbitMQUsername: lagoon
-
 imagePullSecrets: []
+
+rabbitMQUsername: lagoon
 
 # this default podSecurityContext is set for all services and can be overridden
 # on the service level

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -59,6 +59,9 @@ imagePullSecrets: []
 
 rabbitMQUsername: lagoon
 
+harborAPIVersion: v2.0
+# Set to an empty string to support Harbor v1.x.x
+
 # this default podSecurityContext is set for all services and can be overridden
 # on the service level
 podSecurityContext:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -3,6 +3,7 @@
 # elasticsearchHost:
 # harborURL:
 # harborAdminPassword:
+# harborAPIVersion:
 # kibanaURL:
 # registry:
 # sshHostKeyRSA:


### PR DESCRIPTION
This PR adds the `HarborAPIVersion` value, which allows us to maintain backwards compatibility with Harbor v1 while also supporting Harbor v2 as well. This PR works in tandem with the variable introduced in [Lagoon PR #2231](https://github.com/amazeeio/lagoon/issues/2231) to provide this functionality.