### PR TITLE
Lagoon ci

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -20,8 +20,8 @@ jobs:
     - name: Generate helm templates
       run: |
         cd charts
-        # workaround for lagoon-test templated values
-        cp lagoon-test/ci/linter-values.yaml{.tpl,}
+        # hacky workaround for lagoon-test templated values
+        tests=[foo,bar] envsubst '$tests' < lagoon-test/ci/linter-values.yaml.tpl > lagoon-test/ci/linter-values.yaml
 
         for chart in *; do
           helm dependency build $chart

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite:
+        test:
         - features-kubernetes
         - nginx
         - active-standby-kubernetes
@@ -98,7 +98,7 @@ jobs:
 
     - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
       if: steps.list-changed.outputs.changed == 'true'
-      run: make -j8 -O fill-test-ci-values SUITE=${{ matrix.suite }}
+      run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}]
 
     - name: Free up some disk space
       if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 SUITE = features-kubernetes
+# if IMAGE_TAG is not set, it will fall back to the version set in the CI
+# values file, then to the chart default.
+IMAGE_TAG =
 
 .PHONY: fill-test-ci-values
 fill-test-ci-values: install-ingress install-registry install-lagoon-core install-lagoon-remote install-nfs-server-provisioner
@@ -97,6 +100,7 @@ install-lagoon-core:
 		--set "harborAdminPassword=Harbor12345" \
 		--set storageCalculator.enabled=false \
 		--set sshPortal.enabled=false \
+		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
 		lagoon-core \
 		./charts/lagoon-core
 
@@ -116,5 +120,6 @@ install-lagoon-remote: install-lagoon-core install-mariadb
 		--set "dbaasOperator.mariadbProviders.development.password=$$(kubectl get secret --namespace mariadb mariadb -o json | jq -r '.data."mariadb-root-password" | @base64d')" \
 		--set "dbaasOperator.mariadbProviders.development.port=3306" \
 		--set "dbaasOperator.mariadbProviders.development.user=root" \
+		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
 		lagoon-remote \
 		./charts/lagoon-remote

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SUITE = features-kubernetes
 # if IMAGE_TAG is not set, it will fall back to the version set in the CI
 # values file, then to the chart default.
 IMAGE_TAG =
+HELM = helm
 
 .PHONY: fill-test-ci-values
 fill-test-ci-values: install-ingress install-registry install-lagoon-core install-lagoon-remote install-nfs-server-provisioner
@@ -16,7 +17,7 @@ fill-test-ci-values: install-ingress install-registry install-lagoon-core instal
 
 .PHONY: install-ingress
 install-ingress:
-	helm upgrade \
+	$(HELM) upgrade \
 		--install \
 		--create-namespace \
 		--namespace ingress-nginx \
@@ -32,7 +33,7 @@ install-ingress:
 
 .PHONY: install-registry
 install-registry:
-	helm upgrade \
+	$(HELM) upgrade \
 		--install \
 		--create-namespace \
 		--namespace registry \
@@ -51,7 +52,7 @@ install-registry:
 
 .PHONY: install-nfs-server-provisioner
 install-nfs-server-provisioner:
-	helm upgrade \
+	$(HELM) upgrade \
 		--install \
 		--create-namespace \
 		--namespace nfs-server-provisioner \
@@ -64,7 +65,7 @@ install-nfs-server-provisioner:
 .PHONY: install-mariadb
 install-mariadb:
 	# root password is required on upgrade if the chart is already installed
-	helm upgrade \
+	$(HELM) upgrade \
 		--install \
 		--create-namespace \
 		--namespace mariadb \
@@ -76,7 +77,7 @@ install-mariadb:
 
 .PHONY: install-lagoon-core
 install-lagoon-core:
-	helm upgrade \
+	$(HELM) upgrade \
 		--install \
 		--create-namespace \
 		--namespace lagoon \
@@ -106,7 +107,7 @@ install-lagoon-core:
 
 .PHONY: install-lagoon-remote
 install-lagoon-remote: install-lagoon-core install-mariadb
-	helm upgrade \
+	$(HELM) upgrade \
 		--install \
 		--create-namespace \
 		--namespace lagoon \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUITE = features-kubernetes
+TESTS = [features-kubernetes]
 # if IMAGE_TAG is not set, it will fall back to the version set in the CI
 # values file, then to the chart default.
 IMAGE_TAG =
@@ -13,7 +13,7 @@ fill-test-ci-values: install-ingress install-registry install-lagoon-core instal
 		&& export routeSuffixHTTP="$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export routeSuffixHTTPS="$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export token="$$($(KUBECTL) -n lagoon get secret -o json | $(JQ) -r '.items[] | select(.metadata.name | match("lagoon-build-deploy-token")) | .data.token | @base64d')" \
-		&& export suite=$(SUITE) \
+		&& export tests='$(TESTS)' \
 		&& valueTemplate=charts/lagoon-test/ci/linter-values.yaml \
 		&& envsubst < $$valueTemplate.tpl > $$valueTemplate
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TESTS = [features-kubernetes]
 # if IMAGE_TAG is not set, it will fall back to the version set in the CI
 # values file, then to the chart default.
 IMAGE_TAG =
+TIMEOUT = 30m
 HELM = helm
 KUBECTL = kubectl
 JQ = jq
