### PR TITLE
Add drupal test suite and supporting services

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+name: Lint and test charts
 
 on: pull_request
 
@@ -59,7 +59,7 @@ jobs:
         fetch-depth: "0"
 
     - name: Set up chart-testing dependencies
-      uses: actions/setup-python@v2
+      run: sudo apt-get -y install python3-wheel
 
     - name: Set up chart-testing
       uses: helm/chart-testing-action@v2.0.1
@@ -82,97 +82,3 @@ jobs:
 
     - name: Run chart-testing (install)
       run: ct install --config ./default.ct.yaml
-
-  # runs for lagoon-core, lagoon-remote, lagoon-test
-  test-suite:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: "0"
-
-    - name: Set up chart-testing dependencies
-      uses: actions/setup-python@v2
-
-    - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.0.1
-
-    - name: Run chart-testing (list-changed)
-      id: list-changed
-      run: |
-        changed=$(ct list-changed --config ./test-suite-lint.ct.yaml)
-        if [[ "$changed" ]]; then
-          echo "::set-output name=changed::true"
-          echo "$changed"
-        fi
-
-    - name: Create kind cluster
-      uses: helm/kind-action@v1.1.0
-      if: steps.list-changed.outputs.changed == 'true'
-      with:
-        config: test-suite.kind-config.yaml
-
-    - name: Install kubectl
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        cd /tmp
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-        chmod +x ./kubectl
-        sudo cp ./kubectl /usr/local/bin/
-
-    - name: Check node IP matches kind configuration
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        NODE_IP="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')"
-        echo Checking for NODE_IP "$NODE_IP"
-        grep $NODE_IP test-suite.kind-config.yaml
-
-    - name: Install Helm
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        cd /tmp
-        curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-        chmod 700 get_helm.sh
-        ./get_helm.sh
-
-    - name: Add dependency chart repos
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        helm repo add harbor https://helm.goharbor.io
-        helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo add bitnami https://charts.bitnami.com/bitnami
-
-    - name: Install gojq
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        cd /tmp
-        curl -sSLO https://github.com/itchyny/gojq/releases/download/v0.11.1/gojq_v0.11.1_linux_amd64.tar.gz
-        tar -xf ./gojq_v0.11.1_linux_amd64.tar.gz
-        sudo cp /tmp/gojq_v0.11.1_linux_amd64/gojq /usr/local/bin/jq
-
-
-    # Uncomment this snippet in your PR to enable the debug action
-    # https://github.com/marketplace/actions/debugging-with-tmate
-    #
-    # Continue after getting a shell via: `touch continue`
-    #
-    - name: Install kubens and kubectl alias
-      run: |
-        cd /tmp
-        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens_v0.9.1_linux_x86_64.tar.gz
-        tar -xf ./kubens_v0.9.1_linux_x86_64.tar.gz
-        sudo cp /tmp/kubens /usr/local/bin/kubens
-        sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
-    - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        make -j8 -O fill-test-ci-values
-
-    - name: Run chart-testing (install) on lagoon-test
-      if: steps.list-changed.outputs.changed == 'true'
-      run: ct install --config ./test-suite-run.ct.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,6 +10,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install Helm
       run: |
+        cd /tmp
         curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
         chmod 700 get_helm.sh
         ./get_helm.sh
@@ -115,6 +116,7 @@ jobs:
     - name: Install kubectl
       if: steps.list-changed.outputs.changed == 'true'
       run: |
+        cd /tmp
         curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
         chmod +x ./kubectl
         sudo cp ./kubectl /usr/local/bin/
@@ -129,6 +131,7 @@ jobs:
     - name: Install Helm
       if: steps.list-changed.outputs.changed == 'true'
       run: |
+        cd /tmp
         curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
         chmod 700 get_helm.sh
         ./get_helm.sh
@@ -144,20 +147,31 @@ jobs:
     - name: Install gojq
       if: steps.list-changed.outputs.changed == 'true'
       run: |
