### PR TITLE
Add feature flags to the lagoon-build-deploy chart

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.4.0
+version: 0.5.0
 
 appVersion: v0.1.7

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -52,6 +52,18 @@ spec:
         - "--build-pod-run-as-group=0"
         - "--build-pod-fs-group=10001"
         {{- end }}
+        {{- with .Values.lagoonFeatureFlagForceRootlessWorkload }}
+        - "--lagoon-feature-flag-force-rootless-workload={{ . }}"
+        {{- end }}
+        {{- with .Values.lagoonFeatureFlagDefaultRootlessWorkload }}
+        - "--lagoon-feature-flag-default-rootless-workload={{ . }}"
+        {{- end }}
+        {{- with .Values.lagoonFeatureFlagForceIsolationNetworkPolicy }}
+        - "--lagoon-feature-flag-force-isolation-network-policy={{ . }}"
+        {{- end }}
+        {{- with .Values.lagoonFeatureFlagDefaultIsolationNetworkPolicy }}
+        - "--lagoon-feature-flag-default-isolation-network-policy={{ . }}"
+        {{- end }}
         {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -12,6 +12,15 @@ taskAPIHost: ""
 # limited to 8 characters (will be truncated by controller if it exceeds this)
 namespacePrefix: ""
 
+# The following values are optional. They tell the build-deploy controller to
+# set an environment variable on the build pods which enforces the state of the
+# feature flag. Valid values are `enabled` or `disabled`.
+
+# lagoonFeatureFlagForceRootlessWorkload: enabled
+# lagoonFeatureFlagDefaultRootlessWorkload: enabled
+# lagoonFeatureFlagForceIsolationNetworkPolicy: disabled
+# lagoonFeatureFlagDefaultIsolationNetworkPolicy: disabled
+
 # the following values are defaults which may be overridden
 
 # rootlessBuildPods tells the build-deploy controller to create build pods


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?
Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
This PR adds experimental support for feature flags to the lagoon-build-deploy chart.
This uses the flags from https://github.com/amazeeio/lagoon-kbd/pull/40