### PR TITLE
Revert back to default Lagoon images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ TESTS = [features-kubernetes]
 # IMAGE_TAG controls the tag used for container images in the lagoon-core,
 # lagoon-remote, and lagoon-test charts. If IMAGE_TAG is not set, it will fall
 # back to the version set in the CI values file, then to the chart default.
-IMAGE_TAG = pr-2534
+IMAGE_TAG =
 # IMAGE_REGISTRY controls the registry used for container images in the
 # lagoon-core, lagoon-remote, and lagoon-test charts. If IMAGE_REGISTRY is not
 # set, it will fall back to the version set in the chart values files. This
 # only affects lagoon-core, lagoon-remote, and the fill-test-ci-values target.
-IMAGE_REGISTRY = testlagoon
+IMAGE_REGISTRY = uselagoon
 # if OVERRIDE_BUILD_DEPLOY_DIND_IMAGE is not set, it will fall back to the
 # controller default (uselagoon/kubectl-build-deploy-dind:latest).
 OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =


### PR DESCRIPTION
This reverts commit ea216852f70cc2ceec65f0e5f3e2ff891b6fc4ab.

That commit temporarily overrode the Lagoon image repository and tag used for testing to work around https://github.com/amazeeio/lagoon/issues/2533. Now that issue is fixed in Lagoon `main`, we can revert back to the default image repository and tag.
