### PR TITLE
lagoon-logging sumologic support and dependency maintenance

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.7.0
-digest: sha256:7fee947e1c8665ec5d247d5e7cff2d4eeb8b4b64e8bdf8dab6af4a046d01ecb2
-generated: "2020-10-22T09:48:52.273596876+08:00"
+  version: 3.9.0
+digest: sha256:40c05879cf55fd7f12de19a2842b59d50ecc44a2237c150f7160392582e8a548
+generated: "2021-01-25T14:11:42.086670763+08:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -29,4 +29,4 @@ appVersion: v2.0.0-alpha.5
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: ~3.7.0
+  version: ~3.9.0

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -148,11 +148,13 @@ data:
       @type record_modifier
       remove_keys docker
     </filter>
-    # add the index name
+    # * add the index name
+    # * ensure the log field is in there, even if empty, to avoid errors in the following parser
     <filter lagoon.*.container>
       @type record_modifier
       <record>
         index_name container-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project')&.gsub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
+        log ${record['log'] || ""}
       </record>
     </filter>
     # post-process to try to eke some more structure out of the logs.
@@ -173,12 +175,6 @@ data:
           format none
         </pattern>
       </parse>
-    </filter>
-    # some container logs have a duplicate message field for some reason, so
-    # remove that.
-    <filter lagoon.*.container>
-      @type record_modifier
-      remove_keys message
     </filter>
     {{- if .Values.consolidateServiceIndices }}
     # some cluster services generate namespaces with a random suffix, so

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -18,8 +18,8 @@ logsDispatcher:
   image:
     repository: uselagoon/logs-dispatcher
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart version.
-    tag: ""
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v1-13-3"
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
This PR:

* bumps the logs-dispatcher image version to support sumologic output.
* bumps the logging-operator dependency version for maintenance reasons.
* avoid stripping the `message` field, since this appears to depend on the container runtime in use(?): https://github.com/banzaicloud/logging-operator/blob/chart/logging-operator/3.9.0/pkg/sdk/model/types/types.go#L28-L34

Closes: #165 
