### PR TITLE
Rely on upstream chart-testing image

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,7 +18,6 @@ jobs:
       id: lint
       uses: helm/chart-testing-action@v1.1.0
       with:
-        image: smlx/chart-testing:v3.0.0-patch.2
         command: lint
         config: default.ct.yaml
 
@@ -29,14 +28,12 @@ jobs:
     - name: Run chart-testing (install)
       uses: helm/chart-testing-action@v1.1.0
       with:
-        image: smlx/chart-testing:v3.0.0-patch.2
         command: install
         config: default.ct.yaml
 
     - name: Show changed charts
       uses: helm/chart-testing-action@v1.1.0
       with:
-        image: smlx/chart-testing:v3.0.0-patch.2
         command: list-changed
         config: default.ct.yaml
 
@@ -54,7 +51,6 @@ jobs:
       id: lint
       uses: helm/chart-testing-action@v1.1.0
       with:
-        image: smlx/chart-testing:v3.0.0-patch.2
         command: lint
         config: test-suite-lint.ct.yaml
 
@@ -178,6 +174,5 @@ jobs:
       uses: helm/chart-testing-action@v1.1.0
       if: steps.lint.outputs.changed == 'true'
       with:
-        image: smlx/chart-testing:v3.0.0-patch.2
         command: install
         config: test-suite-run.ct.yaml


### PR DESCRIPTION
We were using a custom chart-testing image, but the required changes are available in [3.1.0](https://github.com/helm/chart-testing/releases/tag/v3.1.0)+.

Specifically we needed:
* https://github.com/helm/chart-testing/pull/250
* https://github.com/helm/chart-testing/pull/252
* https://github.com/helm/chart-testing/pull/253
* https://github.com/helm/chart-testing/pull/260

Closes: #108