+        cd /tmp
         curl -sSLO https://github.com/itchyny/gojq/releases/download/v0.11.1/gojq_v0.11.1_linux_amd64.tar.gz
-        tar -xf ./gojq_v0.11.1_linux_amd64.tar.gz -C /tmp
+        tar -xf ./gojq_v0.11.1_linux_amd64.tar.gz
         sudo cp /tmp/gojq_v0.11.1_linux_amd64/gojq /usr/local/bin/jq
 
-    - name: Helm-install the test fixutres and fill lagoon-test/ci/linter-values.yaml
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        make -j8 -O fill-test-ci-values
 
     # Uncomment this snippet in your PR to enable the debug action
     # https://github.com/marketplace/actions/debugging-with-tmate
     #
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
+    # Continue after getting a shell via: `touch continue`
+    #
+    - name: Install kubens and kubectl alias
+      run: |
+        cd /tmp
+        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens_v0.9.1_linux_x86_64.tar.gz
+        tar -xf ./kubens_v0.9.1_linux_x86_64.tar.gz
+        sudo cp /tmp/kubens /usr/local/bin/kubens
+        sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
+    - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        make -j8 -O fill-test-ci-values
 
     - name: Run chart-testing (install) on lagoon-test
       if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -139,6 +139,7 @@ jobs:
         helm repo add harbor https://helm.goharbor.io
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo add stable https://charts.helm.sh/stable
+        helm repo add bitnami https://charts.bitnami.com/bitnami
 
     - name: Install gojq
       if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -138,6 +138,7 @@ jobs:
       run: |
         helm repo add harbor https://helm.goharbor.io
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+        helm repo add stable https://charts.helm.sh/stable
 
     - name: Install gojq
       if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -1,0 +1,109 @@
+name: Lagoon tests
+
+on: pull_request
+
+jobs:
+  # runs for lagoon-core, lagoon-remote, lagoon-test
+  test-suite:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        suite:
+        - features-kubernetes
+        - nginx
+        - active-standby-kubernetes
+        - drupal-php72
+        - drupal-php73
+        - drupal-php74
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: "0"
+
+    - name: Set up chart-testing dependencies
+      run: sudo apt-get -y install python3-wheel
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.0.1
+
+    - name: Run chart-testing (list-changed)
+      id: list-changed
+      run: |
+        changed=$(ct list-changed --config ./test-suite-lint.ct.yaml)
+        if [[ "$changed" ]]; then
+          echo "::set-output name=changed::true"
+          echo "$changed"
+        fi
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.1.0
+      if: steps.list-changed.outputs.changed == 'true'
+      with:
+        config: test-suite.kind-config.yaml
+
+    - name: Install kubectl
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        cd /tmp
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo cp ./kubectl /usr/local/bin/
+
+    - name: Check node IP matches kind configuration
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        NODE_IP="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')"
+        echo Checking for NODE_IP "$NODE_IP"
+        grep $NODE_IP test-suite.kind-config.yaml
+
+    - name: Install Helm
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        cd /tmp
+        curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+        chmod 700 get_helm.sh
+        ./get_helm.sh
+
+    - name: Add dependency chart repos
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        helm repo add harbor https://helm.goharbor.io
+        helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+        helm repo add stable https://charts.helm.sh/stable
+        helm repo add bitnami https://charts.bitnami.com/bitnami
+
+    - name: Install gojq
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        cd /tmp
+        curl -sSLO https://github.com/itchyny/gojq/releases/download/v0.11.1/gojq_v0.11.1_linux_amd64.tar.gz
+        tar -xf ./gojq_v0.11.1_linux_amd64.tar.gz
+        sudo cp /tmp/gojq_v0.11.1_linux_amd64/gojq /usr/local/bin/jq
+
+    # Uncomment this snippet in your PR to enable the debug action
+    # https://github.com/marketplace/actions/debugging-with-tmate
+    #
+    # Continue after getting a shell via: `touch continue`
+    #
+    # - name: Install kubens and kubectl alias
+    #   run: |
+    #     cd /tmp
+    #     curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens_v0.9.1_linux_x86_64.tar.gz
+    #     tar -xf ./kubens_v0.9.1_linux_x86_64.tar.gz
+    #     sudo cp /tmp/kubens /usr/local/bin/kubens
+    #     sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
+
+    - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
+      if: steps.list-changed.outputs.changed == 'true'
+      run: make -j8 -O fill-test-ci-values SUITE=${{ matrix.suite }}
+
+    - name: Free up some disk space
+      if: steps.list-changed.outputs.changed == 'true'
+      run: docker system prune -f -a --volumes
+
+    - name: Run chart-testing (install) on lagoon-test
+      if: steps.list-changed.outputs.changed == 'true'
+      run: ct install --config ./test-suite-run.ct.yaml

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ install-lagoon-core:
 		./charts/lagoon-core
 
 .PHONY: install-lagoon-remote
