### PR TITLE
Fix name length issues in lagoon-gatekeeper

### DIFF
--- a/charts/lagoon-gatekeeper/Chart.yaml
+++ b/charts/lagoon-gatekeeper/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
 # appVersion reflects the gatekeeper-library version
 appVersion: 2e5e92f

--- a/charts/lagoon-gatekeeper/templates/_helpers.tpl
+++ b/charts/lagoon-gatekeeper/templates/_helpers.tpl
@@ -19,6 +19,13 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Append a suffix to the fully qualified app name without hitting length limits of 63 (62 plus hyphen).
+*/}}
+{{- define "lagoon-gatekeeper.fullname.suffix" -}}
+{{ include "lagoon-gatekeeper.fullname" . | trunc (sub 62 (len .suffix) | int) }}-{{ .suffix }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "lagoon-gatekeeper.chart" -}}

--- a/charts/lagoon-gatekeeper/templates/constraint.job.yaml
+++ b/charts/lagoon-gatekeeper/templates/constraint.job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "lagoon-gatekeeper.fullname" . }}-wait-for-constraint-crd
+  name: {{ include "lagoon-gatekeeper.fullname.suffix" (merge (dict "suffix" "wait-for-constraint-crd") .) }}
   labels:
     {{- include "lagoon-gatekeeper.labels" . | nindent 4 }}
   annotations:
@@ -12,7 +12,7 @@ spec:
   backoffLimit: 1
   template:
     metadata:
-      name: {{ template "lagoon-gatekeeper.fullname" . }}-wait-for-constraint-crd
+      name: {{ include "lagoon-gatekeeper.fullname.suffix" (merge (dict "suffix" "wait-for-constraint-crd") .) }}
       labels:
         {{- include "lagoon-gatekeeper.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/lagoon-gatekeeper/templates/psp-pods-allowed-user-ranges.constraint.yaml
+++ b/charts/lagoon-gatekeeper/templates/psp-pods-allowed-user-ranges.constraint.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sPSPAllowedUsers
 metadata:
-  name: {{ include "lagoon-gatekeeper.fullname" . }}-psp-pods-allowed-user-ranges
+  name: {{ include "lagoon-gatekeeper.fullname.suffix" (merge (dict "suffix" "psp-pods-allowed-user-ranges") .) }}
   labels:
     {{- include "lagoon-gatekeeper.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
When used as a subchart, names in lagoon-gatekeeper can hit the 63 character limit. This PR adds a function to safely suffix the chart fullname without breaking 63 chars.
