### PR TITLE
Underline to dashes

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.14.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -176,7 +176,7 @@ data:
     <filter lagoon.*.container>
       @type record_modifier
       <record>
-        index_name container-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project') || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        index_name container-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project').sub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
     # post-process to try to eke some more structure out of the logs.
@@ -225,6 +225,15 @@ data:
     #
     # process application logs
     #
+    # replace underlines with dashes as lagoon-logs creates the namespace manually based on
+    # ${lagoonProject}-${lagoonEnviornment}
+    <filter lagoon.*.application>
+      @type record_modifier
+      remove_keys _dummy_
+      <record>
+        _dummy_ ${record['type'] = record['type'].sub("_", "-"); nil}
+      </record>
+    </filter>
     # restructure so the kubernetes_metadata plugin can find the keys it needs
     <filter lagoon.*.application>
       @type record_modifier
@@ -244,7 +253,7 @@ data:
     <filter lagoon.*.application>
       @type record_modifier
       <record>
-        index_name application-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project') || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        index_name application-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project').sub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
     # strip the kubernetes data as it's duplicated in container/router logs and
@@ -309,7 +318,7 @@ data:
     <filter lagoon.*.router.**>
       @type record_modifier
       <record>
-        index_name router-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project') || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        index_name router-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project').sub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
 


### PR DESCRIPTION
lagoon projectnames with underlines are deprecated
unfortunately we still have some projects with underlines, but no auxiliary systems (kibana, billing, etc.) support them, so we change underlines to dashes when creating the indexes

