### PR TITLE
allow to control fluentd replicas from values.yaml

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.0
+version: 0.26.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -44,6 +44,7 @@ tls:
     FejDrD4asORcLF9xN2tsM5fGoBuHy9KpUw==
     -----END EC PRIVATE KEY-----
 
+fluentdreplicaCount: 1
 consolidateServiceIndices: true
 
 logging-operator:
@@ -54,3 +55,4 @@ logging-operator:
 logsDispatcher:
   serviceMonitor:
     enabled: false
+  replicaCount: 1

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -44,7 +44,7 @@ tls:
     FejDrD4asORcLF9xN2tsM5fGoBuHy9KpUw==
     -----END EC PRIVATE KEY-----
 
-fluentdreplicaCount: 1
+fluentdReplicaCount: 1
 consolidateServiceIndices: true
 
 logging-operator:

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -11,7 +11,7 @@ spec:
         runAsUser: 100
         fsGroup: 0
     scaling:
-      replicas: 3
+      replicas: {{ .Values.fluentdReplicaCount }}
   {{- if .Values.fluentbitPrivileged }}
   fluentbit:
     security:

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -320,6 +320,9 @@ consolidateServiceIndices: false
 # sent to a third-party service and not to a central elasticsearch.
 enableDefaultForwarding: true
 
+# Set how many fluentd pods should be running
+fluentdReplicaCount: 3
+
 # The values below must be supplied during installation.
 # Certificates should be provided in PEM format, and are generated as described
 # in the README for the lagoon-logs-concentrator chart.


### PR DESCRIPTION
This PR allows helm templates to control the replicas for the fluentd pods inside the logging operator.  It keeps the default at 3, but uses 1 for CI (and we would also use 1 for local development)