-install-lagoon-remote: install-lagoon-core
+install-lagoon-remote: install-lagoon-core install-mariadb
 	helm upgrade \
 		--install \
 		--create-namespace \
@@ -107,5 +107,10 @@ install-lagoon-remote: install-lagoon-core
 		--values ./charts/lagoon-remote/ci/linter-values.yaml \
 		--set "rabbitMQPassword=$$(kubectl -n lagoon get secret lagoon-core-broker -o json | jq -r '.data.RABBITMQ_PASSWORD | @base64d')" \
 		--set "dockerHost.registry=registry.$$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
+		--set "dbaasOperator.mariadbProviders.development.environment=development" \
+		--set "dbaasOperator.mariadbProviders.development.hostname=mariadb.mariadb.svc.cluster.local" \
+		--set "dbaasOperator.mariadbProviders.development.password=$$(kubectl get secret --namespace mariadb mariadb -o json | jq -r '.data."mariadb-root-password" | @base64d')" \
+		--set "dbaasOperator.mariadbProviders.development.port=3306" \
+		--set "dbaasOperator.mariadbProviders.development.user=root" \
 		lagoon-remote \
 		./charts/lagoon-remote

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ install-lagoon-core:
 		--timeout 15m \
 		--values ./charts/lagoon-core/ci/linter-values.yaml \
 		--set autoIdler.enabled=false \
+		--set backupHandler.enabled=false \
 		--set logs2email.enabled=false \
 		--set logs2microsoftteams.enabled=false \
 		--set logs2rocketchat.enabled=false \

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,19 @@ install-nfs-server-provisioner:
 		nfs-server-provisioner \
 		stable/nfs-server-provisioner
 
+.PHONY: install-mariadb
+install-mariadb:
+	# root password is required on upgrade if the chart is already installed
+	helm upgrade \
+		--install \
+		--create-namespace \
+		--namespace mariadb \
+		--wait \
+		--timeout 15m \
+		$$(kubectl get ns mariadb > /dev/null 2>&1 && echo --set auth.rootPassword=$$(kubectl get secret --namespace mariadb mariadb -o json | jq -r '.data."mariadb-root-password" | @base64d')) \
+		mariadb \
+		bitnami/mariadb
+
 .PHONY: install-lagoon-core
 install-lagoon-core:
 	helm upgrade \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: fill-test-ci-values
-fill-test-ci-values: install-ingress install-registry install-lagoon-core install-lagoon-remote
+fill-test-ci-values: install-ingress install-registry install-lagoon-core install-lagoon-remote install-nfs-server-provisioner
 	export ingressIP="$$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')" \
 		&& export keycloakAuthServerClientSecret="$$(kubectl -n lagoon get secret lagoon-core-keycloak -o json | jq -r '.data.KEYCLOAK_AUTH_SERVER_CLIENT_SECRET | @base64d')" \
 		&& export routeSuffixHTTP="$$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
@@ -42,6 +42,18 @@ install-registry:
 		--set trivy.enabled=false \
 		registry \
 		harbor/harbor
