### PR TITLE
Run tests for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
   directory: /
   schedule:
     interval: daily
+  labels:
+  - dependencies
+  - needs-testing


### PR DESCRIPTION
Tell dependabot to tag any PRs with `needs-testing` so the test suite runs.
