### PR TITLE
chore: disable gatekeeper chart in CI

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.26.0
+version: 0.26.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -17,4 +17,4 @@ dbaas-operator:
   enabled: true
 
 lagoon-gatekeeper:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
This chart is currently not very maintained and not used in production.
So lets not run it in CI yet.