+
+.PHONY: install-nfs-server-provisioner
+install-nfs-server-provisioner:
+	helm upgrade \
+		--install \
+		--create-namespace \
+		--namespace nfs-server-provisioner \
+		--wait \
+		--timeout 15m \
+		--set storageClass.name=bulk \
+		nfs-server-provisioner \
+		stable/nfs-server-provisioner
 
 .PHONY: install-lagoon-core
 install-lagoon-core:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SUITE = features-kubernetes
+
 .PHONY: fill-test-ci-values
 fill-test-ci-values: install-ingress install-registry install-lagoon-core install-lagoon-remote install-nfs-server-provisioner
 	export ingressIP="$$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')" \
@@ -5,6 +7,7 @@ fill-test-ci-values: install-ingress install-registry install-lagoon-core instal
 		&& export routeSuffixHTTP="$$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export routeSuffixHTTPS="$$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export token="$$(kubectl -n lagoon get secret -o json | jq -r '.items[] | select(.metadata.name | match("lagoon-build-deploy-token")) | .data.token | @base64d')" \
+		&& export suite=$(SUITE) \
 		&& valueTemplate=charts/lagoon-test/ci/linter-values.yaml \
 		&& envsubst < $$valueTemplate.tpl > $$valueTemplate
 

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.0
+version: 0.34.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -78,6 +78,7 @@ api:
 apiDB:
   image:
     repository: testlagoon/api-db
+  storageSize: 16Gi
 
 apiRedis:
   image:

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -75,4 +75,4 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 128Gi
+          storage: {{ .Values.apiDB.storageSize | quote }}

--- a/charts/lagoon-core/templates/backup-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/backup-handler.deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.backupHandler.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -106,3 +107,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/backup-handler.hpa.yaml
+++ b/charts/lagoon-core/templates/backup-handler.hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backupHandler.autoscaling.enabled -}}
+{{- if and .Values.backupHandler.enabled .Values.backupHandler.autoscaling.enabled -}}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/lagoon-core/templates/backup-handler.ingress.yaml
+++ b/charts/lagoon-core/templates/backup-handler.ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backupHandler.ingress.enabled -}}
+{{- if and .Values.backupHandler.enabled .Values.backupHandler.ingress.enabled -}}
 {{- $fullName := include "lagoon-core.backupHandler.fullname" . -}}
 {{- $svcPort := .Values.backupHandler.service.port -}}
 apiVersion: networking.k8s.io/v1beta1

