### PR TITLE
Adding k8up annotations to api-db and keycloak-db pods in lagoon-core chart

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.46.1
+version: 0.47.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -13,10 +13,8 @@ spec:
     metadata:
       annotations:
         checksum/api-db.secret: {{ include (print $.Template.BasePath "/api-db.secret.yaml") . | sha256sum }}
-        {{- if .Values.k8up }}
         k8up.syn.tools/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
         k8up.syn.tools/file-extension: .api-db.sql
-        {{- end }}
     {{- with .Values.apiDB.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -14,8 +14,8 @@ spec:
       annotations:
         checksum/api-db.secret: {{ include (print $.Template.BasePath "/api-db.secret.yaml") . | sha256sum }}
         {{- if .Values.k8up }}
-        appuio.ch/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
-        backup.appuio.ch/file-extension: .api-db.sql
+        k8up.syn.tools/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
+        k8up.syn.tools/file-extension: .api-db.sql
         {{- end }}
     {{- with .Values.apiDB.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       annotations:
         checksum/api-db.secret: {{ include (print $.Template.BasePath "/api-db.secret.yaml") . | sha256sum }}
+        {{- if .Values.k8up }}
+        appuio.ch/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
+        backup.appuio.ch/file-extension: .api-db.sql
+        {{- end }}
     {{- with .Values.apiDB.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -13,10 +13,8 @@ spec:
     metadata:
       annotations:
         checksum/keycloak.secret: {{ include (print $.Template.BasePath "/keycloak.secret.yaml") . | sha256sum }}
-        {{- if .Values.k8up }}
         k8up.syn.tools/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
-        k8up.syn.tools/file-extension: .api-db.sql
-        {{- end }}
+        k8up.syn.tools/file-extension: .keycloak-db.sql
     {{- with .Values.keycloakDB.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       annotations:
         checksum/keycloak.secret: {{ include (print $.Template.BasePath "/keycloak.secret.yaml") . | sha256sum }}
+        {{- if .Values.k8up }}
+        appuio.ch/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
+        backup.appuio.ch/file-extension: .api-db.sql
+        {{- end }}
     {{- with .Values.keycloakDB.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -14,8 +14,8 @@ spec:
       annotations:
         checksum/keycloak.secret: {{ include (print $.Template.BasePath "/keycloak.secret.yaml") . | sha256sum }}
         {{- if .Values.k8up }}
-        appuio.ch/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
-        backup.appuio.ch/file-extension: .api-db.sql
+        k8up.syn.tools/backupcommand: /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases"
+        k8up.syn.tools/file-extension: .api-db.sql
         {{- end }}
     {{- with .Values.keycloakDB.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -50,8 +50,6 @@
 
 # These values are the chart defaults, but can be overridden.
 
-k8up: false
-
 elasticsearchScheme: https
 elasticsearchHostPort: 9200
 

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -50,6 +50,8 @@
 
 # These values are the chart defaults, but can be overridden.
 
+k8up: false
+
 elasticsearchScheme: https
 elasticsearchHostPort: 9200
 


### PR DESCRIPTION
This PR adds support for the annotations k8up needs to have to backup the `api-db` and `keycloak-db` pods' PVCs in the lagoon-core chart
