### PR TITLE
Make the logs-dispatcher probes more forgiving

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.0
+version: 0.25.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
@@ -65,10 +65,14 @@ spec:
           tcpSocket:
             port: 24224
           initialDelaySeconds: 20
+          periodSeconds: 20
+          timeoutSeconds: 2
         livenessProbe:
           tcpSocket:
             port: 24224
           initialDelaySeconds: 120
+          periodSeconds: 60
+          timeoutSeconds: 2
         volumeMounts:
         - mountPath: /fluentd/etc/fluent.conf
           name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-fluent-conf


### PR DESCRIPTION
Third-party exporters can be slow or otherwise cause TCP probes to take a while. We don't need to kill pods for slow connections.

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
