### PR TITLE
Revert "Use a custom test image"

### DIFF
--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -15,8 +15,7 @@ localAPIDataWatcherPusher:
 
 tests:
   image:
-    repository: testlagoon/tests
-    tag: test-timeout-bumps
+    repository: ${imageRegistry}/tests
   tests: ${tests}
 
 imageTag: ${imageTag}


### PR DESCRIPTION
The branch this image referred to has now been merged to amazeeio/lagoon main branch.

This reverts commit ab4cebb76a267fedd8560112047b77b44275ad8e.

Blocked on https://github.com/uselagoon/lagoon-charts/pull/200 which also uses a custom image.
