### PR TITLE
feat: consolidate openshift-build-test container logs

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.40.1
+version: 0.41.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -364,6 +364,11 @@ data:
           expression /^(?<prefix>container-logs-.+-apb)-(?:prov|depr)-[^-]{5}_(?<suffix>.+)$/
           replace \k<prefix>_\k<suffix>
         </replace>
+        <replace>
+          key index_name
+          expression /^(?<prefix>container-logs-openshift-build-test)-[0-9]+-[^-]{5}$/
+          replace \k<prefix>
+        </replace>
       </filter>
       {{- end }}
       #


### PR DESCRIPTION
This PR add consolidation for the openshift-build-logs.

Test locally using these config files:

fluent.conf:
```
<source>
  @type                forward
</source>

<filter lagoon.*.container>
  @type record_modifier
  <replace>
    key index_name
    expression /^(?<prefix>container-logs-e2e)-[^-]{10}-[^-]{26}_(?<suffix>.+)$/
    replace \k<prefix>_\k<suffix>
  </replace>
  <replace>
    key index_name
    expression /^(?<prefix>container-logs-.+-apb)-(?:prov|depr)-[^-]{5}_(?<suffix>.+)$/
    replace \k<prefix>_\k<suffix>
  </replace>
  <replace>
    key index_name
    expression /^(?<prefix>container-logs-openshift-build-test)-[0-9]+-[^-]{5}$/
    replace \k<prefix>
  </replace>
</filter>

<match lagoon.**>
  @type stdout
</match>
```

sample.log:
```
{"index_name":"container-logs-openshift-build-test"}
{"index_name":"container-logs-openshift-build-test-1624137060-fv86b"}
{"index_name":"container-logs-openshift-build-test-1624407060-5sxsv"}
{"index_name":"container-logs-openshift-build-test-1624468260-ptfvl"}
{"index_name":"container-logs-openshift-build-test-1625681460-knfbm"}
{"index_name":"container-logs-openshift-build-test-1625875860-pvbqp"}
{"index_name":"container-logs-openshift-build-test-1629083460-vkkrf"}
{"index_name":"container-logs-openshift-build-test-1629090660-cr9m8"}
{"index_name":"container-logs-openshift-build-test-1629108660-n9x2m"}
{"index_name":"container-logs-openshift-build-test-1629202260-b65wh"}
{"index_name":"container-logs-openshift-build-testing-project"}
```

Run fluentd:

```
$ docker run -it --rm -v $PWD:/fluentd/etc --user 0 --entrypoint sh -p 24224:24224 fluent/fluentd -c 'fluent-gem install fluent-plugin-record-modifier --no-document && fluentd -c /fluentd/etc/fluent.conf -v'
```

Pipe logs through:

```
$ fluent-cat --json lagoon.test.container < sample.log
```

Result:

```
2021-08-18 04:58:07.774525683 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774681160 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774722380 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774759529 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774787290 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774819633 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774842373 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774864547 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774885068 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774907173 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-test"}
2021-08-18 04:58:07.774929829 +0000 lagoon.test.container: {"index_name":"container-logs-openshift-build-testing-project"}
```

