### PR TITLE
fix: work around invalid version string returned by EKS

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.40.0
+version: 0.40.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 - name: smlx
   email: scott.leggett@amazee.io
   url: https://amazee.io
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 
 # Application charts are a collection of templates that can be packaged into
 # versioned archives to be deployed.


### PR DESCRIPTION
This PR works around https://github.com/aws/eks-distro/issues/512

Closes: #313 