### PR TITLE
Add support for active-standby to lagoon-remote chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install-ingress:
 		--set controller.service.nodePorts.http=32080 \
 		--set controller.service.nodePorts.https=32443 \
 		--set controller.config.proxy-body-size=100m \
+		--set controller.admissionWebhooks.enabled=false \
 		ingress-nginx \
 		ingress-nginx/ingress-nginx
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/crds/dioscuri.yaml
+++ b/charts/lagoon-remote/crds/dioscuri.yaml
@@ -1,0 +1,247 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  name: hostmigrations.dioscuri.amazee.io
+spec:
+  group: dioscuri.amazee.io
+  names:
+    kind: HostMigration
+    listKind: HostMigrationList
+    plural: hostmigrations
+    singular: hostmigration
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: HostMigration is the Schema for the hostmigrations API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HostMigrationSpec defines the desired state of HostMigration
+          properties:
+            destinationNamespace:
+              description: Migrate is an example field of RouteMigrate. Edit RouteMigrate_types.go
+                to remove/update
+              type: string
+            hosts:
+              description: HostMigrationHosts .
+              properties:
+                activeHosts:
+                  type: string
+                standbyHosts:
+                  type: string
+              required:
+              - activeHosts
+              - standbyHosts
+              type: object
+          type: object
+        status:
+          description: HostMigrationStatus defines the observed state of RouteMigrate
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              items:
+                description: HostMigrationConditions defines the observed conditions
+                  of the migrations
+                properties:
+                  condition:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - condition
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  name: ingressmigrates.dioscuri.amazee.io
+spec:
+  group: dioscuri.amazee.io
+  names:
+    kind: IngressMigrate
+    listKind: IngressMigrateList
+    plural: ingressmigrates
+    singular: ingressmigrate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: IngressMigrate is the Schema for the ingressmigrates API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IngressMigrateSpec defines the desired state of IngressMigrate
+          properties:
+            destinationNamespace:
+              description: Migrate is an example field of Migrate. Edit Migrate_types.go
+                to remove/update
+              type: string
+            ingress:
+              description: MigrateIngress .
+              properties:
+                activeIngress:
+                  type: string
+                standbyIngress:
+                  type: string
+              required:
+              - activeIngress
+              - standbyIngress
+              type: object
+          type: object
+        status:
+          description: IngressMigrateStatus defines the observed state of IngressMigrate
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              items:
+                description: IngressMigrateConditions defines the observed conditions
+                  of the migrations
+                properties:
+                  condition:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - condition
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  name: routemigrates.dioscuri.amazee.io
+spec:
+  group: dioscuri.amazee.io
+  names:
+    kind: RouteMigrate
+    listKind: RouteMigrateList
+    plural: routemigrates
+    singular: routemigrate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: RouteMigrate is the Schema for the routemigrates API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RouteMigrateSpec defines the desired state of RouteMigrate
+          properties:
+            destinationNamespace:
+              description: Migrate is an example field of RouteMigrate. Edit RouteMigrate_types.go
+                to remove/update
+              type: string
+            routes:
+              properties:
+                activeRoutes:
+                  type: string
+                standbyRoutes:
+                  type: string
+              required:
+              - activeRoutes
+              - standbyRoutes
+              type: object
+          type: object
+        status:
+          description: RouteMigrateStatus defines the observed state of RouteMigrate
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              items:
+                description: RouteMigrateConditions defines the observed conditions
+                  of the migrations
+                properties:
+                  condition:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - condition
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/lagoon-remote/crds/lagoonBuild.yaml
+++ b/charts/lagoon-remote/crds/lagoonBuild.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
   name: lagoonbuilds.lagoon.amazee.io
 spec:
   group: lagoon.amazee.io
@@ -430,19 +429,12 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
   name: lagoontasks.lagoon.amazee.io
 spec:
   group: lagoon.amazee.io
