### PR TITLE
hotfix: correct apiVersion for ServiceMonitor

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.0
+version: 0.32.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/broker.servicemonitor.yaml
+++ b/charts/lagoon-core/templates/broker.servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.broker.serviceMonitor.enabled -}}
-apiVersion: v1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "lagoon-core.broker.fullname" . }}


### PR DESCRIPTION
hotfix for wrong `apiVersion` of lagoon-core broker.servicemonitor.yaml 