### PR TITLE
Manually add required repository for chart-releaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Fetch history
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: "0"
 
     - name: Configure Git
       run: |
@@ -26,6 +25,10 @@ jobs:
         curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
         chmod 700 get_helm.sh
         ./get_helm.sh
+
+    - name: Add dependency chart repos
+      run: |
+        helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
 
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@v1.1.0


### PR DESCRIPTION
chart-releaser-action v1.1.0 seems to have broken the previous automatic workflow.

