### PR TITLE
Add option to disable Elasticsearch certificate verification

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
@@ -94,6 +94,9 @@ data:
       type_name _doc
       suppress_type_name true
       ssl_version TLSv1_2
+{{- if not .Values.elasticsearchTLSVerify }}
+      ssl_verify false
+{{- end }}
 {{- if not .Values.verifyESVersionAtStartup }}
       verify_es_version_at_startup false
 {{- end }}

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -82,6 +82,10 @@ affinity: {}
 # this is set to false in CI so that the concentrator will start without ES
 # being installed
 verifyESVersionAtStartup: true
+# Verification of the certificate presented by the elasticsearch endpoint can
+# be disabled by setting this option to false, which can be useful for CI and
+# manual testing. Do not disable this in production.
+elasticsearchTLSVerify: true
 
 # The values below must be supplied during installation.
 # Certificates should be provided in PEM format, and are generated as described


### PR DESCRIPTION
It can be useful to disable Elasticsearch certificate verification for local testing.