### PR TITLE
Add cred & port-forward helper scripts to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = [features-api]
+TESTS = [api]
 # IMAGE_TAG controls the tag used for container images in the lagoon-core,
 # lagoon-remote, and lagoon-test charts. If IMAGE_TAG is not set, it will fall
 # back to the version set in the CI values file, then to the chart default.

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ pf-ui:
 
 .PHONY: port-forwards
 port-forwards: pf-keycloak pf-api pf-ssh pf-ui
+
 .PHONY: run-tests
 run-tests:
 	$(HELM) test --namespace lagoon --timeout 30m lagoon-test


### PR DESCRIPTION
This PR adds a pair of scripts to help with local development.

`make get-admin-creds` will return the GraphQL token (admin-scoped) and the necessary Keycloak and Lagoon passwords.
`make port-forwards` will automatically create the necessary port forwards for the UI, API and Keycloak to function.