### PR TITLE
Collect logs from system namespaces

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.0
+version: 0.20.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -234,23 +234,6 @@ logsTeeApplication:
 # Don't collect logs from these namespaces.
 # Comment out this field to collect from all namespaces.
 excludeNamespaces:
-# k8s
-- cattle-prometheus
-- cattle-system
-- dbaas-operator
-- default
-- kube-cleanup-operator
-- kube-node-lease
-- kube-public
-- kube-system
-- metrics-server
-- syn
-- syn-backup
-- syn-cert-manager
-- syn-cluster-autoscaler
-- syn-efs-provisioner
-- syn-resource-locker
-- syn-synsights
 # openshift
 - acme-controller
 - appuio-baas-operator


### PR DESCRIPTION
We had a couple of cases where we really needed logs from system namespaces.
I'm not sure though if this is really the right way to do this. Basically we're sending many thousand of log entries to the elasticsearch which is also used by our customers. 
If I would have time I probably would create a separate logging infrastructure for system logs from our clusters, but as we don't really have time I think the easiest right now is to just send them in the same place.
Any opinions @smlx ?