### PR TITLE
Add experimental support for rootless build pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG =
 # Overrides the image repository for amazeeio/lagoon-builddeploy whose default
 # is the amazeeio/lagoon-builddeploy.
 OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY =
+# If set, sets the lagoon-build-deploy chart .Value.rootless=true.
+BUILD_DEPLOY_CONTROLLER_ROOTLESS_BUILD_PODS =
 TIMEOUT = 30m
 HELM = helm
 KUBECTL = kubectl
@@ -203,6 +205,7 @@ install-lagoon-remote: install-lagoon-core install-mariadb install-postgresql in
 		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set lagoon-build-deploy.overrideBuildDeployImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
 		$$([ $(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG) ] && echo '--set lagoon-build-deploy.image.tag=$(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG)') \
 		$$([ $(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY) ] && echo '--set lagoon-build-deploy.image.repository=$(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY)') \
+		$$([ $(BUILD_DEPLOY_CONTROLLER_ROOTLESS_BUILD_PODS) ] && echo '--set lagoon-build-deploy.rootlessBuildPods=true') \
 		lagoon-remote \
 		./charts/lagoon-remote
 

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.3.2
+version: 0.4.0
 
 appVersion: v0.1.7

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -45,9 +45,16 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /manager
-        {{- with .Values.extraArgs }}
+        {{- if (or .Values.rootlessBuildPods .Values.extraArgs) }}
         args:
+        {{- if .Values.rootlessBuildPods }}
+        - "--build-pod-run-as-user=10000"
+        - "--build-pod-run-as-group=0"
+        - "--build-pod-fs-group=10001"
+        {{- end }}
+        {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
         env:
         - name: LAGOON_TARGET_NAME

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -14,6 +14,11 @@ namespacePrefix: ""
 
 # the following values are defaults which may be overridden
 
+# rootlessBuildPods tells the build-deploy controller to create build pods
+# which do not run as root. See https://github.com/amazeeio/lagoon/pull/2481
+# for details.
+rootlessBuildPods: false
+
 # If the controller is running in an openshift,
 # then the argument `--is-openshift=true` should be added
 extraArgs:


### PR DESCRIPTION
This is required for testing https://github.com/amazeeio/lagoon/pull/2481 and is disabled by default.
