### PR TITLE
Docker host storageclass

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.23.0
+version: 0.24.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/templates/docker-host.pvc.yaml
+++ b/charts/lagoon-remote/templates/docker-host.pvc.yaml
@@ -11,4 +11,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.dockerHost.storage.size | quote }}
-{{- end -}}
+  {{- with .Values.dockerHost.storage.className }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -31,6 +31,20 @@ dockerHost:
   storage:
     create: true
     size: 750Gi
+    # className sets the storageClassName for the docker-host PVC. This is
+    # useful if the docker-host requires a specific storage class for features
+    # such as increased IOPS.
+    #
+    # WARNING: On platforms such as AKS not all storage volume classes can be
+    # bound to all node types. So if you configure a storage class that can't
+    # be bound to any nodes in the cluster it will cause the docker-host pod to
+    # fail to schedule. For example AKS requires Premium Storage suport on the
+    # node for the managed-premium storage class.
+    #
+    # If className is not defined the chart will not set any specify storage
+    # class on the PVC, effectively falling back to the cluster default.
+    #
+    # className: managed-premium
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
This PR makes the docker-host PVC storage class configurable through the helm chart values. By default we keep the current behaviour of not defining a storage class so as to fall back to cluster default.

Closes #251 
