### PR TITLE
add needs-testing label logic to github actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
 
     - name: Run chart-testing (install)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -83,7 +83,9 @@ jobs:
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
 
     - name: Run chart-testing (install)
       run: ct install --config ./default.ct.yaml

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Configure node IP in kind-config.yaml
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         docker network create kind
@@ -51,14 +51,14 @@ jobs:
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       with:
         config: test-suite.kind-config.yaml
 
     - name: Install kubectl
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
@@ -68,7 +68,7 @@ jobs:
 
     - name: Check node IP matches kind configuration
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         NODE_IP="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')"
@@ -77,7 +77,7 @@ jobs:
 
     - name: Install Helm
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
@@ -87,7 +87,7 @@ jobs:
 
     - name: Add dependency chart repos
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         helm repo add harbor https://helm.goharbor.io
@@ -98,7 +98,7 @@ jobs:
 
     - name: Install gojq
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
@@ -123,19 +123,19 @@ jobs:
 
     - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}]
 
     - name: Free up some disk space
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: docker system prune -f -a --volumes
 
     - name: Run chart-testing (install) on lagoon-test
       if: |
-        (steps.list-changed.outputs.changed == 'true') || 
+        (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: ct lint-and-install --config ./test-suite-run.ct.yaml
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -40,7 +40,9 @@ jobs:
         fi
 
     - name: Configure node IP in kind-config.yaml
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         docker network create kind
         export KIND_NODE_IP=$(docker run --network kind --rm alpine ip -o addr show eth0 | sed -nE 's/.* ([0-9.]{7,})\/.*/\1/p')
@@ -48,12 +50,16 @@ jobs:
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       with:
         config: test-suite.kind-config.yaml
 
     - name: Install kubectl
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
         curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
@@ -61,14 +67,18 @@ jobs:
         sudo cp ./kubectl /usr/local/bin/
 
     - name: Check node IP matches kind configuration
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         NODE_IP="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')"
         echo Checking for NODE_IP "$NODE_IP"
         grep $NODE_IP test-suite.kind-config.yaml
 
     - name: Install Helm
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
         curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
@@ -76,7 +86,9 @@ jobs:
         ./get_helm.sh
 
     - name: Add dependency chart repos
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         helm repo add harbor https://helm.goharbor.io
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -85,7 +97,9 @@ jobs:
         helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
 
     - name: Install gojq
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
         curl -sSLO https://github.com/itchyny/gojq/releases/download/v0.11.1/gojq_v0.11.1_linux_amd64.tar.gz
@@ -108,15 +122,21 @@ jobs:
     #   uses: mxschmitt/action-tmate@v3
 
     - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: make -j8 -O fill-test-ci-values TESTS=[${{ matrix.test }}]
 
     - name: Free up some disk space
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: docker system prune -f -a --volumes
 
     - name: Run chart-testing (install) on lagoon-test
-      if: steps.list-changed.outputs.changed == 'true'
+      if: |
+        (steps.list-changed.outputs.changed == 'true') || 
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: ct lint-and-install --config ./test-suite-run.ct.yaml
 
     # the following steps gather various debug information on test failure


### PR DESCRIPTION
This PR adds a logic step to the k8s cluster steps that will perform them even if there are no chart changes.

This may be needed to test logic in the makefiles etc.  To use it, allow the skipped run of the GitHub action to complete, then add the `needs-testing` label, and trigger a new run for the PR.