### PR TITLE
enable the UI by default for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ install-lagoon-core:
 		--set ssh.image.repository=$(IMAGE_REGISTRY)/ssh \
 		--set sshPortal.enabled=false \
 		--set storageCalculator.enabled=false \
-		--set ui.enabled=false \
+		--set ui.image.repository=$(IMAGE_REGISTRY)/ui \
 		--set webhookHandler.image.repository=$(IMAGE_REGISTRY)/webhook-handler \
 		--set webhooks2tasks.image.repository=$(IMAGE_REGISTRY)/webhooks2tasks \
 		lagoon-core \


### PR DESCRIPTION
In order to avoid messy re-helming once running in lagoon-charts or lagoon-main, lets just enable the UI now.  If it's not used in CI, the overhead shouldn't make an impact.