### PR TITLE
Move default args to template for builddeploy controller

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.5.0
+version: 0.5.1
 
 appVersion: v0.1.7

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - /manager
         {{- if (or .Values.rootlessBuildPods .Values.extraArgs) }}
         args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election=true"
         {{- if .Values.rootlessBuildPods }}
         - "--build-pod-run-as-user=10000"
         - "--build-pod-run-as-group=0"

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /manager
-        {{- if (or .Values.rootlessBuildPods .Values.extraArgs) }}
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election=true"
@@ -68,7 +67,6 @@ spec:
         {{- end }}
         {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- end }}
         env:
         {{- range $name, $value := .Values.extraEnvs }}

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
         {{- end }}
         {{- end }}
         env:
+        {{- range $name, $value := .Values.extraEnvs }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end }}
         - name: LAGOON_TARGET_NAME
           value: {{ required "A valid .Values.lagoonTargetName required!" .Values.lagoonTargetName | quote }}
         {{- with .Values.overrideBuildDeployImage }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -31,8 +31,6 @@ rootlessBuildPods: false
 # If the controller is running in an openshift,
 # then the argument `--is-openshift=true` should be added
 extraArgs:
-- "--metrics-addr=127.0.0.1:8080"
-- "--enable-leader-election=true"
 
 pendingMessageCron: "*/5 * * * *"
 

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -32,6 +32,9 @@ rootlessBuildPods: false
 # then the argument `--is-openshift=true` should be added
 extraArgs:
 
+# add extra environment variables if required
+extraEnvs:
+
 pendingMessageCron: "*/5 * * * *"
 
 # The controller will use `uselagoon/kubectl-build-deploy-dind:latest` by


### PR DESCRIPTION
When needing to add `extraArgs` to the builddeploy controller, defining new values in an external template would override the defaults provided in the template, so they need to be defined again wherever the `extraArgs` are defined.

This moves them into the template and frees up `extraArgs` for actual extra arguments.