@@ -24,7 +25,7 @@ install-ingress:
 		--create-namespace \
 		--namespace ingress-nginx \
 		--wait \
-		--timeout 15m \
+		--timeout $(TIMEOUT) \
 		--set controller.service.type=NodePort \
 		--set controller.service.nodePorts.http=32080 \
 		--set controller.service.nodePorts.https=32443 \
@@ -40,7 +41,7 @@ install-registry:
 		--create-namespace \
 		--namespace registry \
 		--wait \
-		--timeout 15m \
+		--timeout $(TIMEOUT) \
 		--set expose.tls.enabled=false \
 		--set "expose.ingress.annotations.kubernetes\.io\/ingress\.class=nginx" \
 		--set "expose.ingress.hosts.core=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
@@ -59,7 +60,7 @@ install-nfs-server-provisioner:
 		--create-namespace \
 		--namespace nfs-server-provisioner \
 		--wait \
-		--timeout 15m \
+		--timeout $(TIMEOUT) \
 		--set storageClass.name=bulk \
 		nfs-server-provisioner \
 		stable/nfs-server-provisioner
@@ -72,7 +73,7 @@ install-mariadb:
 		--create-namespace \
 		--namespace mariadb \
 		--wait \
-		--timeout 15m \
+		--timeout $(TIMEOUT) \
 		$$($(KUBECTL) get ns mariadb > /dev/null 2>&1 && echo --set auth.rootPassword=$$($(KUBECTL) get secret --namespace mariadb mariadb -o json | $(JQ) -r '.data."mariadb-root-password" | @base64d')) \
 		mariadb \
 		bitnami/mariadb
@@ -84,7 +85,7 @@ install-lagoon-core:
 		--create-namespace \
 		--namespace lagoon \
 		--wait \
-		--timeout 15m \
+		--timeout $(TIMEOUT) \
 		--values ./charts/lagoon-core/ci/linter-values.yaml \
 		--set autoIdler.enabled=false \
 		--set backupHandler.enabled=false \
@@ -114,7 +115,7 @@ install-lagoon-remote: install-lagoon-core install-mariadb
 		--create-namespace \
 		--namespace lagoon \
 		--wait \
-		--timeout 15m \
+		--timeout $(TIMEOUT) \
 		--values ./charts/lagoon-remote/ci/linter-values.yaml \
 		--set "rabbitMQPassword=$$($(KUBECTL) -n lagoon get secret lagoon-core-broker -o json | $(JQ) -r '.data.RABBITMQ_PASSWORD | @base64d')" \
 		--set "dockerHost.registry=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.7.0
+version: 0.8.0
 
 appVersion: v1-9-1

--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -16,6 +16,6 @@ localAPIDataWatcherPusher:
 tests:
   image:
     repository: testlagoon/tests
-  suite: "${suite}"
+  tests: ${tests}
 
 imageTag: main

--- a/charts/lagoon-test/templates/tests/test-suite.yaml
+++ b/charts/lagoon-test/templates/tests/test-suite.yaml
@@ -10,18 +10,20 @@ metadata:
 spec:
   serviceAccountName: {{ include "lagoon-test.serviceAccountName" . }}
   containers:
-  - name: {{ required ".Values.tests.suite is required!" .Values.tests.suite | quote }}
-    image: "{{ .Values.tests.image.repository }}:{{ coalesce .Values.tests.image.tag .Values.imageTag .Chart.AppVersion }}"
-    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+  {{- range (required ".Values.tests.tests is required!" .Values.tests.tests) }}
+  - name: {{ . | quote }}
+    image: "{{ $.Values.tests.image.repository }}:{{ coalesce $.Values.tests.image.tag $.Values.imageTag $.Chart.AppVersion }}"
+    imagePullPolicy: {{ $.Values.tests.image.pullPolicy }}
     envFrom:
     - secretRef:
-        name: {{ include "lagoon-test.fullname" . }}
+        name: {{ include "lagoon-test.fullname" $ }}
     command:
     - /entrypoint.sh
     args:
     - ansible-playbook
     - "--skip-tags"
     - "skip-on-kubernetes"
-    - "/ansible/tests/{{ .Values.tests.suite }}.yaml"
+    - "/ansible/tests/{{ . }}.yaml"
+  {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -128,10 +128,10 @@ tests:
 
   suiteEnabled: true
 
-  # This value is required and must be set to one of the valid test suites:
+  tests: []
+  # This value is required when suiteEnabled is true, and must be set to one or
+  # more of the valid test suites:
   # - features-kubernetes
   # - active-standby-kubernetes
   # - nginx
   # - drupal
-  #
-  # suite: drupal


### PR DESCRIPTION
This PR updates the `Makefile` and `lagoon-test` chart to support CI on the `main` Lagoon branch.

The changes are:

* Paramaterise various fields in the Makefile.
* Double the the chart install timeout from 15m to 30m to allow me to run the tests locally. This is enough time to download all the images on my terrible internet connection.
* Add the ability to pass a _list_ of tests instead of just a single test to enable in the `lagoon-test` chart.

The last point facilitates running a single test on each ephemeral build node in Github CI (this repo), and running multiple tests on a single beefier build node in the Lagoon repo.
