### PR TITLE
Make Calico CNI plugin optional

### DIFF
--- a/test-suite.kind-config.calico.yaml.tpl
+++ b/test-suite.kind-config.calico.yaml.tpl
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: 192.168.0.0/16
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.${KIND_NODE_IP}.nip.io:32443".tls]


### PR DESCRIPTION
Make Calico opt-in and rely on the default kindnet otherwise.

This should improve the local testing experience, particularly on Mac.

Closes: #271 
