### PR TITLE
bump lagoon-build-deploy and disocuri to latest chart versions

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.3.2
+  version: 0.6.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
-  version: 0.3.1
+  version: 0.3.2
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
   version: 0.2.1
 - name: lagoon-gatekeeper
   repository: https://uselagoon.github.io/lagoon-charts/
   version: 0.3.1
-digest: sha256:0546c32b3aa6f486fe37a9d9c8df02a8f8bcc2de4a1ed090f6c0035e2c074eaf
-generated: "2021-03-16T10:24:51.582852669+08:00"
+digest: sha256:b9d57cc56c9f972a08db00e0d5a72ebc37bc79c630a43402a246bdcc35b39950
+generated: "2021-04-13T14:43:08.370675+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -26,7 +26,7 @@ appVersion: v2.0.0-alpha.7
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.3.1
+  version: ~0.6.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.21.0
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
