### PR TITLE
replace Testlagoon images with uselagoon+tag, smoother local dev

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -107,10 +107,6 @@ jobs:
       if: steps.list-changed.outputs.changed == 'true'
       run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}]
 
-    - name: Override only the test images temporarily
-      if: steps.list-changed.outputs.changed == 'true'
-      run: make install-tests TESTS=[${{ matrix.test }}] IMAGE_TAG=pr-2423 IMAGE_REGISTRY=testlagoon
-
     - name: Free up some disk space
       if: steps.list-changed.outputs.changed == 'true'
       run: docker system prune -f -a --volumes
@@ -118,7 +114,6 @@ jobs:
     - name: Run chart-testing (install) on lagoon-test
       if: steps.list-changed.outputs.changed == 'true'
       run: ct lint-and-install --config ./test-suite-run.ct.yaml
-      continue-on-error: true
 
     # the following steps gather various debug information on test failure
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -114,6 +114,7 @@ jobs:
     - name: Run chart-testing (install) on lagoon-test
       if: steps.list-changed.outputs.changed == 'true'
       run: ct lint-and-install --config ./test-suite-run.ct.yaml
+      continue-on-error: true
 
     # the following steps gather various debug information on test failure
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -105,7 +105,7 @@ jobs:
 
     - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
       if: steps.list-changed.outputs.changed == 'true'
-      run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}]
+      run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}] IMAGE_TAG=pr-2423 IMAGE_REGISTRY=testlagoon
 
     - name: Free up some disk space
       if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -105,7 +105,11 @@ jobs:
 
     - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
       if: steps.list-changed.outputs.changed == 'true'
-      run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}] IMAGE_TAG=pr-2423 IMAGE_REGISTRY=testlagoon
+      run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}]
+
+    - name: Override only the test images temporarily
+      if: steps.list-changed.outputs.changed == 'true'
+      run: make install-tests TESTS=[${{ matrix.test }}] IMAGE_TAG=pr-2423 IMAGE_REGISTRY=testlagoon
 
     - name: Free up some disk space
       if: steps.list-changed.outputs.changed == 'true'

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
 appVersion: v0.1.5

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         env:
         - name: LAGOON_TARGET_NAME
           value: {{ required "A valid .Values.lagoonTargetName required!" .Values.lagoonTargetName | quote }}
