### PR TITLE
Reference correct generation Lagoon images and support .Values.imageTag

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.2
+version: 0.33.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -73,8 +73,6 @@ sshHostKeyED25519: |-
 api:
   replicaCount: 1
   # TODO: remove this once a 2.x release is the chart appVersion
-  image:
-    tag: main
 
 broker:
   replicaCount: 1
@@ -84,8 +82,6 @@ broker:
 authServer:
   replicaCount: 1
   # TODO: remove this once a 2.x release is the chart appVersion
-  image:
-    tag: main
 
 webhooks2tasks:
   replicaCount: 1

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -72,46 +72,98 @@ sshHostKeyED25519: |-
 
 api:
   replicaCount: 1
-  # TODO: remove this once a 2.x release is the chart appVersion
+  image:
+    repository: testlagoon/api
+
+apiDB:
+  image:
+    repository: testlagoon/api-db
+
+apiRedis:
+  image:
+    repository: testlagoon/api-redis
+
+keycloak:
+  image:
+    repository: testlagoon/keycloak
+
+keycloakDB:
+  image:
+    repository: testlagoon/keycloak-db
 
 broker:
   replicaCount: 1
   serviceMonitor:
     enabled: false
+  image:
+    repository: testlagoon/broker
 
 authServer:
   replicaCount: 1
-  # TODO: remove this once a 2.x release is the chart appVersion
+  image:
+    repository: testlagoon/auth-server
 
 webhooks2tasks:
   replicaCount: 1
+  image:
+    repository: testlagoon/webhooks2tasks
 
 webhookHandler:
   replicaCount: 1
+  image:
+    repository: testlagoon/webhook-handler
 
 ui:
   replicaCount: 1
+  image:
+    repository: testlagoon/ui
 
 backupHandler:
   replicaCount: 1
+  image:
+    repository: testlagoon/backup-handler
+
+autoIdler:
+  image:
+    repository: testlagoon/auto-idler
+
+storageCalculator:
+  image:
+    repository: testlagoon/storage-calculator
 
 logs2slack:
   replicaCount: 1
+  image:
+    repository: testlagoon/logs2slack
 
 logs2microsoftteams:
   replicaCount: 1
+  image:
+    repository: testlagoon/logs2microsoftteams
 
 logs2rocketchat:
   replicaCount: 1
+  image:
+    repository: testlagoon/logs2rocketchat
 
 logs2email:
   replicaCount: 1
+  image:
+    repository: testlagoon/logs2email
 
 drushAlias:
   replicaCount: 1
+  image:
+    repository: testlagoon/drush-alias
+
+logsDBCurator:
+  image:
+    repository: testlagoon/logs-db-curator
 
 ssh:
   replicaCount: 1
+  image:
+    repository: testlagoon/ssh
 
 sshPortal:
   enabled: true
@@ -120,3 +172,7 @@ sshPortal:
 
 controllerhandler:
   replicaCount: 1
+  image:
+    repository: testlagoon/controllerhandler
+
+imageTag: main

--- a/charts/lagoon-core/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-core/templates/storage-calculator.deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - name: storage-calculator
         securityContext:
           {{- toYaml .Values.storageCalculator.securityContext | nindent 10 }}
-        image: "{{ .Values.storageCalculator.image.repository }}:{{ .Values.storageCalculator.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.storageCalculator.image.repository }}:{{ coalesce .Values.storageCalculator.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.storageCalculator.image.pullPolicy }}
         env:
         - name: JWTSECRET

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -67,14 +67,14 @@ podSecurityContext:
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it falls back to chart appVersion.
-imageTag: "main"
+imageTag: ""
 
 # the following services are part of the lagoon-core chart
 
 api:
   replicaCount: 2
   image:
-    repository: testlagoon/api
+    repository: amazeeiolagoon/api
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -112,7 +112,7 @@ api:
 
 apiDB:
   image:
-    repository: testlagoon/api-db
+    repository: amazeeiolagoon/api-db
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -137,7 +137,7 @@ apiDB:
 
 apiRedis:
   image:
