### PR TITLE
Allow hostname to be ignored in lagoon-logging TLS verification

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.1
+version: 0.25.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -342,9 +342,7 @@ data:
         tls_cert_path /fluentd/tls/ca.crt
         tls_client_cert_path /fluentd/tls/client.crt
         tls_client_private_key_path /fluentd/tls/client.key
-        {{- with .Values.forward.tlsVerifyHostname }}
-        tls_verify_hostname {{ . }}
-        {{- end }}
+        tls_verify_hostname {{ .Values.forward.tlsVerifyHostname }}
         # endpoint
         keepalive true # makes sure the connection is not recreated every second
         keepalive_timeout 10m # reconnect after 10mins in order to handle DNS changes, etc.

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -309,6 +309,7 @@ lagoonLogs:
 
 forward:
   verifyConnectionAtStartup: true
+  tlsVerifyHostname: true
 
 # Some cluster services use ephemeral namespaces that cause many indices to be
 # created in elasticsearch. Setting this to true will cause these service logs


### PR DESCRIPTION
The old logic was plain broken if tlsVerifyHostname was set to `false`.