### PR TITLE
Lagoon core user consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ TESTS = [features-kubernetes]
 # IMAGE_TAG controls the tag used for container images in the lagoon-core,
 # lagoon-remote, and lagoon-test charts. If IMAGE_TAG is not set, it will fall
 # back to the version set in the CI values file, then to the chart default.
-IMAGE_TAG =
+IMAGE_TAG = pr-2534
 # IMAGE_REGISTRY controls the registry used for container images in the
 # lagoon-core, lagoon-remote, and lagoon-test charts. If IMAGE_REGISTRY is not
 # set, it will fall back to the version set in the chart values files. This
 # only affects lagoon-core, lagoon-remote, and the fill-test-ci-values target.
-IMAGE_REGISTRY = uselagoon
+IMAGE_REGISTRY = testlagoon
 # if OVERRIDE_BUILD_DEPLOY_DIND_IMAGE is not set, it will fall back to the
 # controller default (uselagoon/kubectl-build-deploy-dind:latest).
 OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.37.0
+version: 0.38.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -63,7 +63,9 @@ harborAPIVersion: v2.0
 # this default podSecurityContext is set for all services and can be overridden
 # on the service level.
 podSecurityContext:
-  runAsUser: 100
+  fsGroup: 10001
+  runAsGroup: 0
+  runAsUser: 10000
 
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it falls back to chart appVersion.
@@ -130,10 +132,6 @@ apiDB:
   securityContext: {}
 
   resources: {}
-
-  podSecurityContext:
-    runAsUser: 100
-    fsGroup: 0
 
   storageSize: 128Gi
 
@@ -208,10 +206,6 @@ keycloakDB:
 
   resources: {}
 
-  podSecurityContext:
-    runAsUser: 100
-    fsGroup: 0
-
 broker:
   replicaCount: 3
   image:
@@ -255,10 +249,6 @@ broker:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
-
-  podSecurityContext:
-    runAsUser: 100
-    fsGroup: 0
 
   ingress:
     enabled: false
@@ -619,10 +609,6 @@ ssh:
   securityContext: {}
 
   resources: {}
-
-  podSecurityContext:
-    runAsUser: 1000
-    fsGroup: 0
 
   service:
     type: ClusterIP


### PR DESCRIPTION
Use consistent user/group IDs for workloads in lagoon-core too.

This isn't enforced, just better than using some other random IDs.

~Draft until the associated PR is accepted into amazeeio/lagoon.~