### PR TITLE
Build Deploy controller Openshift and Build Image support

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/crds/lagoonBuild.yaml
+++ b/charts/lagoon-remote/crds/lagoonBuild.yaml
@@ -49,7 +49,6 @@ spec:
                 type:
                   type: string
               required:
-              - image
               - type
               type: object
             gitReference:
@@ -157,15 +156,15 @@ spec:
                 of cluster Important: Run "make" to regenerate code after modifying
                 this file'
               items:
-                description: LagoonBuildConditions defines the observed conditions
-                  of the migrations
+                description: LagoonConditions defines the observed conditions of the
+                  pods.
                 properties:
                   lastTransitionTime:
                     type: string
                   status:
                     type: string
                   type:
-                    description: BuildConditionType const for the status type
+                    description: JobConditionType const for the status type
                     type: string
                 required:
                 - lastTransitionTime
@@ -193,6 +192,8 @@ spec:
                   description: LagoonLogMeta is the metadata that is used by logging
                     in Lagoon.
                   properties:
+                    advancedData:
+                      type: string
                     branchName:
                       type: string
                     buildName:
@@ -204,6 +205,10 @@ spec:
                     environment:
                       type: string
                     jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
                       type: string
                     logLink:
                       type: string
@@ -223,8 +228,33 @@ spec:
                       items:
                         type: string
                       type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
                     startTime:
                       type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
                   type: object
                 project:
                   type: string
@@ -241,6 +271,8 @@ spec:
                   description: LagoonLogMeta is the metadata that is used by logging
                     in Lagoon.
                   properties:
+                    advancedData:
+                      type: string
                     branchName:
                       type: string
                     buildName:
@@ -252,6 +284,10 @@ spec:
                     environment:
                       type: string
                     jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
                       type: string
                     logLink:
                       type: string
@@ -271,8 +307,33 @@ spec:
                       items:
                         type: string
                       type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
                     startTime:
                       type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
                   type: object
                 namespace:
                   type: string
@@ -291,6 +352,8 @@ spec:
                   description: LagoonLogMeta is the metadata that is used by logging
                     in Lagoon.
                   properties:
+                    advancedData:
+                      type: string
                     branchName:
                       type: string
                     buildName:
@@ -302,6 +365,10 @@ spec:
                     environment:
                       type: string
                     jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
                       type: string
                     logLink:
                       type: string
@@ -321,8 +388,33 @@ spec:
                       items:
                         type: string
                       type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
                     startTime:
                       type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
                   type: object
                 project:
                   type: string

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -72,8 +72,13 @@ lagoonBuildDeploy:
     repository: amazeeio/lagoon-builddeploy
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.1.3"
+    tag: "v0.1.4"
 
+  # If the controller is running in an openshift,
+  # then the argument `--is-openshift=true` should be added
+  # By default the controller will use the image `uselagoon/kubectl-build-deploy-dind:latest`
+  # but this can be overridden using the `--override-builddeploy-image=<image>` argument
+  # or adding the environment variable `OVERRIDE_BUILD_DEPLOY_DIND_IMAGE` to the controller deployment
   extraArgs:
   - "--metrics-addr=127.0.0.1:8080"
   - "--enable-leader-election=true"


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

The Lagoon Build Deploy controller v0.1.4 supports Openshift now, this PR adds some notes in the `values.yaml` file with information around this. Also updated the CRD to the latest version.

Quick run down on the changes:

The controller supports defining the build image that gets injected into a Lagoon Build, as this will no longer be handled by Lagoon core in the future. 

Currently Lagoon will inject the `image` into the build spec and send that to the controller, and the controller will use what is in the spec before it uses what the controller has defined. This is on purpose, as there may be changes in Lagoon in the future that could allow for custom build images to be injected directly into the build per project/environment and override what is defined by the controller. 

The controller will default to using `uselagoon/kubectl-build-deploy-dind:latest` as the image if one is not defined anywhere else.

I think this can be merged any time as the existing functionality of the controller is unchanged in v0.1.4 of the controller.

This is work that was done to support Openshift using the controller for Lagoon https://github.com/amazeeio/lagoon/pull/2216