-    repository: testlagoon/api-redis
+    repository: amazeeiolagoon/api-redis
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -155,7 +155,7 @@ apiRedis:
 keycloak:
   replicaCount: 1
   image:
-    repository: testlagoon/keycloak
+    repository: amazeeiolagoon/keycloak
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -187,7 +187,7 @@ keycloak:
 keycloakDB:
   replicaCount: 1
   image:
-    repository: testlagoon/keycloak-db
+    repository: amazeeiolagoon/keycloak-db
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -213,7 +213,7 @@ keycloakDB:
 broker:
   replicaCount: 3
   image:
-    repository: testlagoon/broker
+    repository: amazeeiolagoon/broker
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -276,7 +276,7 @@ broker:
 authServer:
   replicaCount: 2
   image:
-    repository: testlagoon/auth-server
+    repository: amazeeiolagoon/auth-server
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -302,7 +302,7 @@ webhooks2tasks:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/webhooks2tasks
+    repository: amazeeiolagoon/webhooks2tasks
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -324,7 +324,7 @@ webhookHandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/webhook-handler
+    repository: amazeeiolagoon/webhook-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -363,7 +363,7 @@ webhookHandler:
 ui:
   replicaCount: 2
   image:
-    repository: testlagoon/ui
+    repository: amazeeiolagoon/ui
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -402,7 +402,7 @@ ui:
 backupHandler:
   replicaCount: 2
   image:
-    repository: testlagoon/backup-handler
+    repository: amazeeiolagoon/backup-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -441,7 +441,7 @@ backupHandler:
 autoIdler:
   enabled: true
   image:
-    repository: testlagoon/auto-idler
+    repository: amazeeiolagoon/auto-idler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -455,7 +455,7 @@ autoIdler:
 storageCalculator:
   enabled: true
   image:
-    repository: testlagoon/storage-calculator
+    repository: amazeeiolagoon/storage-calculator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -470,7 +470,7 @@ logs2slack:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/logs2slack
+    repository: amazeeiolagoon/logs2slack
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -492,7 +492,7 @@ logs2microsoftteams:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/logs2microsoftteams
+    repository: amazeeiolagoon/logs2microsoftteams
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -514,7 +514,7 @@ logs2rocketchat:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/logs2rocketchat
+    repository: amazeeiolagoon/logs2rocketchat
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -530,7 +530,7 @@ logs2email:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/logs2email
+    repository: amazeeiolagoon/logs2email
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -552,7 +552,7 @@ drushAlias:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/drush-alias
+    repository: amazeeiolagoon/drush-alias
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -591,7 +591,7 @@ drushAlias:
 logsDBCurator:
   enabled: true
   image:
-    repository: testlagoon/logs-db-curator
+    repository: amazeeiolagoon/logs-db-curator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -605,7 +605,7 @@ logsDBCurator:
 ssh:
   replicaCount: 2
   image:
-    repository: testlagoon/ssh
+    repository: amazeeiolagoon/ssh
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -669,7 +669,7 @@ controllerhandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/controllerhandler
+    repository: amazeeiolagoon/controllerhandler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -67,14 +67,14 @@ podSecurityContext:
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it falls back to chart appVersion.
-imageTag: ""
+imageTag: "main"
 
 # the following services are part of the lagoon-core chart
 
 api:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/api
+    repository: testlagoon/api
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -112,7 +112,7 @@ api:
 
 apiDB:
   image:
-    repository: amazeeiolagoon/api-db
+    repository: testlagoon/api-db
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -137,7 +137,7 @@ apiDB:
 
 apiRedis:
   image:
-    repository: amazeeiolagoon/api-redis
+    repository: testlagoon/api-redis
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -155,7 +155,7 @@ apiRedis:
 keycloak:
   replicaCount: 1
   image:
-    repository: amazeeiolagoon/keycloak
+    repository: testlagoon/keycloak
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -187,7 +187,7 @@ keycloak:
 keycloakDB:
   replicaCount: 1
   image:
