### PR TITLE
Lagoon gatekeeper integration with lagoon-remote

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -34,8 +34,11 @@ jobs:
             --output-dir /tmp/charts/$chart
         done
 
-        # workaround until gatekeeper templates are fixed
-        rm -rf /tmp/charts/lagoon-gatekeeper/lagoon-gatekeeper/charts
+        # workaround until gatekeeper templates are fixed:
+        # * https://github.com/open-policy-agent/gatekeeper/pull/1114
+        # * https://github.com/open-policy-agent/gatekeeper/pull/1115
+        rm -rf /tmp/charts/lagoon-gatekeeper/lagoon-gatekeeper/charts/gatekeeper
+        rm -rf /tmp/charts/lagoon-remote/lagoon-remote/charts/lagoon-gatekeeper/charts/gatekeeper
     - name: Install YAMLlint
       run: sudo apt-get -y install yamllint
     - name: Lint the templates

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
   version: 0.2.0
-digest: sha256:a0ced4db276fc8863fd7ff13c9ee329d3c99a3d67f195109093a2b4c8f185f3b
-generated: "2021-01-06T23:18:24.850263509+08:00"
+- name: lagoon-gatekeeper
+  repository: https://uselagoon.github.io/lagoon-charts/
+  version: 0.3.1
+digest: sha256:b34d635a83e3b0d73860bf2b3c0372f6e9e2691914bfd4c492abb0b31104e0ba
+generated: "2021-02-04T21:29:52.496988861+08:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.17.0
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -37,3 +37,7 @@ dependencies:
   version: ~0.2.0
   repository: https://amazeeio.github.io/charts/
   condition: dbaas-operator.enabled
+- name: lagoon-gatekeeper
+  version: ~0.3.1
+  repository: https://uselagoon.github.io/lagoon-charts/
+  condition: lagoon-gatekeeper.enabled

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -15,3 +15,6 @@ imageTag: ""
 
 dbaas-operator:
   enabled: true
+
+lagoon-gatekeeper:
+  enabled: true

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -89,6 +89,12 @@ dioscuri:
 # dbaas-operator provisions database-as-a-service accounts for projects.
 # Example provider configuration can be found in the dbaas-operator values.yaml
 # https://github.com/amazeeio/charts/blob/main/charts/dbaas-operator/values.yaml
-# This subchart is enabled by default as this is a core Lagoon feature.
+# This subchart is disabled by default for legacy reasons. It will be enabled
+# by default in future as this is a core Lagoon feature.
 dbaas-operator:
+  enabled: false
+
+# lagoon-gatekeeper is a subchart which enforces security policy for Lagoon
+# workloads. It is currently experimental so it is disabled by default.
+lagoon-gatekeeper:
   enabled: false


### PR DESCRIPTION
This PR adds lagoon-gatekeeper as a lagoon-remote dependency, disabled by default, but enabled in CI.

lagoon-gatekeeper runs in audit-only mode by default so it does not block admission of pods to the cluster.
