### PR TITLE
Add optional mxout service to lagoon-remote chart

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.30.0
+version: 0.31.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -21,3 +21,5 @@ dbaas-operator:
 
 lagoon-gatekeeper:
   enabled: false
+
+mxoutHost: mxout1.example.com

--- a/charts/lagoon-remote/templates/mxout.service.yaml
+++ b/charts/lagoon-remote/templates/mxout.service.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.mxoutHost -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: mxout
+  labels:
+    {{- include "lagoon-remote.labels" . | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.mxoutHost | quote }}
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -10,6 +10,11 @@ imagePullSecrets: []
 logsDispatcherHost: |-
   lagoon-logging-logs-dispatcher.lagoon-logging.svc.cluster.local
 
+# If this value is set, it will create an `mxout` ExternalName service in the
+# deployed namespace pointing at the given host. This service can then be used
+# by workloads running in-cluster to connect to a platform-provided mailserver.
+mxoutHost: ""
+
 # this default image tag is set for all services and can be overridden
 # on the service level, if not set it uses chart appVersion
 imageTag: ""


### PR DESCRIPTION
This service is used by workloads running in-cluster to access a mailserver at a stable domain name.

Closes: #178