### PR TITLE
update lagoon to v2.0.0-rc.1

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         test:
-        - features-kubernetes
-        - nginx
-        # - active-standby-kubernetes
-        # - drupal-php73 -- disable to make tests smaller
-        - drupal-php74
         - api
+        - features-kubernetes
+        - features-kubernetes-2
+        - nginx
+        - active-standby-kubernetes
+        - drupal-php74
         - github
         - gitlab
         - bitbucket

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -12,12 +12,19 @@ jobs:
         - api
         - features-kubernetes
         - features-kubernetes-2
-        - nginx
         - active-standby-kubernetes
-        - drupal-php74
-        - github
-        - gitlab
-        - bitbucket
+        ## Re-enable any of these below tests in your branch for specific testing
+        ## - drupal-php74
+        ## - drupal-postgres
+        ## - node-mongodb
+        ## - nginx
+        ## - node
+        ## - python
+        ## - elasticsearch
+        ## - github
+        ## - gitlab
+        ## - bitbucket
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2.3.4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = [features-kubernetes]
+TESTS = [features-api]
 # IMAGE_TAG controls the tag used for container images in the lagoon-core,
 # lagoon-remote, and lagoon-test charts. If IMAGE_TAG is not set, it will fall
 # back to the version set in the CI values file, then to the chart default.

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ install-mongodb: install-calico
 install-lagoon-core: install-calico
 	$(HELM) upgrade \
 		--install \
+		--debug \
 		--create-namespace \
 		--namespace lagoon \
 		--wait \
@@ -169,6 +170,7 @@ install-lagoon-core: install-calico
 		--set logs2microsoftteams.enabled=false \
 		--set logs2rocketchat.enabled=false \
 		--set logs2slack.enabled=false \
+		--set logs2webhook.enabled=false \
 		--set logsDBCurator.enabled=false \
 		--set ssh.image.repository=$(IMAGE_REGISTRY)/ssh \
 		--set sshPortal.enabled=false \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,6 @@ install-mongodb: install-calico
 install-lagoon-core: install-calico
 	$(HELM) upgrade \
 		--install \
-		--debug \
 		--create-namespace \
 		--namespace lagoon \
 		--wait \

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.41.0
+version: 0.42.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.9
+appVersion: v2.0.0-rc.1

--- a/charts/lagoon-core/README.md
+++ b/charts/lagoon-core/README.md
@@ -21,6 +21,8 @@ logs2rocketchat:
   enabled: false
 logs2slack:
   enabled: false
+logs2webhook:
+  enabled: false
 logsDBCurator:
   enabled: false
 storageCalculator:

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -139,6 +139,8 @@ logs2slack:
 
 logs2webhook:
   replicaCount: 1
+  image:
+    repository: uselagoon/logs2webhook
 
 logs2microsoftteams:
   replicaCount: 1

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -137,6 +137,9 @@ logs2slack:
   image:
     repository: uselagoon/logs2slack
 
+logs2webhook:
+  replicaCount: 1
+
 logs2microsoftteams:
   replicaCount: 1
   image:

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -476,6 +476,36 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 
 {{/*
+Create a default fully qualified app name for logs2webhook.
+*/}}
+{{- define "lagoon-core.logs2webhook.fullname" -}}
+{{- include "lagoon-core.fullname" . }}-logs2webhook
+{{- end }}
+
+{{/*
+Common labels logs2webhook.
+*/}}
+{{- define "lagoon-core.logs2webhook.labels" -}}
+helm.sh/chart: {{ include "lagoon-core.chart" . }}
+{{ include "lagoon-core.logs2webhook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels logs2webhook.
+*/}}
+{{- define "lagoon-core.logs2webhook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-core.logs2webhook.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+{{/*
 Create a default fully qualified app name for logs2microsoftteams.
 */}}
 {{- define "lagoon-core.logs2microsoftteams.fullname" -}}

--- a/charts/lagoon-core/templates/logs2webhook.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2webhook.deployment.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.logs2webhook.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-core.logs2webhook.fullname" . }}
+  labels:
+    {{- include "lagoon-core.logs2webhook.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.logs2webhook.autoscaling.enabled }}
+  replicas: {{ .Values.logs2webhook.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.logs2webhook.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/broker.secret: {{ include (print $.Template.BasePath "/broker.secret.yaml") . | sha256sum }}
+    {{- with .Values.logs2webhook.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "lagoon-core.logs2webhook.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml (coalesce .Values.logs2webhook.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
+      containers:
+      - name: logs2webhook
+        securityContext:
+          {{- toYaml .Values.logs2webhook.securityContext | nindent 10 }}
+        image: "{{ .Values.logs2webhook.image.repository }}:{{ coalesce .Values.logs2webhook.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.logs2webhook.image.pullPolicy }}
+        env:
+        - name: API_HOST
+          value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}
+        - name: JWTSECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.fullname" . }}-jwtsecret
+              key: JWTSECRET
+        - name: RABBITMQ_HOST
+          value: {{ include "lagoon-core.broker.fullname" . }}
+        - name: RABBITMQ_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.broker.fullname" . }}
+              key: RABBITMQ_USERNAME
+        - name: RABBITMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.broker.fullname" . }}
+              key: RABBITMQ_PASSWORD
+        resources:
+          {{- toYaml .Values.logs2webhook.resources | nindent 10 }}
+      {{- with .Values.logs2webhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.logs2webhook.fullname" . }}
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.logs2webhook.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.logs2webhook.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/logs2webhook.hpa.yaml
+++ b/charts/lagoon-core/templates/logs2webhook.hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.logs2webhook.autoscaling.enabled -}}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lagoon-core.logs2webhook.fullname" . }}
+  labels:
+    {{- include "lagoon-core.logs2webhook.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lagoon-core.logs2webhook.fullname" . }}
+  minReplicas: {{ .Values.logs2webhook.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.logs2webhook.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.logs2webhook.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.logs2webhook.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.logs2webhook.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.logs2webhook.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -482,6 +482,29 @@ logs2slack:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+
+logs2webhook:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: testlagoon/logs2webhook
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: pr-2593
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
 logs2microsoftteams:
   enabled: true
   replicaCount: 2

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -487,10 +487,10 @@ logs2webhook:
   enabled: true
   replicaCount: 2
   image:
-    repository: testlagoon/logs2webhook
+    repository: uselagoon/logs2webhook
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: pr-2593
+    tag: ""
 
   podAnnotations: {}
 

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.28.0
+version: 0.29.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.9
+appVersion: v2.0.0-rc.1
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.1
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-alpha.9
+appVersion: v2.0.0-rc.1

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,11 +18,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.25.2
+version: 0.26.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.0.0-alpha.9
+appVersion: v2.0.0-rc.1
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.14.1
+version: 0.15.0
 
-appVersion: v2.0.0-alpha.9
+appVersion: v2.0.0-rc.1


### PR DESCRIPTION
* It updates the version of Lagoon to https://github.com/uselagoon/lagoon/releases/tag/v2.0.0-rc.1 
* This PR also includes #269 to add the new logs2webhook service in
* It reduces the number of tests performed to those related to Lagoon only (API, Features 1&2, Active/Standby)
* Any other tests can be enabled on a per PR/Branch basis