### PR TITLE
v2.0.0-rc.4 AppImage updates for release

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.43.0
+version: 0.44.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-rc.2
+appVersion: v2.0.0-rc.4

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -119,13 +119,13 @@ spec:
           {{- if .Values.lagoonUIURL }}
           value: {{ .Values.lagoonUIURL | quote }}
           {{- else }}
-          value: https://{{ index .Values.ui.ingress.hosts 0 "host" }}/
+          value: https://{{ index .Values.ui.ingress.hosts 0 "host" }}
           {{- end }}
         - name: WEBHOOK_URL
           {{- if .Values.lagoonWebhookURL }}
           value: {{ .Values.lagoonWebhookURL | quote }}
           {{- else }}
-          value: https://{{ index .Values.webhookHandler.ingress.hosts 0 "host" }}/
+          value: https://{{ index .Values.webhookHandler.ingress.hosts 0 "host" }}
           {{- end }}
         envFrom:
         - secretRef:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -32,8 +32,8 @@
 
 # keycloakAPIURL: https://keycloak.example.com/auth
 # lagoonAPIURL: https://api.example.com/graphql
-# lagoonUIURL: https://ui.example.com/
-# lagoonWebhookURL: https://webhook-handler.example.com/
+# lagoonUIURL: https://ui.example.com
+# lagoonWebhookURL: https://webhook-handler.example.com
 
 # These values are randomly generated on install if not otherwise defined.
 

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.0
+version: 0.31.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-rc.2
+appVersion: v2.0.0-rc.4
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.0.0-rc.2
+appVersion: v2.0.0-rc.4

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,11 +18,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.28.0
+version: 0.29.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.0.0-rc.2
+appVersion: v2.0.0-rc.4
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.16.0
+version: 0.17.0
 
-appVersion: v2.0.0-rc.2
+appVersion: v2.0.0-rc.4


### PR DESCRIPTION
Updates lagoon-charts for the https://github.com/uselagoon/lagoon/releases/tag/v2.0.0-rc.4 release

Note there was no v2.0.0-rc.3 release, changes are incorporated into v2.0.0-rc.4.

Also resolves an issue with trailing slashes in the UI and Webhook URLs

Closes #283 