### PR TITLE
Bump the logging-operator dependency version

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.4.0
-digest: sha256:d248221846af4df24cb1402d84c6bf8d8db6c26a6348d10345bd5572ed6d8ab7
-generated: "2020-07-15T11:52:39.381243481+08:00"
+  version: 3.6.1
+digest: sha256:92f194cf855a427258a75db9eba682d7e164f01e3813b1c704fe9c48cf846173
+generated: "2020-10-20T09:46:29.986661529+08:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -29,4 +29,4 @@ appVersion: 0.1.0
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: ~3.4.0
+  version: ~3.6.0

--- a/charts/lagoon-logging/templates/clusterflow.yaml
+++ b/charts/lagoon-logging/templates/clusterflow.yaml
@@ -23,5 +23,5 @@ spec:
   {{- end }}
   filters:
   - tag_normaliser: {}
-  outputRefs:
+  globalOutputRefs:
   - {{ include "lagoon-logging.fullname" . }}


### PR DESCRIPTION
This requires an update to the CRD as per
https://github.com/banzaicloud/logging-operator/releases/tag/3.6.0

Closes: #57 