### PR TITLE
lowercasing the generated lagoon-core k8up bucket name

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.54.1
+version: 0.54.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/k8up.schedule.yaml
+++ b/charts/lagoon-core/templates/k8up.schedule.yaml
@@ -14,7 +14,7 @@ spec:
       {{ else if (lookup "backup.appuio.ch/v1alpha1" "Schedule" "" (include "lagoon-core.fullname" .) )}}
       bucket: {{ (lookup "backup.appuio.ch/v1alpha1" "Schedule" "" (include "lagoon-core.fullname" .) ).spec.backend.s3.bucket }}
       {{ else }}
-      bucket: {{ include "lagoon-core.fullname" . }}-{{ randAlphaNum 8 }}
+      bucket: {{ include "lagoon-core.fullname" . }}-{{ randAlphaNum 8 | lower }}
       {{ end }}
       {{ if .Values.k8upS3Endpoint }}
       endpoint: {{ .Values.k8upS3Endpoint }}


### PR DESCRIPTION
This PR adds support for casting the generated bucket name for lagoon-core's k8up schedule into lowercase characters and numbers only. This is required because uppercase characters are not allowed to be used as an S3 bucket name.