### PR TITLE
Revert logs dispatcher tag

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.21.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -53,18 +53,3 @@ logging-operator:
 logsDispatcher:
   serviceMonitor:
     enabled: false
-  image:
-    repository: uselagoon/logs-dispatcher
-    tag: ""
-
-logsTeeRouter:
-  image:
-    repository: uselagoon/logs-tee
-    tag: ""
-
-logsTeeApplication:
-  image:
-    repository: uselagoon/logs-tee
-    tag: ""
-
-imageTag: ""

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -19,7 +19,7 @@ logsDispatcher:
     repository: uselagoon/logs-dispatcher
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v1-13-3"
+    tag: ""
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
The update on the default tag in #204 neglected to take into account the image the tag was attached to.

In addition this issue exposed a problem in our CI `linter-values.yaml`, so this PR fixes that too.
