### PR TITLE
add JWTSECRET to test-suite

### DIFF
--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.14.0
+version: 0.14.1
 
 appVersion: v2.0.0-alpha.9

--- a/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml
+++ b/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml
@@ -57,7 +57,7 @@ spec:
             # this container uses wget to inject test fixtures into the lagoon api.
             # once wget stops running, it's good to go.
             - "for i in $(seq 4); do pgrep wget && exit 1 || sleep 1; done"
-          initialDelaySeconds: 128
+          initialDelaySeconds: 32
           timeoutSeconds: 8
         resources:
           {{- toYaml .Values.localAPIDataWatcherPusher.resources | nindent 10 }}

--- a/charts/lagoon-test/templates/tests/test-suite.yaml
+++ b/charts/lagoon-test/templates/tests/test-suite.yaml
@@ -14,6 +14,12 @@ spec:
   - name: {{ . | quote }}
     image: "{{ $.Values.tests.image.repository }}:{{ coalesce $.Values.tests.image.tag $.Values.imageTag $.Chart.AppVersion }}"
     imagePullPolicy: {{ $.Values.tests.image.pullPolicy }}
+    env:
+    - name: JWTSECRET
+      valueFrom:
+        secretKeyRef:
+          name: {{ $.Values.jwtSecretSecret | quote }}
+          key: JWTSECRET
     envFrom:
     - secretRef:
         name: {{ include "lagoon-test.fullname" $ }}


### PR DESCRIPTION
This PR adds the JWTSECRET to the lagoon-test-test-suite.

This will enable ansible playbooks etc to perform GraphQL mutations in tests to add and delete projects, groups, notifications, and other permissions not available to normal users.