### PR TITLE
Consolidation fixes

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.0
+version: 0.17.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -176,12 +176,12 @@ data:
       <replace>
         key index_name
         expression /^(?<prefix>(?:container|router)-logs-e2e)-[^-]{10}-[^-]{26}_(?<suffix>.+)$/
-        replace \\k<prefix>_\\k<suffix>
+        replace \k<prefix>_\k<suffix>
       </replace>
       <replace>
         key index_name
         expression /^(?<prefix>container-logs-.+-apb)-(?:prov|depr)-[^-]{5}_(?<suffix>.+)$/
-        replace \\k<prefix>_\\k<suffix>
+        replace \k<prefix>_\k<suffix>
       </replace>
     </filter>
     {{- end }}

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -175,7 +175,7 @@ data:
       @type record_modifier
       <replace>
         key index_name
-        expression /^(?<prefix>(?:container|router)-logs-e2e)-[^-]{10}-[^-]{26}_(?<suffix>.+)$/
+        expression /^(?<prefix>container-logs-e2e)-[^-]{10}-[^-]{26}_(?<suffix>.+)$/
         replace \k<prefix>_\k<suffix>
       </replace>
       <replace>
@@ -270,8 +270,8 @@ data:
       skip_container_metadata true
       skip_master_url         true
     </filter>
-{{- end }}
 
+{{- end }}
     #
     # add the router index_name
     #
@@ -281,6 +281,18 @@ data:
         index_name router-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project')&.gsub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
       </record>
     </filter>
+    {{- if .Values.consolidateServiceIndices }}
+    # some cluster services generate namespaces with a random suffix, so
+    # consolidate those in a single index for each service
+    <filter lagoon.*.router.openshift.**>
+      @type record_modifier
+      <replace>
+        key index_name
+        expression /^(?<prefix>router-logs-e2e)-[^-]{10}-[^-]{26}_(?<suffix>.+)$/
+        replace \k<prefix>_\k<suffix>
+      </replace>
+    </filter>
+    {{- end }}
 
     #
     # add the lagoon index_name


### PR DESCRIPTION
While reviewing #156 and debugging some other error messages in the `logs-concentrator` I realised that the consolidation syntax was wrong.

Going back to my original testing for this I discovered that this is actually an issue with the upstream fluentd `record_modifier` plugin documentation and test suite. There's a PR for upstream here that explains the issue: https://github.com/repeatedly/fluent-plugin-record-modifier/pull/56

So I incorporated the changes for #156 and also fixed the syntax. I hope you don't mind that I took some config snippets from your PR @Schnitzel!

Supersedes / Closes: #156 
