### PR TITLE
Give the test serviceaccount admin clusterrole

### DIFF
--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.15.0
+version: 0.15.1
 
 appVersion: v2.0.0-rc.1

--- a/charts/lagoon-test/templates/test.clusterrolebinding.yaml
+++ b/charts/lagoon-test/templates/test.clusterrolebinding.yaml
@@ -10,5 +10,5 @@ subjects:
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: ClusterRole
-  name: view
+  name: admin
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This allows the test serviceaccount to list secrets, which is required for some of the CI tests.