@@ -848,9 +840,3 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/lagoon-remote/templates/_helpers.tpl
+++ b/charts/lagoon-remote/templates/_helpers.tpl
@@ -156,3 +156,40 @@ app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-remote.lagoonBuildDeploy.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+
+{{/*
+Create the name of the service account to use for dioscuri.
+*/}}
+{{- define "lagoon-remote.dioscuri.serviceAccountName" -}}
+{{- default (include "lagoon-remote.dioscuri.fullname" .) .Values.dioscuri.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for dioscuri.
+*/}}
+{{- define "lagoon-remote.dioscuri.fullname" -}}
+{{- include "lagoon-remote.fullname" . }}-dioscuri
+{{- end }}
+
+{{/*
+Common labels dioscuri.
+*/}}
+{{- define "lagoon-remote.dioscuri.labels" -}}
+helm.sh/chart: {{ include "lagoon-remote.chart" . }}
+{{ include "lagoon-remote.dioscuri.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels dioscuri.
+*/}}
+{{- define "lagoon-remote.dioscuri.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-remote.dioscuri.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.clusterrole.yaml
@@ -1,0 +1,214 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-manager
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - ingress/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - '*'
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dioscuri.amazee.io
+  resources:
+  - ingressmigrates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dioscuri.amazee.io
+  resources:
+  - ingressmigrates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - dioscuri.amazee.io
+  resources:
+  - routemigrates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dioscuri.amazee.io
+  resources:
+  - routemigrates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+- apiGroups:
+  - dioscuri.amazee.io
+  resources:
+  - hostmigrations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dioscuri.amazee.io
+  resources:
+  - hostmigrations/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-proxy
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-routemigrates-role
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["dioscuri.amazee.io"]
+  resources: ["routemigrates"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-ingressmigrates-role
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["dioscuri.amazee.io"]
+  resources: ["ingressmigrates"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-hostmigrations-role
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["dioscuri.amazee.io"]
+  resources: ["hostmigrations"]
+  verbs: ["*"]
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.clusterrolebinding.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.clusterrolebinding.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-manager
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.dioscuri.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-proxy
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.dioscuri.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-proxy
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.deployment.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.deployment.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-remote.dioscuri.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lagoon-remote.dioscuri.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lagoon-remote.dioscuri.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dioscuri.podSecurityContext | nindent 8 }}
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          {{- toYaml .Values.dioscuri.kubeRBACProxy.securityContext | nindent 10 }}
+        image: "{{ .Values.dioscuri.kubeRBACProxy.image.repository }}:{{ .Values.dioscuri.kubeRBACProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.dioscuri.kubeRBACProxy.image.pullPolicy }}
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          {{- toYaml .Values.dioscuri.kubeRBACProxy.resources | nindent 10 }}
+      - name: manager
+        securityContext:
+          {{- toYaml .Values.dioscuri.securityContext | nindent 10 }}
+        image: "{{ .Values.dioscuri.image.repository }}:{{ .Values.dioscuri.image.tag | default .Chart.AppVersion}}"
+        imagePullPolicy: {{ .Values.dioscuri.image.pullPolicy }}
+        command:
+        - /manager
+        {{- with .Values.dioscuri.extraArgs }}
+        args:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.dioscuri.resources | nindent 10 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.role.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.role.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-leader-election
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.rolebinding.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-leader-election
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}-leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.dioscuri.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.service.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.dioscuri.service.type }}
+  ports:
+  - port: {{ .Values.dioscuri.service.port }}
+    targetPort: https
+    protocol: TCP
+    name: https
+  selector:
+    {{- include "lagoon-remote.dioscuri.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.serviceaccount.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.dioscuri.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lagoon-remote.dioscuri.serviceAccountName" . }}
+  labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
+  {{- with .Values.dioscuri.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/lagoon-build-deploy.deployment.yaml
+++ b/charts/lagoon-remote/templates/lagoon-build-deploy.deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: kube-rbac-proxy
         securityContext:
-          {{- toYaml .Values.kubeRBACProxy.securityContext | nindent 10 }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
+          {{- toYaml .Values.lagoonBuildDeploy.kubeRBACProxy.securityContext | nindent 10 }}
+        image: "{{ .Values.lagoonBuildDeploy.kubeRBACProxy.image.repository }}:{{ .Values.lagoonBuildDeploy.kubeRBACProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.lagoonBuildDeploy.kubeRBACProxy.image.pullPolicy }}
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -36,7 +36,7 @@ spec:
         - containerPort: 8443
           name: https
         resources:
-          {{- toYaml .Values.kubeRBACProxy.resources | nindent 10 }}
+          {{- toYaml .Values.lagoonBuildDeploy.kubeRBACProxy.resources | nindent 10 }}
       - name: manager
         securityContext:
           {{- toYaml .Values.lagoonBuildDeploy.securityContext | nindent 10 }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -74,7 +74,7 @@ lagoonBuildDeploy:
   enabled: false
   image:
     repository: amazeeio/lagoon-builddeploy
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "v0.1.4"
 
@@ -102,17 +102,18 @@ lagoonBuildDeploy:
 
   resources: {}
 
-# this is a sidecar in the same pod as the lagoonBuildDeploy container
-kubeRBACProxy:
-  image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    pullPolicy: Always
-    tag: v0.4.1
+  # this is a sidecar in the same pod as the lagoonBuildDeploy container
+  kubeRBACProxy:
+    image:
+      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      pullPolicy: IfNotPresent
+      tag: v0.4.1
 
-  securityContext: {}
+    securityContext: {}
 
-  resources: {}
+    resources: {}
 
+# this account is used by the legacy Lagoon kubernetes build deploy system.
 kubernetesBuildDeploy:
   serviceAccount:
     # The name of the service account to use.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -119,3 +119,45 @@ kubernetesBuildDeploy:
     # The name of the service account to use.
     # If not set, a name is generated using the fullname template.
     name:
+
+# dioscuri is the name of the operator which implements Lagoon active-standby.
+dioscuri:
+  enabled: true
+  image:
+    repository: amazeeio/dioscuri
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.1.6"
+
+  # If the controller is running in an openshift,
+  # then `--openshift=true` should be set.
+  extraArgs:
+  - "--metrics-addr=127.0.0.1:8080"
+  - "--enable-leader-election=true"
+  # - "--openshift=true"
+
+  service:
+    type: ClusterIP
+    port: 8443
+
+  serviceAccount:
+    # The name of the service account to use.
+    # If not set, a name is generated using the fullname template.
+    name:
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  # this sidecar runs in the same pod as dioscuri
+  kubeRBACProxy:
+    image:
+      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      pullPolicy: IfNotPresent
+      tag: v0.4.1
+
+    securityContext: {}
+
+    resources: {}

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.5.0
+version: 0.6.0
 
 appVersion: v1-9-1

--- a/charts/lagoon-test/templates/tests/test-suite.yaml
+++ b/charts/lagoon-test/templates/tests/test-suite.yaml
@@ -36,5 +36,18 @@ spec:
     - "--skip-tags"
     - "skip-on-kubernetes"
     - "/ansible/tests/nginx.yaml"
+  - name: active-standby-kubernetes
+    image: "{{ .Values.tests.image.repository }}:{{ coalesce .Values.tests.image.tag .Values.imageTag .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+    envFrom:
+    - secretRef:
+        name: {{ include "lagoon-test.fullname" . }}
+    command:
+    - /entrypoint.sh
+    args:
+    - ansible-playbook
+    - "--skip-tags"
+    - "skip-on-kubernetes"
+    - "/ansible/tests/active-standby-kubernetes.yaml"
   restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
This PR combines a few different changes:

* Add [dioscuri](https://github.com/amazeeio/dioscuri) to the lagoon-remote chart to support active-standby in Lagoon.
* Refactor the lagoon-remote values.yaml for consisitency.
* Add the active-standby test suite to CI.
* Disable the ingress-nginx admission controller webhook in CI to work around https://github.com/amazeeio/dioscuri/issues/10. Once that is fixed in dioscuri this change needs to be reverted (https://github.com/uselagoon/lagoon-charts/issues/168).

Closes: #160, partially addresses #118.