--- a/charts/lagoon-core/templates/backup-handler.service.yaml
+++ b/charts/lagoon-core/templates/backup-handler.service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.backupHandler.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     name: http-3000
   selector:
     {{- include "lagoon-core.backupHandler.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -403,6 +403,7 @@ ui:
     # targetMemoryUtilizationPercentage: 80
 
 backupHandler:
+  enabled: true
   replicaCount: 2
   image:
     repository: amazeeiolagoon/backup-handler

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -135,6 +135,8 @@ apiDB:
     runAsUser: 100
     fsGroup: 0
 
+  storageSize: 128Gi
+
 apiRedis:
   image:
     repository: amazeeiolagoon/api-redis

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -12,3 +12,6 @@ dockerHost:
     size: 50Gi
 
 imageTag: main
+
+dbaasOperator:
+  enabled: true

--- a/charts/lagoon-remote/crds/dbaasOperator.mariadb.yaml
+++ b/charts/lagoon-remote/crds/dbaasOperator.mariadb.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: mariadbproviders.mariadb.amazee.io
+spec:
+  group: mariadb.amazee.io
+  names:
+    kind: MariaDBProvider
+    listKind: MariaDBProviderList
+    plural: mariadbproviders
+    singular: mariadbprovider
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: MariaDBProvider is the Schema for the mariadbproviders API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MariaDBProviderSpec defines the desired state of MariaDBProvider
+          properties:
+            environment:
+              description: These are the spec options for providers
+              type: string
+            hostname:
+              type: string
+            password:
+              type: string
+            port:
+              type: string
+            readReplicaHostnames:
+              items:
+                type: string
+              type: array
+            user:
+              type: string
+          type: object
+        status:
+          description: MariaDBProviderStatus defines the observed state of MariaDBProvider
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: mariadbconsumers.mariadb.amazee.io
+spec:
+  group: mariadb.amazee.io
+  names:
+    kind: MariaDBConsumer
+    listKind: MariaDBConsumerList
+    plural: mariadbconsumers
+    singular: mariadbconsumer
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: MariaDBConsumer is the Schema for the mariadbconsumers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MariaDBConsumerSpec defines the desired state of MariaDBConsumer
+          properties:
+            consumer:
+              description: MariaDBConsumerData defines the provider link for this
+                consumer
+              properties:
+                database:
+                  type: string
+                password:
+                  type: string
+                services:
+                  description: MariaDBConsumerServices defines the provider link for
+                    this consumer
+                  properties:
+                    primary:
+                      type: string
+                    replicas:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                username:
+                  type: string
+              type: object
+            environment:
+              description: These are the spec options for consumers
+              type: string
+            provider:
+              description: MariaDBConsumerProvider defines the provider link for this
+                consumer
+              properties:
+                hostname:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                port:
+                  type: string
+                readReplicas:
+                  items:
+                    type: string
+                  type: array
+                type:
+                  type: string
+              type: object
+          type: object
+        status:
+          description: MariaDBConsumerStatus defines the observed state of MariaDBConsumer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/lagoon-remote/crds/dbaasOperator.postgres.yaml
+++ b/charts/lagoon-remote/crds/dbaasOperator.postgres.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: postgresqlconsumers.postgres.amazee.io
+spec:
+  group: postgres.amazee.io
+  names:
+    kind: PostgreSQLConsumer
+    listKind: PostgreSQLConsumerList
+    plural: postgresqlconsumers
+    singular: postgresqlconsumer
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: PostgreSQLConsumer is the Schema for the postgresqlconsumers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PostgreSQLConsumerSpec defines the desired state of PostgreSQLConsumer
+          properties:
+            consumer:
+              description: PostgreSQLConsumerData defines the provider link for this
+                consumer
+              properties:
+                database:
+                  type: string
+                password:
+                  type: string
+                services:
+                  description: PostgreSQLConsumerServices defines the provider link
+                    for this consumer
+                  properties:
+                    primary:
+                      type: string
+                  type: object
+                username:
+                  type: string
+              type: object
+            environment:
+              description: These are the spec options for consumers
+              type: string
+            provider:
+              description: PostgreSQLConsumerProvider defines the provider link for
+                this consumer
+              properties:
+                hostname:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                port:
+                  type: string
+              type: object
+          type: object
+        status:
+          description: PostgreSQLConsumerStatus defines the observed state of PostgreSQLConsumer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: postgresqlproviders.postgres.amazee.io
+spec:
+  group: postgres.amazee.io
+  names:
+    kind: PostgreSQLProvider
+    listKind: PostgreSQLProviderList
+    plural: postgresqlproviders
+    singular: postgresqlprovider
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: PostgreSQLProvider is the Schema for the postgresqlproviders API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PostgreSQLProviderSpec defines the desired state of PostgreSQLProvider
+          properties:
+            environment:
+              description: These are the spec options for providers
+              type: string
+            hostname:
+              type: string
+            name:
+              type: string
+            namespace:
+              type: string
+            password:
+              type: string
+            port:
+              type: string
+            type:
+              type: string
+            user:
+              type: string
+          type: object
+        status:
+          description: PostgreSQLProviderStatus defines the observed state of PostgreSQLProvider
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/lagoon-remote/templates/_helpers.tpl
+++ b/charts/lagoon-remote/templates/_helpers.tpl
@@ -193,3 +193,40 @@ app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-remote.dioscuri.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+
+{{/*
+Create the name of the service account to use for dbaas-operator.
+*/}}
+{{- define "lagoon-remote.dbaasOperator.serviceAccountName" -}}
+{{- default (include "lagoon-remote.dbaasOperator.fullname" .) .Values.dbaasOperator.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for dbaas-operator.
+*/}}
+{{- define "lagoon-remote.dbaasOperator.fullname" -}}
+{{- include "lagoon-remote.fullname" . }}-dbaas-operator
+{{- end }}
+
+{{/*
+Common labels dbaas-operator.
+*/}}
+{{- define "lagoon-remote.dbaasOperator.labels" -}}
+helm.sh/chart: {{ include "lagoon-remote.chart" . }}
+{{ include "lagoon-remote.dbaasOperator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels dbaas-operator.
+*/}}
+{{- define "lagoon-remote.dbaasOperator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-remote.dbaasOperator.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.clusterrole.yaml
@@ -1,0 +1,177 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-manager
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbconsumers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbproviders
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.amazee.io
+  resources:
+  - mariadbproviders/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - postgres.amazee.io
+  resources:
+  - postgresqlconsumers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgres.amazee.io
+  resources:
+  - postgresqlconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - postgres.amazee.io
+  resources:
+  - postgresqlproviders
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgres.amazee.io
+  resources:
+  - postgresqlproviders/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-proxy
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-mariadbconsumer-role
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["mariadb.amazee.io"]
+  resources: ["mariadbconsumers"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-mariadbprovider-role
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["mariadb.amazee.io"]
+  resources: ["mariadbproviders"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-postgresqlconsumer-role
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["postgres.amazee.io"]
+  resources: ["postgresqlconsumers"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-postgresqlprovider-role
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["postgres.amazee.io"]
+  resources: ["postgresqlproviders"]
+  verbs: ["*"]
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.clusterrolebinding.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.clusterrolebinding.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-manager
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.dbaasOperator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-proxy
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-proxy
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.dbaasOperator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.deployment.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.deployment.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-remote.dbaasOperator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lagoon-remote.dbaasOperator.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "lagoon-remote.dbaasOperator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dbaasOperator.podSecurityContext | nindent 8 }}
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          {{- toYaml .Values.dbaasOperator.kubeRBACProxy.securityContext | nindent 10 }}
+        image: "{{ .Values.dbaasOperator.kubeRBACProxy.image.repository }}:{{ .Values.dbaasOperator.kubeRBACProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.dbaasOperator.kubeRBACProxy.image.pullPolicy }}
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          {{- toYaml .Values.dbaasOperator.kubeRBACProxy.resources | nindent 10 }}
+      - name: manager
+        securityContext:
+          {{- toYaml .Values.dbaasOperator.securityContext | nindent 10 }}
+        image: "{{ .Values.dbaasOperator.image.repository }}:{{ .Values.dbaasOperator.image.tag | default .Chart.AppVersion}}"
+        imagePullPolicy: {{ .Values.dbaasOperator.image.pullPolicy }}
+        command:
+        - /manager
+        {{- with .Values.dbaasOperator.extraArgs }}
+        args:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.dbaasOperator.resources | nindent 10 }}
+      {{- with .Values.dbaasOperator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.dbaasOperator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.dbaasOperator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.mariadbprovider.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.mariadbprovider.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.dbaasOperator.enabled -}}
+{{- range $providerName, $providerConfig := .Values.dbaasOperator.mariadbProviders }}
+---
+apiVersion: mariadb.amazee.io/v1
+kind: MariaDBProvider
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" $ }}-{{ $providerName }}
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" $ | nindent 4 }}
+spec:
+  environment: {{ required (printf "environment is required for %s" $providerName) $providerConfig.environment | quote }}
+  hostname:  {{ required (printf "hostname is required for %s" $providerName) $providerConfig.hostname | quote }}
+  {{- with $providerConfig.readReplicaHostnames }}
+  readReplicaHostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  password: {{ required (printf "password is required for %s" $providerName) $providerConfig.password | quote }}
+  port: {{ required (printf "port is required for %s" $providerName) $providerConfig.port | quote }}
+  user: {{ required (printf "user is required for %s" $providerName) $providerConfig.user | quote }}
+  {{- with $providerConfig.type }}
+  type: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.postgresqlprovider.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.postgresqlprovider.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.dbaasOperator.enabled -}}
+{{- range $providerName, $providerConfig := .Values.dbaasOperator.postgresqlProviders }}
+---
+apiVersion: postgres.amazee.io/v1
+kind: PostgreSQLProvider
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" $ }}-{{ $providerName }}
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" $ | nindent 4 }}
+spec:
+  environment: {{ required (printf "environment is required for %s" $providerName) $providerConfig.environment | quote }}
+  hostname:  {{ required (printf "hostname is required for %s" $providerName) $providerConfig.hostname | quote }}
+  password: {{ required (printf "password is required for %s" $providerName) $providerConfig.password | quote }}
+  port: {{ required (printf "port is required for %s" $providerName) $providerConfig.port | quote }}
+  user: {{ required (printf "user is required for %s" $providerName) $providerConfig.user | quote }}
+  {{- with $providerConfig.type }}
+  type: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.role.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.role.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-leader-election
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.rolebinding.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-leader-election
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}-leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.dbaasOperator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.service.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.dbaasOperator.service.type }}
+  ports:
+  - port: {{ .Values.dbaasOperator.service.port }}
+    targetPort: https
+    protocol: TCP
+    name: https
+  selector:
+    {{- include "lagoon-remote.dbaasOperator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dbaas-operator.serviceaccount.yaml
+++ b/charts/lagoon-remote/templates/dbaas-operator.serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.dbaasOperator.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lagoon-remote.dbaasOperator.serviceAccountName" . }}
+  labels:
+    {{- include "lagoon-remote.dbaasOperator.labels" . | nindent 4 }}
+  {{- with .Values.dbaasOperator.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/dioscuri.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.clusterrole.yaml
@@ -178,6 +178,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "lagoon-remote.dioscuri.fullname" . }}-routemigrates-role
   labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
     # Add these permissions to the "admin" and "edit" default roles.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -191,6 +192,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "lagoon-remote.dioscuri.fullname" . }}-ingressmigrates-role
   labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
     # Add these permissions to the "admin" and "edit" default roles.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -204,6 +206,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "lagoon-remote.dioscuri.fullname" . }}-hostmigrations-role
   labels:
+    {{- include "lagoon-remote.dioscuri.labels" . | nindent 4 }}
     # Add these permissions to the "admin" and "edit" default roles.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/charts/lagoon-remote/templates/dioscuri.deployment.yaml
+++ b/charts/lagoon-remote/templates/dioscuri.deployment.yaml
@@ -50,15 +50,15 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.dioscuri.resources | nindent 10 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.dioscuri.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.dioscuri.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with .Values.dioscuri.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -161,3 +161,89 @@ dioscuri:
     securityContext: {}
 
     resources: {}
+
+# dbaasOperator provisions DBaaS accounts for projects.
+dbaasOperator:
+  enabled: false
+  image:
+    repository: amazeeio/dbaas-operator
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.1.3"
+
+  extraArgs:
+  - "--metrics-addr=127.0.0.1:8080"
+  - "--enable-leader-election=true"
+
+  service:
+    type: ClusterIP
+    port: 8443
+
+  serviceAccount:
+    # The name of the service account to use.
+    # If not set, a name is generated using the fullname template.
+    name:
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  # this sidecar runs in the same pod as dioscuri
+  kubeRBACProxy:
+    image:
+      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      pullPolicy: IfNotPresent
+      tag: v0.4.1
+
+    securityContext: {}
+
+    resources: {}
+
+  # this is a list of providers that the dbaas operator uses to provision
+  # mariadb services for projects
+  mariadbProviders: {}
+    # production:
+    #   environment: production
+    #   hostname: 172.17.0.1.nip.io
+    #   readReplicaHostnames:
+    #   - 172.17.0.1.nip.io
+    #   password: password
+    #   port: '3306'
+    #   user: root
+
+    # development:
+    #   environment: development
+    #   hostname: 172.17.0.1.nip.io
+    #   readReplicaHostnames:
+    #   - 172.17.0.1.nip.io
+    #   password: password
+    #   port: '3306'
+    #   user: root
+
+    # development-azure:
+    #   environment: development
+    #   hostname: azure-hostname.172.17.0.1.nip.io
+    #   readReplicaHostnames:
+    #   - azure-hostname.172.17.0.1.nip.io
+    #   password: password
+    #   port: '3306'
+    #   user: root@azure-hostname
+    #   type: azure
+
+  # this is a list of providers that the dbaas operator uses to provision
+  # postgresql services for projects
+  postgresqlProviders: {}
+    # production:
+    #   environment: production
+    #   hostname: 172.17.0.1.nip.io
+    #   password: password
+    #   port: '3306'
+    #   user: root
+
+    # development:
+    #   environment: development
+    #   hostname: 172.17.0.1.nip.io
+    #   password: password
+    #   port: '3306'

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -120,7 +120,7 @@ kubernetesBuildDeploy:
     # If not set, a name is generated using the fullname template.
     name:
 
-# dioscuri is the name of the operator which implements Lagoon active-standby.
+# dioscuri is the operator which implements Lagoon active-standby.
 dioscuri:
   enabled: true
   image:

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.6.0
+version: 0.7.0
 
 appVersion: v1-9-1

--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -16,5 +16,6 @@ localAPIDataWatcherPusher:
 tests:
   image:
     repository: testlagoon/tests
+  suite: "${suite}"
 
 imageTag: main

--- a/charts/lagoon-test/templates/tests/test-suite.yaml
+++ b/charts/lagoon-test/templates/tests/test-suite.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceAccountName: {{ include "lagoon-test.serviceAccountName" . }}
   containers:
-  - name: features-kubernetes
+  - name: {{ required ".Values.tests.suite is required!" .Values.tests.suite | quote }}
     image: "{{ .Values.tests.image.repository }}:{{ coalesce .Values.tests.image.tag .Values.imageTag .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     envFrom:
@@ -22,32 +22,6 @@ spec:
     - ansible-playbook
     - "--skip-tags"
     - "skip-on-kubernetes"
-    - "/ansible/tests/features-kubernetes.yaml"
-  - name: nginx
-    image: "{{ .Values.tests.image.repository }}:{{ coalesce .Values.tests.image.tag .Values.imageTag .Chart.AppVersion }}"
-    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
-    envFrom:
-    - secretRef:
-        name: {{ include "lagoon-test.fullname" . }}
-    command:
-    - /entrypoint.sh
-    args:
-    - ansible-playbook
-    - "--skip-tags"
-    - "skip-on-kubernetes"
-    - "/ansible/tests/nginx.yaml"
-  - name: active-standby-kubernetes
-    image: "{{ .Values.tests.image.repository }}:{{ coalesce .Values.tests.image.tag .Values.imageTag .Chart.AppVersion }}"
-    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
-    envFrom:
-    - secretRef:
-        name: {{ include "lagoon-test.fullname" . }}
-    command:
-    - /entrypoint.sh
-    args:
-    - ansible-playbook
-    - "--skip-tags"
-    - "skip-on-kubernetes"
-    - "/ansible/tests/active-standby-kubernetes.yaml"
+    - "/ansible/tests/{{ .Values.tests.suite }}.yaml"
   restartPolicy: Never
 {{- end }}

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -127,3 +127,11 @@ tests:
     tag: ""
 
   suiteEnabled: true
+
+  # This value is required and must be set to one of the valid test suites:
+  # - features-kubernetes
+  # - active-standby-kubernetes
+  # - nginx
+  # - drupal
+  #
+  # suite: drupal


### PR DESCRIPTION
This PR makes several changes in support of the drupal test suite:
* Add a shared-storage provisioner to CI to support the drupal test suite
* Add a mariadb service to CI to support the drupal test suite
* Add support for the [DBaaS operator](https://github.com/amazeeio/dbaas-operator) to the lagoon-remote chart. Disabled by default so as not to break any existing installs, but enabled in CI to support the drupal test suite.
* Add the drupal test suite

Closes: #118
