### PR TITLE
Support local registry

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -36,6 +36,13 @@ jobs:
           echo "$changed"
         fi
 
+    - name: Configure node IP in kind-config.yaml
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        docker network create kind
+        export KIND_NODE_IP=$(docker run --network kind --rm alpine ip -o addr show eth0 | sed -nE 's/.* ([0-9.]{7,})\/.*/\1/p')
+        envsubst < test-suite.kind-config.yaml.tpl > test-suite.kind-config.yaml
+
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
       if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ TESTS = [features-kubernetes]
 # if IMAGE_TAG is not set, it will fall back to the version set in the CI
 # values file, then to the chart default.
 IMAGE_TAG =
+# if IMAGE_REGISTRY is not set, it will fall back to the version set in the
+# chart values files. This only affects lagoon-core, lagoon-remote, and the
+# fill-test-ci-values target.
+IMAGE_REGISTRY = testlagoon
 # if OVERRIDE_BUILD_DEPLOY_DIND_IMAGE is not set, it will fall back to the
 # lagoon API default and, in the future, the controller default.
 OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =
@@ -17,7 +21,8 @@ fill-test-ci-values: install-ingress install-registry install-lagoon-core instal
 		&& export routeSuffixHTTP="$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export routeSuffixHTTPS="$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export token="$$($(KUBECTL) -n lagoon get secret -o json | $(JQ) -r '.items[] | select(.metadata.name | match("lagoon-build-deploy-token")) | .data.token | @base64d')" \
-		&& export tests='$(TESTS)' \
+		&& export $$([ $(IMAGE_TAG) ] && echo imageTag='$(IMAGE_TAG)' || echo imageTag='pr-2372') \
+		&& export tests='$(TESTS)' imageRegistry='$(IMAGE_REGISTRY)' \
 		&& valueTemplate=charts/lagoon-test/ci/linter-values.yaml \
 		&& envsubst < $$valueTemplate.tpl > $$valueTemplate
 
@@ -38,7 +43,7 @@ install-ingress:
 		ingress-nginx/ingress-nginx
 
 .PHONY: install-registry
-install-registry:
+install-registry: install-ingress
 	$(HELM) upgrade \
 		--install \
 		--create-namespace \
@@ -90,25 +95,35 @@ install-lagoon-core:
 		--wait \
 		--timeout $(TIMEOUT) \
 		--values ./charts/lagoon-core/ci/linter-values.yaml \
+		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
+		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set overwriteKubectlBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
+		--set "harborAdminPassword=Harbor12345" \
+		--set "harborURL=http://registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
+		--set "keycloakAPIURL=http://localhost:8080/auth" \
+		--set "lagoonAPIURL=http://localhost:7070/graphql" \
+		--set "registry=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32443" \
+		--set api.image.repository=$(IMAGE_REGISTRY)/api \
+		--set apiDB.image.repository=$(IMAGE_REGISTRY)/api-db \
+		--set apiRedis.image.repository=$(IMAGE_REGISTRY)/api-redis \
+		--set authServer.image.repository=$(IMAGE_REGISTRY)/auth-server \
 		--set autoIdler.enabled=false \
 		--set backupHandler.enabled=false \
+		--set broker.image.repository=$(IMAGE_REGISTRY)/broker \
+		--set controllerhandler.image.repository=$(IMAGE_REGISTRY)/controllerhandler \
+		--set drushAlias.image.repository=$(IMAGE_REGISTRY)/drush-alias \
+		--set keycloak.image.repository=$(IMAGE_REGISTRY)/keycloak \
+		--set keycloakDB.image.repository=$(IMAGE_REGISTRY)/keycloak-db \
 		--set logs2email.enabled=false \
 		--set logs2microsoftteams.enabled=false \
 		--set logs2rocketchat.enabled=false \
 		--set logs2slack.enabled=false \
 		--set logsDBCurator.enabled=false \
-		--set webhooks2tasks.enabled=false \
-		--set webhookHandler.enabled=false \
-		--set ui.enabled=false \
-		--set "registry=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32443" \
-		--set "lagoonAPIURL=http://localhost:7070/graphql" \
-		--set "keycloakAPIURL=http://localhost:8080/auth" \
-		--set "harborURL=http://registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
-		--set "harborAdminPassword=Harbor12345" \
-		--set storageCalculator.enabled=false \
+		--set ssh.image.repository=$(IMAGE_REGISTRY)/ssh \
 		--set sshPortal.enabled=false \
-		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
-		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set overwriteKubectlBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
+		--set storageCalculator.enabled=false \
+		--set ui.enabled=false \
+		--set webhookHandler.enabled=false \
+		--set webhooks2tasks.enabled=false \
 		lagoon-core \
 		./charts/lagoon-core
 
@@ -121,6 +136,7 @@ install-lagoon-remote: install-lagoon-core install-mariadb
 		--wait \
 		--timeout $(TIMEOUT) \
 		--values ./charts/lagoon-remote/ci/linter-values.yaml \
+		--set dockerHost.image.repository=$(IMAGE_REGISTRY)/docker-host \
 		--set "rabbitMQPassword=$$($(KUBECTL) -n lagoon get secret lagoon-core-broker -o json | $(JQ) -r '.data.RABBITMQ_PASSWORD | @base64d')" \
 		--set "dockerHost.registry=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
 		--set "dbaasOperator.mariadbProviders.development.environment=development" \

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.8.1
+version: 0.8.2
 
 appVersion: v1-9-1

--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -7,15 +7,15 @@ token: "${token}"
 
 localGit:
   image:
-    repository: testlagoon/local-git
+    repository: ${imageRegistry}/local-git
 
 localAPIDataWatcherPusher:
   image:
-    repository: testlagoon/local-api-data-watcher-pusher
+    repository: ${imageRegistry}/local-api-data-watcher-pusher
 
 tests:
   image:
-    repository: testlagoon/tests
+    repository: ${imageRegistry}/tests
   tests: ${tests}
 
-imageTag: pr-2372
+imageTag: ${imageTag}

--- a/test-suite.kind-config.yaml
+++ b/test-suite.kind-config.yaml
@@ -1,9 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.172.18.0.2.nip.io:32443".tls]
-    insecure_skip_verify = true
-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.172.18.0.2.nip.io:32080"]
-    endpoint = ["http://registry.172.18.0.2.nip.io:32080"]

--- a/test-suite.kind-config.yaml.tpl
+++ b/test-suite.kind-config.yaml.tpl
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.${KIND_NODE_IP}.nip.io:32443".tls]
+    insecure_skip_verify = true
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.${KIND_NODE_IP}.nip.io:32080"]
+    endpoint = ["http://registry.${KIND_NODE_IP}.nip.io:32080"]


### PR DESCRIPTION
This PR makes it possible to run chart testing using a local registry.

This is in support of Lagoon 2.0 CI.
