### PR TITLE
Update required repositories in test and release workflows

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: Add dependency chart repos
       if: steps.lint.outputs.changed == 'true'
       run: |
-        helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+        helm repo add stable https://charts.helm.sh/stable
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
     - name: Install gojq

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,11 +27,6 @@ jobs:
         chmod 700 get_helm.sh
         ./get_helm.sh
 
-    - name: Add dependency chart repos
-      run: |
-        helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-        helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
-
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@v1.0.0
       env:


### PR DESCRIPTION
The `stable` helm repository is deprecated and is being removed in a few weeks. The URL has now changed.

A follow-up PR will remove all usage of the `stable` repo. See also https://github.com/uselagoon/lagoon-charts/issues/132
