### PR TITLE
Update builddeploy chart to use latest image

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.5.0
+version: 0.6.0
 
-appVersion: v0.1.7
+appVersion: v0.1.8

--- a/charts/lagoon-build-deploy/crds/lagoonBuild.yaml
+++ b/charts/lagoon-build-deploy/crds/lagoonBuild.yaml
@@ -59,10 +59,14 @@ spec:
                   type: string
                 environment:
                   type: string
+                environmentId:
+                  type: integer
                 environmentType:
                   type: string
                 gitUrl:
                   type: string
+                id:
+                  type: integer
                 key:
                   format: byte
                   type: string
@@ -203,6 +207,8 @@ spec:
                       type: string
                     environment:
                       type: string
+                    environmentId:
+                      type: integer
                     jobName:
                       type: string
                     jobStatus:
@@ -217,6 +223,8 @@ spec:
                       type: array
                     project:
                       type: string
+                    projectId:
+                      type: integer
                     projectName:
                       type: string
                     remoteId:
@@ -282,6 +290,8 @@ spec:
                       type: string
                     environment:
                       type: string
+                    environmentId:
+                      type: integer
                     jobName:
                       type: string
                     jobStatus:
@@ -296,6 +306,8 @@ spec:
                       type: array
                     project:
                       type: string
+                    projectId:
+                      type: integer
                     projectName:
                       type: string
                     remoteId:
@@ -363,6 +375,8 @@ spec:
                       type: string
                     environment:
                       type: string
+                    environmentId:
+                      type: integer
                     jobName:
                       type: string
                     jobStatus:
@@ -377,6 +391,8 @@ spec:
                       type: array
                     project:
                       type: string
+                    projectId:
+                      type: integer
                     projectName:
                       type: string
                     remoteId:
@@ -614,6 +630,8 @@ spec:
                       type: string
                     environment:
                       type: string
+                    environmentId:
+                      type: integer
                     jobName:
                       type: string
                     jobStatus:
@@ -628,6 +646,8 @@ spec:
                       type: array
                     project:
                       type: string
+                    projectId:
+                      type: integer
                     projectName:
                       type: string
                     remoteId:
@@ -693,6 +713,8 @@ spec:
                       type: string
                     environment:
                       type: string
+                    environmentId:
+                      type: integer
                     jobName:
                       type: string
                     jobStatus:
@@ -707,6 +729,8 @@ spec:
                       type: array
                     project:
                       type: string
+                    projectId:
+                      type: integer
                     projectName:
                       type: string
                     remoteId:
@@ -774,6 +798,8 @@ spec:
                       type: string
                     environment:
                       type: string
+                    environmentId:
+                      type: integer
                     jobName:
                       type: string
                     jobStatus:
@@ -788,6 +814,8 @@ spec:
                       type: array
                     project:
                       type: string
+                    projectId:
+                      type: integer
                     projectName:
                       type: string
                     remoteId:


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Update the builddeploy chart to use the latest image of [v0.1.8 (changes)](https://github.com/amazeeio/lagoon-kbd/releases/tag/v0.1.8)

Also updated the CRD to support https://github.com/amazeeio/lagoon-kbd/pull/41 as the second part of the fix for https://github.com/amazeeio/lagoon/issues/2568