-    repository: amazeeiolagoon/keycloak-db
+    repository: testlagoon/keycloak-db
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -213,7 +213,7 @@ keycloakDB:
 broker:
   replicaCount: 3
   image:
-    repository: amazeeiolagoon/broker
+    repository: testlagoon/broker
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -276,7 +276,7 @@ broker:
 authServer:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/auth-server
+    repository: testlagoon/auth-server
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -302,7 +302,7 @@ webhooks2tasks:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/webhooks2tasks
+    repository: testlagoon/webhooks2tasks
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -324,7 +324,7 @@ webhookHandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/webhook-handler
+    repository: testlagoon/webhook-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -363,7 +363,7 @@ webhookHandler:
 ui:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/ui
+    repository: testlagoon/ui
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -402,7 +402,7 @@ ui:
 backupHandler:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/backup-handler
+    repository: testlagoon/backup-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -441,7 +441,7 @@ backupHandler:
 autoIdler:
   enabled: true
   image:
-    repository: amazeeiolagoon/auto-idler
+    repository: testlagoon/auto-idler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -455,7 +455,7 @@ autoIdler:
 storageCalculator:
   enabled: true
   image:
-    repository: amazeeiolagoon/storage-calculator
+    repository: testlagoon/storage-calculator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -470,7 +470,7 @@ logs2slack:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2slack
+    repository: testlagoon/logs2slack
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -492,7 +492,7 @@ logs2microsoftteams:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2microsoftteams
+    repository: testlagoon/logs2microsoftteams
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -514,7 +514,7 @@ logs2rocketchat:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2rocketchat
+    repository: testlagoon/logs2rocketchat
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -530,7 +530,7 @@ logs2email:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2email
+    repository: testlagoon/logs2email
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -552,7 +552,7 @@ drushAlias:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/drush-alias
+    repository: testlagoon/drush-alias
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -591,7 +591,7 @@ drushAlias:
 logsDBCurator:
   enabled: true
   image:
-    repository: amazeeiolagoon/logs-db-curator
+    repository: testlagoon/logs-db-curator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -605,7 +605,7 @@ logsDBCurator:
 ssh:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/ssh
+    repository: testlagoon/ssh
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -669,7 +669,7 @@ controllerhandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/controllerhandler
+    repository: testlagoon/controllerhandler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.2
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -53,3 +53,15 @@ logging-operator:
 logsDispatcher:
   serviceMonitor:
     enabled: false
+  image:
+    repository: testlagoon/logs-dispatcher
+
+logsTeeRouter:
+  image:
+    repository: testlagoon/logs-tee
+
+logsTeeApplication:
+  image:
+    repository: testlagoon/logs-tee
+
+imageTag: main

--- a/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       - name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-fluentd
         securityContext:
           {{- toYaml .Values.logsDispatcher.securityContext | nindent 10 }}
-        image: "{{ .Values.logsDispatcher.image.repository }}:{{ .Values.logsDispatcher.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.logsDispatcher.image.repository }}:{{ coalesce .Values.logsDispatcher.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.logsDispatcher.image.pullPolicy }}
         ports:
         - containerPort: 24224

--- a/charts/lagoon-logging/templates/logs-tee.deployment.yaml
+++ b/charts/lagoon-logging/templates/logs-tee.deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: socat
           securityContext:
             {{- toYaml .Values.logsTeeRouter.securityContext | nindent 12 }}
-          image: "{{ .Values.logsTeeRouter.image.repository }}:{{ .Values.logsTeeRouter.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.logsTeeRouter.image.repository }}:{{ coalesce .Values.logsTeeRouter.image.tag .Values.imageTag .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.logsTeeRouter.image.pullPolicy }}
           args:
           # UDP port in
@@ -89,7 +89,7 @@ spec:
         - name: socat
           securityContext:
             {{- toYaml .Values.logsTeeApplication.securityContext | nindent 12 }}
