### PR TITLE
Gitlab API token fix

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -5,9 +5,9 @@ description: >
 home: https://github.com/uselagoon/lagoon-charts
 icon: https://raw.githubusercontent.com/uselagoon/lagoon-charts/main/icon.png
 maintainers:
-- name: smlx
-  email: scott.leggett@amazee.io
-  url: https://amazee.io
+  - name: smlx
+    email: scott.leggett@amazee.io
+    url: https://amazee.io
 
 # Application charts are a collection of templates that can be packaged into
 # versioned archives to be deployed.
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.41.0
+version: 0.41.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.46.0
+version: 0.46.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -5,9 +5,9 @@ description: >
 home: https://github.com/uselagoon/lagoon-charts
 icon: https://raw.githubusercontent.com/uselagoon/lagoon-charts/main/icon.png
 maintainers:
-  - name: smlx
-    email: scott.leggett@amazee.io
-    url: https://amazee.io
+- name: smlx
+  email: scott.leggett@amazee.io
+  url: https://amazee.io
 
 # Application charts are a collection of templates that can be packaged into
 # versioned archives to be deployed.

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: GITLAB_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "lagoon-core.api.fullname" . }}
+              name: {{ include "lagoon-core.api.fullname" $ }}
               key: GITLAB_API_TOKEN
         {{- end }}
         - name: JWTSECRET


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
This pull request fixes an issue where settings the gitlabAPIToken helm value causes an error rendering the chart yaml.  The {{ include }} for the secret name fails due to it being in a 'with' block.

Closes: #262
