### PR TITLE
Safe underscore replacement

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.2
+version: 0.14.3
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -230,7 +230,10 @@ data:
       @type record_modifier
       remove_keys _dummy_,type
       <record>
-        _dummy_ ${record['openshift_project'] = record['type']; record['kubernetes'] = {'namespace_name' => record['type'], 'pod_name' => record['host'], 'container_name' => 'unknown'}; record['docker'] = {'container_id' => "#{record['type']}_#{record['host']}"}; nil}
+        # modify the 'type' record before removal to convert underscores to
+        # hyphens as the former are illegal in k8s names. Lagoon does this same
+        # modification when creating the namespace.
+        _dummy_ ${record['openshift_project'] = record['type']&.gsub!('_', '-'); record['kubernetes'] = {'namespace_name' => record['type'], 'pod_name' => record['host'], 'container_name' => 'unknown'}; record['docker'] = {'container_id' => "#{record['type']}_#{record['host']}"}; nil}
       </record>
     </filter>
     # enrich with k8s metadata (will get the namespace labels)

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -176,7 +176,7 @@ data:
     <filter lagoon.*.container>
       @type record_modifier
       <record>
-        index_name container-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project').sub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        index_name container-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project')&.gsub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
     # post-process to try to eke some more structure out of the logs.
@@ -225,15 +225,6 @@ data:
     #
     # process application logs
     #
-    # replace underlines with dashes as lagoon-logs creates the namespace manually based on
-    # ${lagoonProject}-${lagoonEnviornment}
-    <filter lagoon.*.application>
-      @type record_modifier
-      remove_keys _dummy_
-      <record>
-        _dummy_ ${record['type'] = record['type'].sub("_", "-"); nil}
-      </record>
-    </filter>
     # restructure so the kubernetes_metadata plugin can find the keys it needs
     <filter lagoon.*.application>
       @type record_modifier
@@ -253,7 +244,7 @@ data:
     <filter lagoon.*.application>
       @type record_modifier
       <record>
-        index_name application-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project').sub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        index_name application-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project')&.gsub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
     # strip the kubernetes data as it's duplicated in container/router logs and
@@ -318,7 +309,7 @@ data:
     <filter lagoon.*.router.**>
       @type record_modifier
       <record>
-        index_name router-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project').sub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        index_name router-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project')&.gsub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
 


### PR DESCRIPTION
There are a couple of issues with the change from https://github.com/uselagoon/lagoon-charts/pull/140

1. the result of `record.dig()` may be nil, so calling `sub()` will raise an exception (and cause the worker thread to restart). This PR fixes that by using the lonely operator.
2. `sub()` only replaces the _first_ match. This PR changes it to use `gsub()` instead.

The result of this logic is:

* the project part of the index names in Elasticsearch will have their underscores replaced by hyphens. 
* the field `lagoon_sh/project` within the log record will still have the original project name with any underscores.

Is that the way it should be @Schnitzel?