-          image: "{{ .Values.logsTeeApplication.image.repository }}:{{ .Values.logsTeeApplication.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.logsTeeApplication.image.repository }}:{{ coalesce .Values.logsTeeApplication.image.tag .Values.imageTag .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.logsTeeApplication.image.pullPolicy }}
           args:
           # UDP port in

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it falls back to chart appVersion.
-imageTag: "main"
+imageTag: ""
 
 logsDispatcher:
 
@@ -16,7 +16,7 @@ logsDispatcher:
   replicaCount: 3
 
   image:
-    repository: testlagoon/logs-dispatcher
+    repository: amazeeiolagoon/logs-dispatcher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""
@@ -114,7 +114,7 @@ logsTeeRouter:
   replicaCount: 3
 
   image:
-    repository: testlagoon/logs-tee
+    repository: amazeeiolagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""
@@ -177,7 +177,7 @@ logsTeeApplication:
   replicaCount: 3
 
   image:
-    repository: testlagoon/logs-tee
+    repository: amazeeiolagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -5,6 +5,10 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# this default image tag is set for all services and can be overridden
+# on the service level, if not set it falls back to chart appVersion.
+imageTag: "main"
+
 logsDispatcher:
 
   name: logs-dispatcher
@@ -12,7 +16,7 @@ logsDispatcher:
   replicaCount: 3
 
   image:
-    repository: amazeeiolagoon/logs-dispatcher
+    repository: testlagoon/logs-dispatcher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""
@@ -110,7 +114,7 @@ logsTeeRouter:
   replicaCount: 3
 
   image:
-    repository: amazeeiolagoon/logs-tee
+    repository: testlagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""
@@ -173,7 +177,7 @@ logsTeeApplication:
   replicaCount: 3
 
   image:
-    repository: amazeeiolagoon/logs-tee
+    repository: testlagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -44,3 +44,8 @@ users:
 verifyESVersionAtStartup: false
 serviceMonitor:
   enabled: false
+
+image:
+  repository: testlagoon/logs-concentrator
+
+imageTag: main

--- a/charts/lagoon-logs-concentrator/templates/statefulset.yaml
+++ b/charts/lagoon-logs-concentrator/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       - name: fluentd
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ coalesce .Values.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - name: forward

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# this default image tag is set for all services and can be overridden
+# on the service level, if not set it falls back to chart appVersion.
+imageTag: "main"
+
 replicaCount: 1
 
 image:

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: amazeeiolagoon/logs-concentrator
+  repository: testlagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
   tag: ""

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -4,12 +4,12 @@
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it falls back to chart appVersion.
-imageTag: "main"
+imageTag: ""
 
 replicaCount: 1
 
 image:
-  repository: testlagoon/logs-concentrator
+  repository: amazeeiolagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
   tag: ""

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -4,3 +4,9 @@ rabbitMQHostname: lagoon-core-broker
 lagoonTargetName: ci-local-control-k8s
 lagoonBuildDeploy:
   enabled: true
+
+dockerHost:
+  image:
+    repository: testlagoon/docker-host
+
+imageTag: main

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -17,11 +17,11 @@ pendingMessageCron: "*/5 * * * *"
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it uses chart appVersion
-imageTag: ""
+imageTag: "main"
 
 dockerHost:
   image:
-    repository: amazeeiolagoon/docker-host
+    repository: testlagoon/docker-host
     pullPolicy: Always
     tag: ""
 

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -17,11 +17,11 @@ pendingMessageCron: "*/5 * * * *"
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it uses chart appVersion
-imageTag: "main"
+imageTag: ""
 
 dockerHost:
   image:
-    repository: testlagoon/docker-host
+    repository: amazeeiolagoon/docker-host
     pullPolicy: Always
     tag: ""
 

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.3.2
+version: 0.4.0
 
 appVersion: v1-9-1

--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -5,12 +5,16 @@ routeSuffixHTTP: "${routeSuffixHTTP}"
 routeSuffixHTTPS: "${routeSuffixHTTPS}"
 token: "${token}"
 
