### PR TITLE
fix wrong s3FilesSecretAccessKey name

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.39.0
+version: 0.39.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/README.md
+++ b/charts/lagoon-core/README.md
@@ -155,3 +155,15 @@ ssh:
 
 * The `broker` has a serviceaccount bound to a role to allow service discovery for HA clustering.
 * The `ssh-portal` (disabled by default, eventually will be moved to `lagoon-remote`, see [amazeeio/lagoon#2179](https://github.com/amazeeio/lagoon/pull/2179)) has a serviceaccount bound to a clusterrole to allow exec into pods.
+
+
+## Lagoon Files
+
+Lagoon needs to upload files in some specific cases (like when a developer requests an dump of a database, the dump will be store in the Lagoon Files system).
+Lagoon uses S3 compatible storage for it, it can be configured via these helm values:
+
+
+- `s3FilesHost` - S3 Host name, like `https://s3.amazonaws.com` or `https://storage.googleapis.com`
+- `s3FilesBucket` - Name of the S3 Bucket
+- `s3FilesAccessKeyID` - AccessKey for the S3 Bucket
+- `s3FilesSecretAccessKey` - AccessKey Secret for the S3 Bucket

--- a/charts/lagoon-core/README.md
+++ b/charts/lagoon-core/README.md
@@ -79,8 +79,8 @@ lagoons:
 6. Check you can log in:
 ```
 $ lagoon whoami
-ID                                  	EMAIL	FIRSTNAME	LASTNAME	SSHKEYS 
-f57455c1-0d6b-491a-9117-89a9763dc940	-    	-        	-       	1	
+ID                                  	EMAIL	FIRSTNAME	LASTNAME	SSHKEYS
+f57455c1-0d6b-491a-9117-89a9763dc940	-    	-        	-       	1
 ```
 
 At this point `lagoon-core` is installed.

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -12,7 +12,7 @@
 # s3FilesAccessKeyID:
 # s3FilesBucket:
 # s3FilesHost:
-# s3SecretAccessKey:
+# s3FilesSecretAccessKey:
 
 # These values are optional.
 


### PR DESCRIPTION
was called `s3SecretAccessKey` in the values.yaml, but the template actually searches for `s3FilesSecretAccessKey`