### PR TITLE
Logging extra conf

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.1
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -372,5 +372,17 @@ data:
         </buffer>
       </store>
       {{- end }}
+      {{- if .Values.extraConf }}
+      <store>
+        @type relabel
+        @label @EXTRACONF
+      </store>
+      {{- end }}
       @include store.d/*.conf
     </match>
+    {{- with .Values.extraConf }}
+
+    <label @EXTRACONF>
+      {{- . | nindent 6 }}
+    </label>
+    {{- end }}

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -387,6 +387,27 @@ enableDefaultForwarding: true
 #       ...
 #     </store>
 
+# Optional extra fluentd configuration.
+#
+# This adds a <label @EXTRACONF></label> section to the fluentd configuration
+# containing the given configuration, and copies logs to that label after all
+# the Lagoon-specific munging. It uses the pattern described here:
+# https://docs.fluentd.org/configuration/routing-examples#re-route-event-to-other-label
+#
+# extraConf: |-
+#   <match lagoon.*.router.**>
+#     @type sumologic
+#     ...
+#   </match>
+#   <match lagoon.*.container>
+#     @type sumologic
+#     ...
+#   </match>
+#   <match lagoon.*.application>
+#     @type sumologic
+#     ...
+#   </match>
+
 # Openshift only!
 #
 # fluentbitPrivileged: true


### PR DESCRIPTION
This PR makes it possible to inject raw fluentd configuration snippets into the logs-dispatcher's `fluent.conf`.

This is useful if, for example, you want to be able to direct logs to different `<match>...</match>` endpoints by tag.
