### PR TITLE
Add lagoon-build-deploy chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ Please ensure that any new chart:
 The CI runs in a [constrained environment](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources) which makes it a good place to test how your chart handles slow-starting pods.
 Ideally pods should never be killed due to failing probes during chart-install, even if they do eventually start and the chart installation succeeds.
 Documentation on probes for pod startup is [here](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+
+## Development tips
+
+### Run chart-testing (lint) locally
+
+```
+$ docker run --rm --interactive --detach --network host --name ct "--volume=$(pwd):/workdir" "--workdir=/workdir" --volume=$(pwd)/default.ct.yaml:/etc/ct/ct.yaml quay.io/helmpack/chart-testing:latest cat
+$ docker exec ct ct lint
+```

--- a/charts/lagoon-build-deploy/.helmignore
+++ b/charts/lagoon-build-deploy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: lagoon-build-deploy
+description:
+  A Helm chart for Kubernetes which installs Lagoon build deploy controllers
+  (https://github.com/amazeeio/lagoon-kbd).
+home: https://github.com/uselagoon/lagoon-charts
+icon: https://raw.githubusercontent.com/uselagoon/lagoon-charts/main/icon.png
+maintainers:
+- name: shreddedbacon
+  email: ben.jackson@amazee.io
+  url: https://amazee.io
+- name: smlx
+  email: scott.leggett@amazee.io
+  url: https://amazee.io
+
+type: application
+
+version: 0.1.0
+
+appVersion: v0.1.4

--- a/charts/lagoon-build-deploy/ci/linter-values.yaml
+++ b/charts/lagoon-build-deploy/ci/linter-values.yaml
@@ -1,0 +1,4 @@
+rabbitMQUsername: lagoon
+rabbitMQPassword: ci
+rabbitMQHostname: ci-broker
+lagoonTargetName: ci-local-control-k8s

--- a/charts/lagoon-build-deploy/crds/lagoonBuild.yaml
+++ b/charts/lagoon-build-deploy/crds/lagoonBuild.yaml
@@ -1,0 +1,842 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  name: lagoonbuilds.lagoon.amazee.io
+spec:
+  group: lagoon.amazee.io
+  names:
+    kind: LagoonBuild
+    listKind: LagoonBuildList
+    plural: lagoonbuilds
+    singular: lagoonbuild
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: LagoonBuild is the Schema for the lagoonbuilds API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LagoonBuildSpec defines the desired state of LagoonBuild
+          properties:
+            branch:
+              description: Branch contains the branch name used for a branch deployment.
+              properties:
+                name:
+                  type: string
+              type: object
+            build:
+              description: Build contains the type of build, and the image to use
+                for the builder.
+              properties:
+                ci:
+                  type: string
+                image:
+                  type: string
+                type:
+                  type: string
+              required:
+              - type
+              type: object
+            gitReference:
+              type: string
+            project:
+              description: Project contains the project information from lagoon.
+              properties:
+                deployTarget:
+                  type: string
+                environment:
+                  type: string
+                environmentType:
+                  type: string
+                gitUrl:
+                  type: string
+                key:
+                  format: byte
+                  type: string
+                monitoring:
+                  description: Monitoring contains the monitoring information for
+                    the project in Lagoon.
+                  properties:
+                    contact:
+                      type: string
+                    statuspageID:
+                      type: string
+                  type: object
+                name:
+                  type: string
+                namespacePattern:
+                  type: string
+                productionEnvironment:
+                  type: string
+                projectSecret:
+                  type: string
+                registry:
+                  type: string
+                routerPattern:
+                  type: string
+                standbyEnvironment:
+                  type: string
+                subfolder:
+                  type: string
+                uiLink:
+                  type: string
+                variables:
+                  description: Variables contains the project and environment variables
+                    from lagoon.
+                  properties:
+                    environment:
+                      format: byte
+                      type: string
+                    project:
+                      format: byte
+                      type: string
+                  type: object
+              required:
+              - deployTarget
+              - environment
+              - environmentType
+              - gitUrl
+              - key
+              - monitoring
+              - name
+              - productionEnvironment
+              - projectSecret
+              - standbyEnvironment
+              - variables
+              type: object
+            promote:
+              description: Promote contains the information for a promote deployment.
+              properties:
+                sourceEnvironment:
+                  type: string
+                sourceProject:
+                  type: string
+              type: object
+            pullrequest:
+              description: Pullrequest contains the information for a pullrequest
+                deployment.
+              properties:
+                baseBranch:
+                  type: string
+                baseSha:
+                  type: string
+                headBranch:
+                  type: string
+                headSha:
+                  type: string
+                number:
+                  type: integer
+                title:
+                  type: string
+              type: object
+          required:
+          - build
+          - gitReference
+          - project
+          type: object
+        status:
+          description: LagoonBuildStatus defines the observed state of LagoonBuild
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              items:
+                description: LagoonConditions defines the observed conditions of the
+                  pods.
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: JobConditionType const for the status type
+                    type: string
+                required:
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+            log:
+              format: byte
+              type: string
+          type: object
+        statusMessages:
+          description: LagoonStatusMessages is where unsent messages are stored for
+            re-sending.
+          properties:
+            buildLogMessage:
+              description: LagoonLog is used to sendToLagoonLogs messaging queue this
+                is general logging information
+              properties:
+                event:
+                  type: string
+                message:
+                  type: string
+                meta:
+                  description: LagoonLogMeta is the metadata that is used by logging
+                    in Lagoon.
+                  properties:
+                    advancedData:
+                      type: string
+                    branchName:
+                      type: string
+                    buildName:
+                      type: string
+                    buildPhase:
+                      type: string
+                    endTime:
+                      type: string
+                    environment:
+                      type: string
+                    jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
+                      type: string
+                    logLink:
+                      type: string
+                    monitoringUrls:
+                      items:
+                        type: string
+                      type: array
+                    project:
+                      type: string
+                    projectName:
+                      type: string
+                    remoteId:
+                      type: string
+                    route:
+                      type: string
+                    routes:
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
+                    startTime:
+                      type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                  type: object
+                project:
+                  type: string
+                severity:
+                  type: string
+                uuid:
+                  type: string
+              type: object
+            environmentMessage:
+              description: LagoonMessage is used for sending build info back to Lagoon
+                messaging queue to update the environment or deployment
+              properties:
+                meta:
+                  description: LagoonLogMeta is the metadata that is used by logging
+                    in Lagoon.
+                  properties:
+                    advancedData:
+                      type: string
+                    branchName:
+                      type: string
+                    buildName:
+                      type: string
+                    buildPhase:
+                      type: string
+                    endTime:
+                      type: string
+                    environment:
+                      type: string
+                    jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
+                      type: string
+                    logLink:
+                      type: string
+                    monitoringUrls:
+                      items:
+                        type: string
+                      type: array
+                    project:
+                      type: string
+                    projectName:
+                      type: string
+                    remoteId:
+                      type: string
+                    route:
+                      type: string
+                    routes:
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
+                    startTime:
+                      type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                  type: object
+                namespace:
+                  type: string
+                type:
+                  type: string
+              type: object
+            statusMessage:
+              description: LagoonLog is used to sendToLagoonLogs messaging queue this
+                is general logging information
+              properties:
+                event:
+                  type: string
+                message:
+                  type: string
+                meta:
+                  description: LagoonLogMeta is the metadata that is used by logging
+                    in Lagoon.
+                  properties:
+                    advancedData:
+                      type: string
+                    branchName:
+                      type: string
+                    buildName:
+                      type: string
+                    buildPhase:
+                      type: string
+                    endTime:
+                      type: string
+                    environment:
+                      type: string
+                    jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
+                      type: string
+                    logLink:
+                      type: string
+                    monitoringUrls:
+                      items:
+                        type: string
+                      type: array
+                    project:
+                      type: string
+                    projectName:
+                      type: string
+                    remoteId:
+                      type: string
+                    route:
+                      type: string
+                    routes:
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
+                    startTime:
+                      type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                  type: object
+                project:
+                  type: string
+                severity:
+                  type: string
+                uuid:
+                  type: string
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  name: lagoontasks.lagoon.amazee.io
+spec:
+  group: lagoon.amazee.io
+  names:
+    kind: LagoonTask
+    listKind: LagoonTaskList
+    plural: lagoontasks
+    singular: lagoontask
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: LagoonTask is the Schema for the lagoontasks API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LagoonTaskSpec defines the desired state of LagoonTask
+          properties:
+            advancedTask:
+              description: LagoonAdvancedTaskInfo defines what an advanced task can
+                use for the creation of the pod.
+              properties:
+                JSONPayload:
+                  type: string
+                runnerImage:
+                  type: string
+              type: object
+            environment:
+              description: LagoonTaskEnvironment defines the lagoon environment information.
+              properties:
+                environmentType:
+                  type: string
+                id:
+                  type: string
+                name:
+                  type: string
+                openshiftProjectName:
+                  type: string
+                project:
+                  type: string
+              required:
+              - environmentType
+              - id
+              - name
+              - openshiftProjectName
+              - project
+              type: object
+            key:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "make" to regenerate code after modifying this file'
+              type: string
+            misc:
+              description: LagoonMiscInfo defines the resource or backup information
+                for a misc task.
+              properties:
+                backup:
+                  description: LagoonMiscBackupInfo defines the information for a
+                    backup.
+                  properties:
+                    backupId:
+                      type: string
+                    id:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - backupId
+                  - id
+                  - source
+                  type: object
+                id:
+                  type: string
+                miscResource:
+                  format: byte
+                  type: string
+                name:
+                  type: string
+              required:
+              - id
+              type: object
+            project:
+              description: LagoonTaskProject defines the lagoon project information.
+              properties:
+                id:
+                  type: string
+                name:
+                  type: string
+              required:
+              - id
+              - name
+              type: object
+            task:
+              description: LagoonTaskInfo defines what a task can use to communicate
+                with Lagoon via SSH/API.
+              properties:
+                apiHost:
+                  type: string
+                command:
+                  type: string
+                id:
+                  type: string
+                name:
+                  type: string
+                service:
+                  type: string
+                sshHost:
+                  type: string
+                sshPort:
+                  type: string
+              required:
+              - id
+              type: object
+          type: object
+        status:
+          description: LagoonTaskStatus defines the observed state of LagoonTask
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              items:
+                description: LagoonConditions defines the observed conditions of the
+                  pods.
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: JobConditionType const for the status type
+                    type: string
+                required:
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+            log:
+              format: byte
+              type: string
+          type: object
+        statusMessages:
+          description: LagoonStatusMessages is where unsent messages are stored for
+            re-sending.
+          properties:
+            buildLogMessage:
+              description: LagoonLog is used to sendToLagoonLogs messaging queue this
+                is general logging information
+              properties:
+                event:
+                  type: string
+                message:
+                  type: string
+                meta:
+                  description: LagoonLogMeta is the metadata that is used by logging
+                    in Lagoon.
+                  properties:
+                    advancedData:
+                      type: string
+                    branchName:
+                      type: string
+                    buildName:
+                      type: string
+                    buildPhase:
+                      type: string
+                    endTime:
+                      type: string
+                    environment:
+                      type: string
+                    jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
+                      type: string
+                    logLink:
+                      type: string
+                    monitoringUrls:
+                      items:
+                        type: string
+                      type: array
+                    project:
+                      type: string
+                    projectName:
+                      type: string
+                    remoteId:
+                      type: string
+                    route:
+                      type: string
+                    routes:
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
+                    startTime:
+                      type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                  type: object
+                project:
+                  type: string
+                severity:
+                  type: string
+                uuid:
+                  type: string
+              type: object
+            environmentMessage:
+              description: LagoonMessage is used for sending build info back to Lagoon
+                messaging queue to update the environment or deployment
+              properties:
+                meta:
+                  description: LagoonLogMeta is the metadata that is used by logging
+                    in Lagoon.
+                  properties:
+                    advancedData:
+                      type: string
+                    branchName:
+                      type: string
+                    buildName:
+                      type: string
+                    buildPhase:
+                      type: string
+                    endTime:
+                      type: string
+                    environment:
+                      type: string
+                    jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
+                      type: string
+                    logLink:
+                      type: string
+                    monitoringUrls:
+                      items:
+                        type: string
+                      type: array
+                    project:
+                      type: string
+                    projectName:
+                      type: string
+                    remoteId:
+                      type: string
+                    route:
+                      type: string
+                    routes:
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
+                    startTime:
+                      type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                  type: object
+                namespace:
+                  type: string
+                type:
+                  type: string
+              type: object
+            statusMessage:
+              description: LagoonLog is used to sendToLagoonLogs messaging queue this
+                is general logging information
+              properties:
+                event:
+                  type: string
+                message:
+                  type: string
+                meta:
+                  description: LagoonLogMeta is the metadata that is used by logging
+                    in Lagoon.
+                  properties:
+                    advancedData:
+                      type: string
+                    branchName:
+                      type: string
+                    buildName:
+                      type: string
+                    buildPhase:
+                      type: string
+                    endTime:
+                      type: string
+                    environment:
+                      type: string
+                    jobName:
+                      type: string
+                    jobStatus:
+                      type: string
+                    key:
+                      type: string
+                    logLink:
+                      type: string
+                    monitoringUrls:
+                      items:
+                        type: string
+                      type: array
+                    project:
+                      type: string
+                    projectName:
+                      type: string
+                    remoteId:
+                      type: string
+                    route:
+                      type: string
+                    routes:
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      items:
+                        type: string
+                      type: array
+                    startTime:
+                      type: string
+                    task:
+                      description: LagoonTaskInfo defines what a task can use to communicate
+                        with Lagoon via SSH/API.
+                      properties:
+                        apiHost:
+                          type: string
+                        command:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        sshHost:
+                          type: string
+                        sshPort:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                  type: object
+                project:
+                  type: string
+                severity:
+                  type: string
+                uuid:
+                  type: string
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/lagoon-build-deploy/templates/NOTES.txt
+++ b/charts/lagoon-build-deploy/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Lagoon Remote configured with target name "{{ .Values.lagoonTargetName }}", and RabbitMQ host "{{ .Values.rabbitMQHostname }}".

--- a/charts/lagoon-build-deploy/templates/_helpers.tpl
+++ b/charts/lagoon-build-deploy/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lagoon-build-deploy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lagoon-build-deploy.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lagoon-build-deploy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lagoon-build-deploy.labels" -}}
+helm.sh/chart: {{ include "lagoon-build-deploy.chart" . }}
+{{ include "lagoon-build-deploy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lagoon-build-deploy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-build-deploy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lagoon-build-deploy.serviceAccountName" -}}
+{{- default (include "lagoon-build-deploy.fullname" .) .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/lagoon-build-deploy/templates/clusterrolebinding.yaml
+++ b/charts/lagoon-build-deploy/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-build-deploy.fullname" . }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-build-deploy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-build-deploy.fullname" . }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-build-deploy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lagoon-build-deploy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lagoon-build-deploy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          {{- toYaml .Values.kubeRBACProxy.securityContext | nindent 10 }}
+        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          {{- toYaml .Values.kubeRBACProxy.resources | nindent 10 }}
+      - name: manager
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /manager
+        {{- with .Values.extraArgs }}
+        args:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        env:
+        - name: LAGOON_TARGET_NAME
+          value: {{ required "A valid .Values.lagoonTargetName required!" .Values.lagoonTargetName | quote }}
+        {{- with .Values.overrideBuildDeployDindImage }}
+        - name: OVERRIDE_BUILD_DEPLOY_DIND_IMAGE
+          value: {{ . | quote }}
+        {{- end }}
+        - name: PENDING_MESSAGE_CRON
+          value: {{ .Values.pendingMessageCron | quote }}
+        - name: RABBITMQ_HOSTNAME
+          value: {{ required "A valid .Values.rabbitMQHostname required!" .Values.rabbitMQHostname | quote }}
+        - name: RABBITMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-build-deploy.fullname" . }}
+              key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-build-deploy.fullname" . }}
+              key: RABBITMQ_USERNAME
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/lagoon-build-deploy/templates/secret.yaml
+++ b/charts/lagoon-build-deploy/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-build-deploy.fullname" . }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+stringData:
+  RABBITMQ_PASSWORD: {{ required "A valid .Values.rabbitMQPassword required!" .Values.rabbitMQPassword | quote }}
+  RABBITMQ_USERNAME: {{ required "A valid .Values.rabbitMQUsername required!" .Values.rabbitMQUsername | quote }}

--- a/charts/lagoon-build-deploy/templates/service.yaml
+++ b/charts/lagoon-build-deploy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-build-deploy.fullname" . }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: https
+    protocol: TCP
+    name: https
+  selector:
+    {{- include "lagoon-build-deploy.selectorLabels" . | nindent 4 }}

--- a/charts/lagoon-build-deploy/templates/serviceaccount.yaml
+++ b/charts/lagoon-build-deploy/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lagoon-build-deploy.serviceAccountName" . }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -1,0 +1,71 @@
+# the following values are requried and have no sensible default
+
+lagoonTargetName: ""
+rabbitMQHostname: ""
+rabbitMQPassword: ""
+rabbitMQUsername: ""
+
+# the following values are defaults which may be overridden
+
+# If the controller is running in an openshift,
+# then the argument `--is-openshift=true` should be added
+extraArgs:
+- "--metrics-addr=127.0.0.1:8080"
+- "--enable-leader-election=true"
+
+pendingMessageCron: "*/5 * * * *"
+
+# The controller will use `uselagoon/kubectl-build-deploy-dind:latest` by
+# default, but this can be overridden here.
+overrideBuildDeployDindImage: ""
+
+image:
+  repository: amazeeio/lagoon-builddeploy
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8443
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# this is a sidecar in the same pod as the lagoonBuildDeploy container
+kubeRBACProxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: v0.4.1
+
+  securityContext: {}
+
+  resources: {}

--- a/default.ct.yaml
+++ b/default.ct.yaml
@@ -1,4 +1,5 @@
 # See https://github.com/helm/chart-testing#configuration
+# This configuration is used in the lint-test github workflow.
 remote: origin
 target-branch: main
 chart-dirs:

--- a/test-suite-lint.ct.yaml
+++ b/test-suite-lint.ct.yaml
@@ -1,6 +1,10 @@
 # See https://github.com/helm/chart-testing#configuration
+# This configuration is used in the test-suite github workflow.
+# Changes in any chart other than those excluded below will trigger a full test
+# suite run.
 target-branch: main
 excluded-charts:
 - lagoon-logging
 - lagoon-logs-concentrator
+- lagoon-build-deploy
 helm-extra-args: --timeout 10m


### PR DESCRIPTION
This PR creates a separate chart for lagoon-build-deploy. Eventually this will be used as a dependency in lagoon-remote.

Partially addresses https://github.com/uselagoon/lagoon-charts/issues/175.