### PR TITLE
Refactor secrets

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.0
+version: 0.31.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -4,6 +4,7 @@
 elasticsearchHost: opendistro-es-client-service.opendistro-es.svc.cluster.local
 elasticsearchScheme: http
 harborURL: http://harbor:1234
+harborAdminPassword: harbor123
 kibanaURL: http://opendistro-es-kibana-svc.opendistro-es.svc.cluster.local:443
 logsDBAdminPassword: admin
 registry: registry.example.com:5000

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -62,15 +62,6 @@ spec:
         - name: GITLAB_API_HOST
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.gitlabAPIToken }}
-        - name: GITLAB_API_TOKEN
-          value: {{ . | quote }}
-        {{- end }}
-        - name: HARBOR_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "lagoon-core.api.fullname" . }}
-              key: HARBOR_ADMIN_PASSWORD
         - name: HARBOR_API_VERSION
           value: {{ .Values.harborAPIVersion | quote }}
         - name: HARBOR_URL

--- a/charts/lagoon-core/templates/api.secret.yaml
+++ b/charts/lagoon-core/templates/api.secret.yaml
@@ -5,7 +5,6 @@ This somewhat complex logic is intended to:
   * allow overriding if the value is explicitly defined
 */}}
 {{- $data := index (lookup "v1" "Secret" .Release.Namespace (include "lagoon-core.api.fullname" .)) "data" | default dict }}
-{{- $harborAdminPassword := coalesce .Values.harborAdminPassword (ternary (randAlpha 32) (index $data "HARBOR_ADMIN_PASSWORD" | default "" | b64dec) (index $data "HARBOR_ADMIN_PASSWORD" | empty)) }}
 {{- $logsDBAdminPassword := coalesce .Values.logsDBAdminPassword (ternary (randAlpha 32) (index $data "LOGSDB_ADMIN_PASSWORD" | default "" | b64dec) (index $data "LOGSDB_ADMIN_PASSWORD" | empty)) }}
 {{- $redisPassword := coalesce .Values.redisPassword (ternary (randAlpha 32) (index $data "REDIS_PASSWORD" | default "" | b64dec) (index $data "REDIS_PASSWORD" | empty)) }}
 apiVersion: v1
@@ -18,8 +17,11 @@ metadata:
 stringData:
   REDIS_PASSWORD: {{ $redisPassword | quote }}
   LOGSDB_ADMIN_PASSWORD: {{ $logsDBAdminPassword | quote }}
-  HARBOR_ADMIN_PASSWORD: {{ $harborAdminPassword | quote }}
+  HARBOR_ADMIN_PASSWORD: {{ required "A valid .Values.harborAdminPassword required!" .Values.harborAdminPassword | quote }}
   S3_FILES_ACCESS_KEY_ID: {{ required "A valid .Values.s3FilesAccessKeyID required!" .Values.s3FilesAccessKeyID | quote }}
   S3_FILES_SECRET_ACCESS_KEY: {{ required "A valid .Values.s3FilesSecretAccessKey required!" .Values.s3FilesSecretAccessKey | quote }}
   S3_BAAS_ACCESS_KEY_ID: {{ required "A valid .Values.s3BAASAccessKeyID required!" .Values.s3BAASAccessKeyID | quote }}
   S3_BAAS_SECRET_ACCESS_KEY: {{ required "A valid .Values.s3BAASSecretAccessKey required!" .Values.s3BAASSecretAccessKey | quote }}
+  {{- with .Values.gitlabAPIToken }}
+  GITLAB_API_TOKEN: {{ . | quote }}
+  {{- end }}

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -44,7 +44,10 @@ spec:
         {{- end }}
         {{- with .Values.gitlabAPIToken }}
         - name: GITLAB_API_TOKEN
-          value: {{ . | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.api.fullname" . }}
+              key: GITLAB_API_TOKEN
         {{- end }}
         - name: JWTSECRET
           valueFrom:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -30,7 +30,6 @@
 # These values may be set on install, otherwise the chart tries to guess
 # sensible defaults.
 
-# harborAPIVersion: "v2.0"
 # keycloakAPIURL: https://keycloak.example.com/auth
 # lagoonAPIURL: https://api.example.com/graphql
 # lagoonUIURL: https://ui.example.com/
@@ -39,7 +38,6 @@
 # These values are randomly generated on install if not otherwise defined.
 
 # apiDBPassword:
-# harborAdminPassword:
 # jwtSecret:
 # keycloakAdminPassword:
 # keycloakAPIClientSecret:
@@ -50,7 +48,7 @@
 # rabbitMQPassword:
 # redisPassword:
 
-# These values are the chart defaults.
+# These values are the chart defaults, but can be overridden.
 
 elasticsearchScheme: https
 elasticsearchHostPort: 9200
@@ -59,16 +57,16 @@ imagePullSecrets: []
 
 rabbitMQUsername: lagoon
 
-harborAPIVersion: v2.0
 # Set to an empty string to support Harbor v1.x.x
+harborAPIVersion: v2.0
 
 # this default podSecurityContext is set for all services and can be overridden
-# on the service level
+# on the service level.
 podSecurityContext:
   runAsUser: 100
 
 # this default image tag is set for all services and can be overridden
-# on the service level, if not set is uses chart appVersion
+# on the service level, if not set it falls back to chart appVersion.
 imageTag: ""
 
 # the following services are part of the lagoon-core chart


### PR DESCRIPTION
Some secrets were directly referenced as environment variables. Avoid this information leak by mounting them via secrets.

Closes: #112 
