### PR TITLE
Add option to override the build-deploy-dind image in CI

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -106,4 +106,4 @@ jobs:
 
     - name: Run chart-testing (install) on lagoon-test
       if: steps.list-changed.outputs.changed == 'true'
-      run: ct install --config ./test-suite-run.ct.yaml
+      run: ct lint-and-install --config ./test-suite-run.ct.yaml

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ TESTS = [features-kubernetes]
 # if IMAGE_TAG is not set, it will fall back to the version set in the CI
 # values file, then to the chart default.
 IMAGE_TAG =
+# if OVERRIDE_BUILD_DEPLOY_DIND_IMAGE is not set, it will fall back to the
+# lagoon API default and, in the future, the controller default.
+OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =
 TIMEOUT = 30m
 HELM = helm
 KUBECTL = kubectl
@@ -105,6 +108,7 @@ install-lagoon-core:
 		--set storageCalculator.enabled=false \
 		--set sshPortal.enabled=false \
 		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
+		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set overwriteKubectlBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
 		lagoon-core \
 		./charts/lagoon-core
 
@@ -125,5 +129,6 @@ install-lagoon-remote: install-lagoon-core install-mariadb
 		--set "dbaasOperator.mariadbProviders.development.port=3306" \
 		--set "dbaasOperator.mariadbProviders.development.user=root" \
 		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
+		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set lagoonBuildDeploy.overrideBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
 		lagoon-remote \
 		./charts/lagoon-remote

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.1
+version: 0.34.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -54,6 +54,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.fullname" . }}-jwtsecret
               key: JWTSECRET
+        {{- with .Values.overwriteKubectlBuildDeployDindImage }}
+        - name: OVERWRITE_KUBECTL_BUILD_DEPLOY_DIND_IMAGE
+          value: {{ . | quote }}
+        {{- end }}
         - name: HARBOR_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/templates/lagoon-build-deploy.deployment.yaml
+++ b/charts/lagoon-remote/templates/lagoon-build-deploy.deployment.yaml
@@ -51,8 +51,12 @@ spec:
         env:
         - name: LAGOON_TARGET_NAME
           value: {{ required "A valid .Values.lagoonTargetName required!" .Values.lagoonTargetName | quote }}
+        {{- with .Values.lagoonBuildDeploy.overrideBuildDeployDindImage }}
+        - name: OVERRIDE_BUILD_DEPLOY_DIND_IMAGE
+          value: {{ . | quote }}
+        {{- end }}
         - name: PENDING_MESSAGE_CRON
-          value: {{ .Values.pendingMessageCron | quote }}
+          value: {{ .Values.lagoonBuildDeploy.pendingMessageCron | quote }}
         - name: RABBITMQ_HOSTNAME
           value: {{ required "A valid .Values.rabbitMQHostname required!" .Values.rabbitMQHostname | quote }}
         - name: RABBITMQ_PASSWORD

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -13,8 +13,6 @@ logsDispatcherHost: |-
 # rabbitMQHostname:
 # lagoonTargetName:
 
-pendingMessageCron: "*/5 * * * *"
-
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it uses chart appVersion
 imageTag: ""
@@ -80,12 +78,15 @@ lagoonBuildDeploy:
 
   # If the controller is running in an openshift,
   # then the argument `--is-openshift=true` should be added
-  # By default the controller will use the image `uselagoon/kubectl-build-deploy-dind:latest`
-  # but this can be overridden using the `--override-builddeploy-image=<image>` argument
-  # or adding the environment variable `OVERRIDE_BUILD_DEPLOY_DIND_IMAGE` to the controller deployment
   extraArgs:
   - "--metrics-addr=127.0.0.1:8080"
   - "--enable-leader-election=true"
+
+  pendingMessageCron: "*/5 * * * *"
+
+  # The controller will use `uselagoon/kubectl-build-deploy-dind:latest` by
+  # default, but this can be overridden here.
+  overrideBuildDeployDindImage: ""
 
   service:
     type: ClusterIP

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.8.0
+version: 0.8.1
 
 appVersion: v1-9-1

--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -18,4 +18,4 @@ tests:
     repository: testlagoon/tests
   tests: ${tests}
 
-imageTag: main
+imageTag: pr-2372


### PR DESCRIPTION
In CI we need to be able to override the build-deploy-dind image so that the one built locally can be used.

This PR:
* Adds the option for overriding the image in `lagoon-remote`
* Adds the option to pass the image in a variable in the `Makefile`

This change is in support of CI in amazeeio/lagoon.
