### PR TITLE
Bump lagoon-build-deploy to use latest version

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.3.1
+version: 0.3.2
 
-appVersion: v0.1.6
+appVersion: v0.1.7


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Lagoon Build Deploy released a new version [v0.1.7](https://github.com/amazeeio/lagoon-kbd/releases/tag/v0.1.7)
