### PR TITLE
allow to inject additional env variables into services

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.44.0
+version: 0.45.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -127,6 +127,10 @@ spec:
           {{- else }}
           value: https://{{ index .Values.webhookHandler.ingress.hosts 0 "host" }}
           {{- end }}
+      {{- range $key, $val := .Values.api.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "lagoon-core.api.fullname" . }}

--- a/charts/lagoon-core/templates/auth-server.deployment.yaml
+++ b/charts/lagoon-core/templates/auth-server.deployment.yaml
@@ -47,6 +47,10 @@ spec:
               key: KEYCLOAK_AUTH_SERVER_CLIENT_SECRET
         - name: KEYCLOAK_URL
           value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}
+      {{- range $key, $val := .Values.authServer.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: http-3000
           containerPort: 3000

--- a/charts/lagoon-core/templates/backup-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/backup-handler.deployment.yaml
@@ -65,6 +65,10 @@ spec:
           value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}/graphql
         - name: HTTP_LISTEN_PORT
           value: "3000"
+      {{- range $key, $val := .Values.backupHandler.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: http-3000
           containerPort: 3000

--- a/charts/lagoon-core/templates/broker.statefulset.yaml
+++ b/charts/lagoon-core/templates/broker.statefulset.yaml
@@ -57,6 +57,10 @@ spec:
           value: {{ .Release.Namespace | quote }}
         - name: SERVICE_NAME
           value: {{ include "lagoon-core.broker.fullname" . }}
+      {{- range $key, $val := .Values.broker.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: epmd
           containerPort: 4396

--- a/charts/lagoon-core/templates/drush-alias.deployment.yaml
+++ b/charts/lagoon-core/templates/drush-alias.deployment.yaml
@@ -33,6 +33,11 @@ spec:
           {{- toYaml .Values.drushAlias.securityContext | nindent 10 }}
         image: "{{ .Values.drushAlias.image.repository }}:{{ coalesce .Values.drushAlias.image.tag .Values.imageTag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.drushAlias.image.pullPolicy }}
+        env:
+      {{- range $key, $val := .Values.backupHandler.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: http-8080
           containerPort: 8080

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -39,6 +39,10 @@ spec:
             -Djava.awt.headless=true
         - name: DB_ADDR
           value: {{ include "lagoon-core.keycloakDB.fullname" . }}
+      {{- range $key, $val := .Values.keycloak.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "lagoon-core.keycloak.fullname" . }}

--- a/charts/lagoon-core/templates/logs-db-curator.deployment.yaml
+++ b/charts/lagoon-core/templates/logs-db-curator.deployment.yaml
@@ -53,6 +53,10 @@ spec:
         # for historical reasons this variable must be set
         - name: LAGOON_ENVIRONMENT_TYPE
           value: production
+      {{- range $key, $val := .Values.logsDBCurator.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.logsDBCurator.resources | nindent 10 }}
       {{- with .Values.logsDBCurator.nodeSelector }}

--- a/charts/lagoon-core/templates/logs2email.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2email.deployment.yaml
@@ -55,6 +55,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_PASSWORD
+      {{- range $key, $val := .Values.logs2email.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.logs2email.resources | nindent 10 }}
       {{- with .Values.logs2email.nodeSelector }}

--- a/charts/lagoon-core/templates/logs2microsoftteams.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2microsoftteams.deployment.yaml
@@ -55,6 +55,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_PASSWORD
+      {{- range $key, $val := .Values.logs2microsoftteams.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.logs2microsoftteams.resources | nindent 10 }}
       {{- with .Values.logs2microsoftteams.nodeSelector }}

--- a/charts/lagoon-core/templates/logs2rocketchat.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2rocketchat.deployment.yaml
@@ -55,6 +55,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_PASSWORD
+      {{- range $key, $val := .Values.logs2rocketchat.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.logs2rocketchat.resources | nindent 10 }}
       {{- with .Values.logs2rocketchat.nodeSelector }}

--- a/charts/lagoon-core/templates/logs2slack.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2slack.deployment.yaml
@@ -55,6 +55,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_PASSWORD
+      {{- range $key, $val := .Values.logs2slack.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.logs2slack.resources | nindent 10 }}
       {{- with .Values.logs2slack.nodeSelector }}

--- a/charts/lagoon-core/templates/logs2webhook.deployment.yaml
+++ b/charts/lagoon-core/templates/logs2webhook.deployment.yaml
@@ -55,6 +55,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_PASSWORD
+      {{- range $key, $val := .Values.logs2webhook.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.logs2webhook.resources | nindent 10 }}
       {{- with .Values.logs2webhook.nodeSelector }}

--- a/charts/lagoon-core/templates/ssh-portal.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.deployment.yaml
@@ -62,6 +62,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.sshPortal.fullname" . }}
               key: HOSTKEY_ED25519
+      {{- range $key, $val := .Values.sshPortal.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: ssh
           containerPort: 2222

--- a/charts/lagoon-core/templates/ssh.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh.deployment.yaml
@@ -51,6 +51,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.fullname" . }}-jwtsecret
               key: JWTSECRET
+      {{- range $key, $val := .Values.ssh.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: ssh
           containerPort: 2020

--- a/charts/lagoon-core/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-core/templates/storage-calculator.deployment.yaml
@@ -42,6 +42,10 @@ spec:
         - name: CRONJOBS
           value: |-
             5 */12 * * * /lagoon/cronjob.sh /calculate-storage.sh
+      {{- range $key, $val := .Values.storageCalculator.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.storageCalculator.resources | nindent 10 }}
       {{- with .Values.storageCalculator.nodeSelector }}

--- a/charts/lagoon-core/templates/ui.deployment.yaml
+++ b/charts/lagoon-core/templates/ui.deployment.yaml
@@ -52,6 +52,10 @@ spec:
           {{- end }}
         - name: LAGOON_VERSION
           value: {{ .Chart.AppVersion | replace "-" "." }}
+      {{- range $key, $val := .Values.ui.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: http-3000
           containerPort: 3000

--- a/charts/lagoon-core/templates/webhook-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/webhook-handler.deployment.yaml
@@ -47,6 +47,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_USERNAME
+      {{- range $key, $val := .Values.webhookHandler.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         ports:
         - name: http-3000
           containerPort: 3000

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -81,6 +81,10 @@ spec:
               key: RABBITMQ_USERNAME
         - name: REGISTRY
           value: {{ required "A valid .Values.registry required!" .Values.registry | quote }}
+      {{- range $key, $val := .Values.webhooks2tasks.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
         resources:
           {{- toYaml .Values.webhooks2tasks.resources | nindent 10 }}
       {{- with .Values.webhooks2tasks.nodeSelector }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -105,6 +105,9 @@ api:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -133,6 +136,9 @@ apiDB:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   storageSize: 128Gi
 
 apiRedis:
@@ -147,6 +153,9 @@ apiRedis:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   service:
     type: ClusterIP
@@ -165,6 +174,9 @@ keycloak:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   service:
     type: ClusterIP
@@ -235,6 +247,9 @@ broker:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   serviceAccount:
     # Annotations to add to the service account
     annotations: {}
@@ -283,6 +298,9 @@ authServer:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -305,6 +323,9 @@ webhooks2tasks:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -326,6 +347,9 @@ webhookHandler:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   service:
     type: ClusterIP
@@ -367,6 +391,9 @@ ui:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   service:
     type: ClusterIP
     port: 3000
@@ -407,6 +434,9 @@ backupHandler:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   service:
     type: ClusterIP
     port: 3000
@@ -446,6 +476,9 @@ autoIdler:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
 storageCalculator:
   enabled: true
   image:
@@ -459,6 +492,9 @@ storageCalculator:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
 logs2slack:
   enabled: true
@@ -474,6 +510,9 @@ logs2slack:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   autoscaling:
     enabled: false
@@ -498,6 +537,9 @@ logs2webhook:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -519,6 +561,9 @@ logs2microsoftteams:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   autoscaling:
     enabled: false
@@ -543,6 +588,9 @@ logs2rocketchat:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  additionalEnvs:
+  #   FOO: Bar
+
 logs2email:
   enabled: true
   replicaCount: 2
@@ -557,6 +605,9 @@ logs2email:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   autoscaling:
     enabled: false
@@ -579,6 +630,9 @@ drushAlias:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   service:
     type: ClusterIP
@@ -619,6 +673,9 @@ logsDBCurator:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
 ssh:
   replicaCount: 2
   image:
@@ -632,6 +689,9 @@ ssh:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   service:
     type: ClusterIP
@@ -663,6 +723,9 @@ sshPortal:
 
   resources: {}
 
+  additionalEnvs:
+  #   FOO: Bar
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -692,6 +755,9 @@ controllerhandler:
   securityContext: {}
 
   resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
 
   autoscaling:
     enabled: false


### PR DESCRIPTION
many of our lagoon services have env variables to control them, while it doesn't make sense to expose each of them via individual helm variables, we can provide a possibility to inject them this way