### PR TITLE
Create external ingress for webhook and configure URL for Harbor scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ install-lagoon-core: install-calico
 		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set overwriteKubectlBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
 		--set "harborAdminPassword=Harbor12345" \
 		--set "harborURL=http://registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
+		--set "lagoonWebhookURL=http://webhook.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
 		--set "keycloakAPIURL=http://localhost:8080/auth" \
 		--set "lagoonAPIURL=http://localhost:7070/graphql" \
 		--set "registry=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32443" \
@@ -171,6 +172,9 @@ install-lagoon-core: install-calico
 		--set storageCalculator.enabled=false \
 		--set ui.enabled=false \
 		--set webhookHandler.image.repository=$(IMAGE_REGISTRY)/webhook-handler \
+		--set webhookHandler.ingress.enabled=true \
+		--set "webhookHandler.ingress.hosts[0].host=webhook.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
+		--set "webhookHandler.ingress.hosts[0].paths[0]=/" \
 		--set webhooks2tasks.image.repository=$(IMAGE_REGISTRY)/webhooks2tasks \
 		lagoon-core \
 		./charts/lagoon-core
@@ -245,6 +249,7 @@ install-tests:
 		&& export $$([ $(IMAGE_TAG) ] && echo imageTag='$(IMAGE_TAG)' || echo imageTag='latest') \
 		&& export tests='$(TESTS)' imageRegistry='$(IMAGE_REGISTRY)' \
 		&& export webhookHandler="lagoon-core-webhook-handler" \
+		&& export lagoonWebhookURL="http://webhook.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
 		&& export webhookRepoPrefix="ssh://git@lagoon-test-local-git.lagoon.svc.cluster.local:22/git/" \
 		&& valueTemplate=charts/lagoon-test/ci/linter-values.yaml \
 		&& envsubst < $$valueTemplate.tpl > $$valueTemplate \

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install-registry: install-ingress install-calico
 	$(HELM) upgrade \
 		--install \
 		--create-namespace \
-		--namespace registry \
+		--namespace harbor \
 		--wait \
 		--timeout $(TIMEOUT) \
 		--set expose.tls.enabled=false \
@@ -74,9 +74,9 @@ install-registry: install-ingress install-calico
 		--set chartmuseum.enabled=false \
 		--set clair.enabled=false \
 		--set notary.enabled=false \
-		--set trivy.enabled=false \
+		--set trivy.enabled=true \
 		--version=1.5.2 \
-		registry \
+		harbor \
 		harbor/harbor
 
 .PHONY: install-nfs-server-provisioner

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ fill-test-ci-values: install-ingress install-registry install-lagoon-core instal
 		&& export token="$$($(KUBECTL) -n lagoon get secret -o json | $(JQ) -r '.items[] | select(.metadata.name | match("lagoon-build-deploy-token")) | .data.token | @base64d')" \
 		&& export $$([ $(IMAGE_TAG) ] && echo imageTag='$(IMAGE_TAG)' || echo imageTag='latest') \
 		&& export webhookHandler="lagoon-core-webhook-handler" \
+		&& export lagoonWebhookURL="http://webhook.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
+		&& export webhookRepoPrefix="ssh://git@lagoon-test-local-git.lagoon.svc.cluster.local:22/git/" \
 		&& export tests='$(TESTS)' imageRegistry='$(IMAGE_REGISTRY)' \
 		&& valueTemplate=charts/lagoon-test/ci/linter-values.yaml \
 		&& envsubst < $$valueTemplate.tpl > $$valueTemplate
@@ -247,10 +249,10 @@ install-tests:
 		&& export routeSuffixHTTPS="$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io" \
 		&& export token="$$($(KUBECTL) -n lagoon get secret -o json | $(JQ) -r '.items[] | select(.metadata.name | match("lagoon-build-deploy-token")) | .data.token | @base64d')" \
 		&& export $$([ $(IMAGE_TAG) ] && echo imageTag='$(IMAGE_TAG)' || echo imageTag='latest') \
-		&& export tests='$(TESTS)' imageRegistry='$(IMAGE_REGISTRY)' \
 		&& export webhookHandler="lagoon-core-webhook-handler" \
 		&& export lagoonWebhookURL="http://webhook.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
 		&& export webhookRepoPrefix="ssh://git@lagoon-test-local-git.lagoon.svc.cluster.local:22/git/" \
+		&& export tests='$(TESTS)' imageRegistry='$(IMAGE_REGISTRY)' \
 		&& valueTemplate=charts/lagoon-test/ci/linter-values.yaml \
 		&& envsubst < $$valueTemplate.tpl > $$valueTemplate \
 		&& $(HELM) upgrade \

--- a/charts/lagoon-test/ci/linter-values.yaml.tpl
+++ b/charts/lagoon-test/ci/linter-values.yaml.tpl
@@ -5,6 +5,7 @@ routeSuffixHTTP: "${routeSuffixHTTP}"
 routeSuffixHTTPS: "${routeSuffixHTTPS}"
 token: "${token}"
 webhookHost: "${webhookHandler}"
+lagoonWebhookURL: "${lagoonWebhookURL}"
 webhookRepoPrefix: "${webhookRepoPrefix}"
 
 localGit:

--- a/charts/lagoon-test/templates/secret.yaml
+++ b/charts/lagoon-test/templates/secret.yaml
@@ -27,6 +27,7 @@ stringData:
   SSH_PORT: {{ .Values.sshPort | quote }}
   SSH_PRIVATE_KEY: |
     {{- .Values.sshPrivateKey | nindent 4 }}
+  WEBHOOK_URL: {{ .Values.lagoonWebhookURL | quote }}
   WEBHOOK_HOST: {{ .Values.webhookHost | quote }}
   WEBHOOK_PORT: {{ .Values.webhookPort | quote }}
   WEBHOOK_PROTOCOL: {{ .Values.webhookProtocol | quote }}

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -64,6 +64,7 @@ sshPrivateKey: |-
   L6J5iAoqoDKICzjcgF5x3mj9YFWZrC3aRxRrN5RoEgeVdcXeK56UJqXHjmKN++m3
   c8OPEIBZiD8UJuhSNSOLiBFrGz6toy6rpHavqqknGhVWotXsAs1h8LNkBe8=
   -----END RSA PRIVATE KEY-----
+lagoonWebhookURL: http://lagoon-core-webhook-handler.lagoon.svc.cluster.local:3000
 webhookHost: webhook-handler
 webhookPort: 3000
 webhookProtocol: http


### PR DESCRIPTION
This PR (alongside https://github.com/amazeeio/lagoon/pull/2580) re-enables the sending of webhooks from Harbor to Lagoon.

It does this by creating an ingress for the webhook service (along the lines of the registry one) and then setting the webhookURL in the relevant services.

This PR also renames the kubernetes namespace for harbor (back to harbor), as there are Lagoon internals that are set to it as a default.  It doesn't change the external registry.* endpoint.

This PR can be merged irregardless of the Lagoon one - it's backwards compatible too.