### PR TITLE
Rely on built-in operator service monitors

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.2
+version: 0.26.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -47,8 +47,9 @@ tls:
 consolidateServiceIndices: true
 
 logging-operator:
-  serviceMonitor: false
-  serviceMonitorConfig: {}
+  monitoring:
+    serviceMonitor:
+      enabled: false
 
 logsDispatcher:
   serviceMonitor:

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -12,16 +12,12 @@ spec:
         fsGroup: 0
     scaling:
       replicas: 3
-    metrics:
-      serviceMonitor: {{ index .Values "logging-operator" "serviceMonitor" }}
-      serviceMonitorConfig: {{- index .Values "logging-operator" "serviceMonitorConfig" | toYaml  | nindent 8 }}
+  {{- if .Values.fluentbitPrivileged }}
   fluentbit:
-    metrics:
-      serviceMonitor: {{ index .Values "logging-operator" "serviceMonitor" }}
-      serviceMonitorConfig: {{- index .Values "logging-operator" "serviceMonitorConfig" | toYaml  | nindent 8 }}
-  {{- with .Values.fluentbitPrivileged }}
     security:
       securityContext:
-        privileged: {{ . }}
+        privileged: true
+  {{- else }}
+  fluentbit: {}
   {{- end }}
   controlNamespace: {{ .Release.Namespace | quote }}

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -296,11 +296,11 @@ clusterOutputBuffer:
 # chart dependency on logging-operator
 logging-operator:
   enabled: true
-  createCustomResource: false
-  serviceMonitor: true
-  serviceMonitorConfig:
-    additionalLabels:
-      monitoring.lagoon.sh/monitorMe: 'true'
+  monitoring:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        monitoring.lagoon.sh/monitorMe: 'true'
 
 # lagoon logs collection disabled by default. see below for instructions on
 # enabling this.


### PR DESCRIPTION
We don't have to manually configure service monitors any more because they are supported by the operator chart.
