### PR TITLE
Re-enable the ingress-nginx admission controller in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ install-ingress:
 		--set controller.service.nodePorts.http=32080 \
 		--set controller.service.nodePorts.https=32443 \
 		--set controller.config.proxy-body-size=100m \
-		--set controller.admissionWebhooks.enabled=false \
 		--version=3.31.0 \
 		ingress-nginx \
 		ingress-nginx/ingress-nginx


### PR DESCRIPTION
Disabling the admission controller was a workaround for old versions of Dioscuri, and is no longer necessary.

Closes: https://github.com/uselagoon/lagoon-charts/issues/168
Closes: https://github.com/amazeeio/dioscuri/issues/10