-localAPIDataWatcherPusher:
-  # TODO: remove this once a 2.x release is the chart appVersion
+localGit:
   image:
-    tag: "main"
+    repository: testlagoon/local-git
+
+localAPIDataWatcherPusher:
+  image:
+    repository: testlagoon/local-api-data-watcher-pusher
 
 tests:
-  # TODO: remove this once a 2.x release is the chart appVersion
   image:
-    tag: "main"
+    repository: testlagoon/tests
+
+imageTag: main

--- a/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml
+++ b/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml
@@ -27,7 +27,7 @@ spec:
       - name: api-data-watcher-pusher
         securityContext:
           {{- toYaml .Values.localAPIDataWatcherPusher.securityContext | nindent 10 }}
-        image: "{{ .Values.localAPIDataWatcherPusher.image.repository }}:{{ .Values.localAPIDataWatcherPusher.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.localAPIDataWatcherPusher.image.repository }}:{{ coalesce .Values.localAPIDataWatcherPusher.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.localAPIDataWatcherPusher.image.pullPolicy }}
         env:
         - name: API_HOST

--- a/charts/lagoon-test/templates/local-git.deployment.yaml
+++ b/charts/lagoon-test/templates/local-git.deployment.yaml
@@ -27,7 +27,7 @@ spec:
       - name: git
         securityContext:
           {{- toYaml .Values.localGit.securityContext | nindent 10 }}
-        image: "{{ .Values.localGit.image.repository }}:{{ .Values.localGit.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.localGit.image.repository }}:{{ coalesce .Values.localGit.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.localGit.image.pullPolicy }}
         env:
         - name: GIT_AUTHORIZED_KEYS

--- a/charts/lagoon-test/templates/tests/test-suite.yaml
+++ b/charts/lagoon-test/templates/tests/test-suite.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccountName: {{ include "lagoon-test.serviceAccountName" . }}
   containers:
   - name: tests
-    image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag | default .Chart.AppVersion }}"
+    image: "{{ .Values.tests.image.repository }}:{{ coalesce .Values.tests.image.tag .Values.imageTag .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     env:
     - name: API_HOST

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -74,10 +74,14 @@ imagePullSecrets: []
 serviceAccount:
   name: ""
 
+# this default image tag is set for all services and can be overridden
+# on the service level, if not set it falls back to chart appVersion.
+imageTag: "main"
+
 localGit:
 
   image:
-    repository: amazeeiolagoon/local-git
+    repository: testlagoon/local-git
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -103,7 +107,7 @@ localGit:
 localAPIDataWatcherPusher:
 
   image:
-    repository: amazeeiolagoon/local-api-data-watcher-pusher
+    repository: testlagoon/local-api-data-watcher-pusher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -117,7 +121,7 @@ localAPIDataWatcherPusher:
 tests:
 
   image:
-    repository: amazeeiolagoon/tests
+    repository: testlagoon/tests
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -76,12 +76,12 @@ serviceAccount:
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it falls back to chart appVersion.
-imageTag: "main"
+imageTag: ""
 
 localGit:
 
   image:
-    repository: testlagoon/local-git
+    repository: amazeeiolagoon/local-git
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -107,7 +107,7 @@ localGit:
 localAPIDataWatcherPusher:
 
   image:
-    repository: testlagoon/local-api-data-watcher-pusher
+    repository: amazeeiolagoon/local-api-data-watcher-pusher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -121,7 +121,7 @@ localAPIDataWatcherPusher:
 tests:
 
   image:
-    repository: testlagoon/tests
+    repository: amazeeiolagoon/tests
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""


### PR DESCRIPTION
This PR references the `testlagoon/` dockerhub organisation - and sets the `:main` branch for images.

It also adds the necessary logic into all the charts to allow for a top-level .Values.imageTag to be set to override the default image tag behaviour.

Once we have a tagged release of `uselagoon/`-based images, we should switch to them, and then override them with testlagoon images via an additional values.yaml file or similar. 