-        {{- with .Values.overrideBuildDeployDindImage }}
+        {{- with .Values.overrideBuildDeployImage }}
         - name: OVERRIDE_BUILD_DEPLOY_DIND_IMAGE
           value: {{ . | quote }}
         {{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -21,7 +21,7 @@ pendingMessageCron: "*/5 * * * *"
 
 # The controller will use `uselagoon/kubectl-build-deploy-dind:latest` by
 # default, but this can be overridden here.
-overrideBuildDeployDindImage: ""
+overrideBuildDeployImage: ""
 
 # override .Chart.Name
 nameOverride: ""

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.35.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.1
+appVersion: v2.0.0-alpha.2

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.35.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.2
+appVersion: v2.0.0-alpha.3

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.2
+version: 0.35.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v1-9-1
+appVersion: v2.0.0-alpha.1

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -73,98 +73,98 @@ sshHostKeyED25519: |-
 api:
   replicaCount: 1
   image:
-    repository: testlagoon/api
+    repository: uselagoon/api
 
 apiDB:
   image:
-    repository: testlagoon/api-db
+    repository: uselagoon/api-db
   storageSize: 16Gi
 
 apiRedis:
   image:
-    repository: testlagoon/api-redis
+    repository: uselagoon/api-redis
 
 keycloak:
   image:
-    repository: testlagoon/keycloak
+    repository: uselagoon/keycloak
 
 keycloakDB:
   image:
-    repository: testlagoon/keycloak-db
+    repository: uselagoon/keycloak-db
 
 broker:
   replicaCount: 1
   serviceMonitor:
     enabled: false
   image:
-    repository: testlagoon/broker
+    repository: uselagoon/broker
 
 authServer:
   replicaCount: 1
   image:
-    repository: testlagoon/auth-server
+    repository: uselagoon/auth-server
 
 webhooks2tasks:
   replicaCount: 1
   image:
-    repository: testlagoon/webhooks2tasks
+    repository: uselagoon/webhooks2tasks
 
 webhookHandler:
   replicaCount: 1
   image:
-    repository: testlagoon/webhook-handler
+    repository: uselagoon/webhook-handler
 
 ui:
   replicaCount: 1
   image:
-    repository: testlagoon/ui
+    repository: uselagoon/ui
 
 backupHandler:
   replicaCount: 1
   image:
-    repository: testlagoon/backup-handler
+    repository: uselagoon/backup-handler
 
 autoIdler:
   image:
-    repository: testlagoon/auto-idler
+    repository: uselagoon/auto-idler
 
 storageCalculator:
   image:
-    repository: testlagoon/storage-calculator
+    repository: uselagoon/storage-calculator
 
 logs2slack:
   replicaCount: 1
   image:
-    repository: testlagoon/logs2slack
+    repository: uselagoon/logs2slack
 
 logs2microsoftteams:
   replicaCount: 1
   image:
-    repository: testlagoon/logs2microsoftteams
+    repository: uselagoon/logs2microsoftteams
 
 logs2rocketchat:
   replicaCount: 1
   image:
-    repository: testlagoon/logs2rocketchat
+    repository: uselagoon/logs2rocketchat
 
 logs2email:
   replicaCount: 1
   image:
-    repository: testlagoon/logs2email
+    repository: uselagoon/logs2email
 
 drushAlias:
   replicaCount: 1
   image:
-    repository: testlagoon/drush-alias
+    repository: uselagoon/drush-alias
 
 logsDBCurator:
   image:
-    repository: testlagoon/logs-db-curator
+    repository: uselagoon/logs-db-curator
 
 ssh:
   replicaCount: 1
   image:
-    repository: testlagoon/ssh
+    repository: uselagoon/ssh
 
 sshPortal:
   enabled: true
@@ -174,6 +174,6 @@ sshPortal:
 controllerhandler:
   replicaCount: 1
   image:
-    repository: testlagoon/controllerhandler
+    repository: uselagoon/controllerhandler
 
-imageTag: main
+imageTag: ""

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -159,7 +159,8 @@ drushAlias:
 
 logsDBCurator:
   image:
-    repository: uselagoon/logs-db-curator
+    repository: testlagoon/logs-db-curator
+    tag: main
 
 ssh:
   replicaCount: 1

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -159,8 +159,8 @@ drushAlias:
 
 logsDBCurator:
   image:
-    repository: testlagoon/logs-db-curator
-    tag: main
+    repository: uselagoon/logs-db-curator
+    tag: ""
 
 ssh:
   replicaCount: 1

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -74,7 +74,7 @@ imageTag: ""
 api:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/api
+    repository: uselagoon/api
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -112,7 +112,7 @@ api:
 
 apiDB:
   image:
-    repository: amazeeiolagoon/api-db
+    repository: uselagoon/api-db
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -139,7 +139,7 @@ apiDB:
 
 apiRedis:
   image:
-    repository: amazeeiolagoon/api-redis
+    repository: uselagoon/api-redis
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -157,7 +157,7 @@ apiRedis:
 keycloak:
   replicaCount: 1
   image:
-    repository: amazeeiolagoon/keycloak
+    repository: uselagoon/keycloak
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -189,7 +189,7 @@ keycloak:
 keycloakDB:
   replicaCount: 1
   image:
-    repository: amazeeiolagoon/keycloak-db
+    repository: uselagoon/keycloak-db
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -215,7 +215,7 @@ keycloakDB:
 broker:
   replicaCount: 3
   image:
-    repository: amazeeiolagoon/broker
+    repository: uselagoon/broker
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -278,7 +278,7 @@ broker:
 authServer:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/auth-server
+    repository: uselagoon/auth-server
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -304,7 +304,7 @@ webhooks2tasks:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/webhooks2tasks
+    repository: uselagoon/webhooks2tasks
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -326,7 +326,7 @@ webhookHandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/webhook-handler
+    repository: uselagoon/webhook-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -366,7 +366,7 @@ ui:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/ui
+    repository: uselagoon/ui
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -406,7 +406,7 @@ backupHandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/backup-handler
+    repository: uselagoon/backup-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -445,7 +445,7 @@ backupHandler:
 autoIdler:
   enabled: true
   image:
-    repository: amazeeiolagoon/auto-idler
+    repository: uselagoon/auto-idler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -459,7 +459,7 @@ autoIdler:
 storageCalculator:
   enabled: true
   image:
-    repository: amazeeiolagoon/storage-calculator
+    repository: uselagoon/storage-calculator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -474,7 +474,7 @@ logs2slack:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2slack
+    repository: uselagoon/logs2slack
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -496,7 +496,7 @@ logs2microsoftteams:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2microsoftteams
+    repository: uselagoon/logs2microsoftteams
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -518,7 +518,7 @@ logs2rocketchat:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2rocketchat
+    repository: uselagoon/logs2rocketchat
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -534,7 +534,7 @@ logs2email:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/logs2email
+    repository: uselagoon/logs2email
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -556,7 +556,7 @@ drushAlias:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/drush-alias
+    repository: uselagoon/drush-alias
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -595,7 +595,7 @@ drushAlias:
 logsDBCurator:
   enabled: true
   image:
-    repository: amazeeiolagoon/logs-db-curator
+    repository: uselagoon/logs-db-curator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -609,7 +609,7 @@ logsDBCurator:
 ssh:
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/ssh
+    repository: uselagoon/ssh
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -639,7 +639,7 @@ sshPortal:
   enabled: false
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/ssh-portal
+    repository: testlagoon/ssh-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: "pr-2179"
@@ -673,7 +673,7 @@ controllerhandler:
   enabled: true
   replicaCount: 2
   image:
-    repository: amazeeiolagoon/controllerhandler
+    repository: uselagoon/controllerhandler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -595,10 +595,10 @@ drushAlias:
 logsDBCurator:
   enabled: true
   image:
-    repository: testlagoon/logs-db-curator
+    repository: uselagoon/logs-db-curator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: main
+    tag: ""
 
   podAnnotations: {}
 

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -595,10 +595,10 @@ drushAlias:
 logsDBCurator:
   enabled: true
   image:
-    repository: uselagoon/logs-db-curator
+    repository: testlagoon/logs-db-curator
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+    tag: main
 
   podAnnotations: {}
 

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -24,7 +24,7 @@ version: 0.18.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.1
+appVersion: v2.0.0-alpha.2
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -24,7 +24,7 @@ version: 0.18.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.2
+appVersion: v2.0.0-alpha.3
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.1
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v1-9-1
+appVersion: v2.0.0-alpha.1
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -54,14 +54,17 @@ logsDispatcher:
   serviceMonitor:
     enabled: false
   image:
-    repository: uselagoon/logs-dispatcher
+    repository: testlagoon/logs-dispatcher
+    tag: main
 
 logsTeeRouter:
   image:
-    repository: uselagoon/logs-tee
+    repository: testlagoon/logs-tee
+    tag: main
 
 logsTeeApplication:
   image:
-    repository: uselagoon/logs-tee
+    repository: testlagoon/logs-tee
+    tag: main
 
 imageTag: ""

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -54,17 +54,17 @@ logsDispatcher:
   serviceMonitor:
     enabled: false
   image:
-    repository: testlagoon/logs-dispatcher
-    tag: main
+    repository: uselagoon/logs-dispatcher
+    tag: ""
 
 logsTeeRouter:
   image:
-    repository: testlagoon/logs-tee
-    tag: main
+    repository: uselagoon/logs-tee
+    tag: ""
 
 logsTeeApplication:
   image:
-    repository: testlagoon/logs-tee
-    tag: main
+    repository: uselagoon/logs-tee
+    tag: ""
 
 imageTag: ""

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -54,14 +54,14 @@ logsDispatcher:
   serviceMonitor:
     enabled: false
   image:
-    repository: testlagoon/logs-dispatcher
+    repository: uselagoon/logs-dispatcher
 
 logsTeeRouter:
   image:
-    repository: testlagoon/logs-tee
+    repository: uselagoon/logs-tee
 
 logsTeeApplication:
   image:
-    repository: testlagoon/logs-tee
+    repository: uselagoon/logs-tee
 
-imageTag: main
+imageTag: ""

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -16,10 +16,10 @@ logsDispatcher:
   replicaCount: 3
 
   image:
-    repository: testlagoon/logs-dispatcher
+    repository: uselagoon/logs-dispatcher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
-    tag: main
+    tag: ""
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -114,10 +114,10 @@ logsTeeRouter:
   replicaCount: 3
 
   image:
-    repository: testlagoon/logs-tee
+    repository: uselagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
-    tag: main
+    tag: ""
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -177,10 +177,10 @@ logsTeeApplication:
   replicaCount: 3
 
   image:
-    repository: testlagoon/logs-tee
+    repository: uselagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
-    tag: main
+    tag: ""
 
   serviceAccount:
     # Specifies whether a service account should be created

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -16,10 +16,10 @@ logsDispatcher:
   replicaCount: 3
 
   image:
-    repository: uselagoon/logs-dispatcher
+    repository: testlagoon/logs-dispatcher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
-    tag: ""
+    tag: main
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -114,10 +114,10 @@ logsTeeRouter:
   replicaCount: 3
 
   image:
-    repository: uselagoon/logs-tee
+    repository: testlagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
-    tag: ""
+    tag: main
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -177,10 +177,10 @@ logsTeeApplication:
   replicaCount: 3
 
   image:
-    repository: uselagoon/logs-tee
+    repository: testlagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
-    tag: ""
+    tag: main
 
   serviceAccount:
     # Specifies whether a service account should be created

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -16,7 +16,7 @@ logsDispatcher:
   replicaCount: 3
 
   image:
-    repository: amazeeiolagoon/logs-dispatcher
+    repository: uselagoon/logs-dispatcher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""
@@ -114,7 +114,7 @@ logsTeeRouter:
   replicaCount: 3
 
   image:
-    repository: amazeeiolagoon/logs-tee
+    repository: uselagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""
@@ -177,7 +177,7 @@ logsTeeApplication:
   replicaCount: 3
 
   image:
-    repository: amazeeiolagoon/logs-tee
+    repository: uselagoon/logs-tee
     pullPolicy: Always
     # Overrides the image tag whose default is the chart version.
     tag: ""

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.7.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.2
+appVersion: v2.0.0-alpha.3

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.7.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.1
+appVersion: v2.0.0-alpha.2

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v1-9-1
+appVersion: v2.0.0-alpha.1

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -46,6 +46,7 @@ serviceMonitor:
   enabled: false
 
 image:
-  repository: uselagoon/logs-concentrator
+  repository: testlagoon/logs-concentrator
+  tag: main
 
 imageTag: ""

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -46,7 +46,7 @@ serviceMonitor:
   enabled: false
 
 image:
-  repository: testlagoon/logs-concentrator
-  tag: main
+  repository: uselagoon/logs-concentrator
+  tag: ""
 
 imageTag: ""

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -46,6 +46,6 @@ serviceMonitor:
   enabled: false
 
 image:
-  repository: testlagoon/logs-concentrator
+  repository: uselagoon/logs-concentrator
 
-imageTag: main
+imageTag: ""

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -9,7 +9,7 @@ imageTag: ""
 replicaCount: 1
 
 image:
-  repository: amazeeiolagoon/logs-concentrator
+  repository: uselagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
   tag: ""

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -9,10 +9,10 @@ imageTag: ""
 replicaCount: 1
 
 image:
-  repository: testlagoon/logs-concentrator
+  repository: uselagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
-  tag: main
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -9,10 +9,10 @@ imageTag: ""
 replicaCount: 1
 
 image:
-  repository: uselagoon/logs-concentrator
+  repository: testlagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
-  tag: ""
+  tag: main
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -22,7 +22,7 @@ version: 0.12.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.0.0-alpha.2
+appVersion: v2.0.0-alpha.3
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -22,7 +22,7 @@ version: 0.12.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.0.0-alpha.1
+appVersion: v2.0.0-alpha.2
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,11 +18,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.11.2
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v1-9-1
+appVersion: v2.0.0-alpha.1
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -7,11 +7,11 @@ lagoon-build-deploy:
 
 dockerHost:
   image:
-    repository: testlagoon/docker-host
+    repository: uselagoon/docker-host
   storage:
     size: 50Gi
 
-imageTag: main
+imageTag: ""
 
 dbaasOperator:
   enabled: true

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -11,7 +11,7 @@ imageTag: ""
 
 dockerHost:
   image:
-    repository: amazeeiolagoon/docker-host
+    repository: uselagoon/docker-host
     pullPolicy: Always
     tag: ""
 

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.8.3
+version: 0.9.0
 
-appVersion: v1-9-1
+appVersion: v2.0.0-alpha.1

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -12,4 +12,4 @@ type: application
 
 version: 0.9.0
 
-appVersion: v2.0.0-alpha.1
+appVersion: v2.0.0-alpha.2

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -12,4 +12,4 @@ type: application
 
 version: 0.9.0
 
-appVersion: v2.0.0-alpha.2
+appVersion: v2.0.0-alpha.3

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -81,7 +81,7 @@ imageTag: ""
 localGit:
 
   image:
-    repository: amazeeiolagoon/local-git
+    repository: uselagoon/local-git
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -107,7 +107,7 @@ localGit:
 localAPIDataWatcherPusher:
 
   image:
-    repository: amazeeiolagoon/local-api-data-watcher-pusher
+    repository: uselagoon/local-api-data-watcher-pusher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -121,7 +121,7 @@ localAPIDataWatcherPusher:
 tests:
 
   image:
-    repository: amazeeiolagoon/tests
+    repository: uselagoon/tests
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""


### PR DESCRIPTION
so the goals here:

* Set the charts to use the named release of Lagoon (2.0.0-alpha.1) from the uselagoon repo as a default
* Allow the makefile (or command line) to provide a different repository (testlagoon) or tag (main etc) for the images
* Be able to locally build the individual namespaces (core, remote, tests) without having to rebuild everything - again using the common repository/image settings
* Fix up the variable naming in the build-deploy-dind variable overwrite (not working yet)