### PR TITLE
allow to inject task environment variables

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
 appVersion: v0.1.6

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
 appVersion: v0.1.5

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -56,6 +56,18 @@ spec:
         - name: OVERRIDE_BUILD_DEPLOY_DIND_IMAGE
           value: {{ . | quote }}
         {{- end }}
+        {{- with .Values.taskSSHHost }}
+        - name: TASK_SSH_HOST
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.taskSSHPort }}
+        - name: TASK_SSH_PORT
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.taskAPIHost }}
+        - name: TASK_API_HOST
+          value: {{ . | quote }}
+        {{- end }}
         - name: PENDING_MESSAGE_CRON
           value: {{ .Values.pendingMessageCron | quote }}
         - name: RABBITMQ_HOSTNAME

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -4,6 +4,9 @@ lagoonTargetName: ""
 rabbitMQHostname: ""
 rabbitMQPassword: ""
 rabbitMQUsername: ""
+taskSSHHost: ""
+taskSSHPort: ""
+taskAPIHost: ""
 
 # if using controller namespace prefixing, define that prefix here
 # limited to 8 characters (will be truncated by controller if it exceeds this)

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.11.2
+version: 0.11.3
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -26,6 +26,6 @@ appVersion: v1-9-1
 
 dependencies:
 - name: lagoon-build-deploy
-  version: 0.2.1
+  version: 0.2.2
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -26,6 +26,6 @@ appVersion: v1-9-1
 
 dependencies:
 - name: lagoon-build-deploy
-  version: 0.2.2
+  version: 0.2.1
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.13.1
+version: 0.13.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -68,6 +68,9 @@ lagoon-build-deploy:
   # rabbitMQPassword:
   # rabbitMQHostname:
   # lagoonTargetName:
+  # taskSSHHost: ""
+  # taskSSHPort: ""
+  # taskAPIHost: ""
 
 # this account is used by the legacy Lagoon kubernetes build deploy system.
 kubernetesBuildDeploy:


### PR DESCRIPTION
the lagoon-build-deploy controller needs to know the SSH and API Host and ports to properly run lagoon tasks, this allows it inject them.