### PR TITLE
Add Lagoon load-balancer tolerations to fluentbit daemonset

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.36.0
+version: 0.37.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -12,12 +12,18 @@ spec:
         fsGroup: 0
     scaling:
       replicas: {{ .Values.fluentdReplicaCount }}
-  {{- if .Values.fluentbitPrivileged }}
+{{- if or .Values.fluentbitPrivileged .Values.fluentbitTolerations }}
   fluentbit:
+  {{- if .Values.fluentbitPrivileged }}
     security:
       securityContext:
         privileged: true
-  {{- else }}
-  fluentbit: {}
   {{- end }}
+  {{- with .Values.fluentbitTolerations }}
+    tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- else }}
+  fluentbit: {}
+{{- end }}
   controlNamespace: {{ .Release.Namespace | quote }}

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -327,6 +327,13 @@ enableDefaultForwarding: true
 # Set how many fluentd pods should be running
 fluentdReplicaCount: 3
 
+# Add tolerations to the fluentbit daemonset so that it runs on e.g.
+# load-balancer nodes.
+fluentbitTolerations:
+- effect: NoSchedule
+  key: lagoon.sh/lb
+  operator: Exists
+
 # The values below must be supplied during installation.
 # Certificates should be provided in PEM format, and are generated as described
 # in the README for the lagoon-logs-concentrator chart.


### PR DESCRIPTION
This makes it possible to collect router logs on clusters with dedicated load balancer nodes.
