### PR TITLE
Add option to use a custom CA for Elasticsearch

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
@@ -100,4 +100,7 @@ data:
 {{- if not .Values.verifyESVersionAtStartup }}
       verify_es_version_at_startup false
 {{- end }}
+{{- if .Values.elasticsearchCACert }}
+      ca_file /fluentd/es-tls/ca.crt
+{{- end }}
     </match>

--- a/charts/lagoon-logs-concentrator/templates/secret.yaml
+++ b/charts/lagoon-logs-concentrator/templates/secret.yaml
@@ -39,3 +39,16 @@ stringData:
       password "{{ .password }}"
     </user>
     {{- end }}
+{{- if .Values.elasticsearchCACert }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-logs-concentrator.fullname" . }}-es-tls
+  labels:
+    {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
+stringData:
+  ca.crt: |
+    {{- .Values.elasticsearchCACert | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-logs-concentrator/templates/statefulset.yaml
+++ b/charts/lagoon-logs-concentrator/templates/statefulset.yaml
@@ -78,6 +78,10 @@ spec:
           name: {{ include "lagoon-logs-concentrator.fullname" . }}-buffer
         - mountPath: /fluentd/tls/
           name: {{ include "lagoon-logs-concentrator.fullname" . }}-tls
+        {{- if .Values.elasticsearchCACert }}
+        - mountPath: /fluentd/es-tls/
+          name: {{ include "lagoon-logs-concentrator.fullname" . }}-es-tls
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       {{- with .Values.nodeSelector }}
@@ -108,6 +112,12 @@ spec:
           defaultMode: 420
           secretName: {{ include "lagoon-logs-concentrator.fullname" . }}-users
         name: {{ include "lagoon-logs-concentrator.fullname" . }}-users
+      {{- if .Values.elasticsearchCACert }}
+      - secret:
+          defaultMode: 420
+          secretName: {{ include "lagoon-logs-concentrator.fullname" . }}-es-tls
+        name: {{ include "lagoon-logs-concentrator.fullname" . }}-es-tls
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: {{ include "lagoon-logs-concentrator.fullname" . }}-buffer

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -116,9 +116,14 @@ elasticsearchTLSVerify: true
 
 # The values below are optional.
 
-# elasticsearchHostPort: "443" # default 9200
-# elasticsearchScheme: https   # default http
+# elasticsearchHostPort: "443"  # default 9200
+# elasticsearchScheme: https    # default http
 # service:
-#   type: LoadBalancer         # default ClusterIP. Set to LoadBalancer to
-#                              # expose the logs-concentrator service
-#                              # publicly.
+#   type: LoadBalancer          # default ClusterIP. Set to LoadBalancer to
+#                               # expose the logs-concentrator service
+#                               # publicly.
+#
+# elasticsearchCACert: |        # if elasticsearch is presenting a certificate
+#   -----BEGIN CERTIFICATE----- # signed by a private CA, then define the CA
+#   ...                         # root certificate here.
+#   -----END CERTIFICATE-----


### PR DESCRIPTION
This PR adds the option to supply a custom CA to the lagoon-logs-concentrator to use to validate the certificate presented by the backing Elasticsearch service.

This is useful when Elasticsearch is presenting a certificate with a private trust root.
