### PR TITLE
Add the ability to change elasticsearch admin username in logs-concentrator

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.0
+version: 0.33.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -1,5 +1,6 @@
 # values for CI linting and testing
 elasticsearchHost: "logs-db-service.elasticsearch.svc.cluster.local"
+elasticsearchAdminUser: "admin"
 elasticsearchAdminPassword: "securepass"
 tls:
   caCert: |-

--- a/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
@@ -70,7 +70,7 @@ data:
       scheme "#{ENV.fetch('ELASTICSEARCH_SCHEME','http')}"
       ssl_min_version TLSv1_2
       ssl_max_version TLSv1_3
-      user admin
+      user "#{ENV['LOGSDB_ADMIN_USER']}"
       password "#{ENV['LOGSDB_ADMIN_PASSWORD']}"
       # endpoint error handling
       reconnect_on_error true

--- a/charts/lagoon-logs-concentrator/templates/secret.yaml
+++ b/charts/lagoon-logs-concentrator/templates/secret.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
 stringData:
   FORWARD_SHARED_KEY: {{ required "A valid .Values.forwardSharedKey required!" .Values.forwardSharedKey }}
+  LOGSDB_ADMIN_USER: {{ default "admin" .Values.elasticsearchAdminUser }}
   LOGSDB_ADMIN_PASSWORD: {{ required "A valid .Values.elasticsearchAdminPassword required!" .Values.elasticsearchAdminPassword }}
 ---
 apiVersion: v1

--- a/charts/lagoon-logs-concentrator/templates/secret.yaml
+++ b/charts/lagoon-logs-concentrator/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
 stringData:
   FORWARD_SHARED_KEY: {{ required "A valid .Values.forwardSharedKey required!" .Values.forwardSharedKey }}
-  LOGSDB_ADMIN_USER: {{ default "admin" .Values.elasticsearchAdminUser }}
+  LOGSDB_ADMIN_USER: {{ .Values.elasticsearchAdminUser }}
   LOGSDB_ADMIN_PASSWORD: {{ required "A valid .Values.elasticsearchAdminPassword required!" .Values.elasticsearchAdminPassword }}
 ---
 apiVersion: v1

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -90,10 +90,10 @@ elasticsearchTLSVerify: true
 # The values below must be supplied during installation.
 # Certificates should be provided in PEM format, and are generated as described
 # in the README.
-# Sample data shown below.
+elasticsearchAdminUser: "admin"
 
+# Sample data shown below.
 # elasticsearchHost: "logs-db-service.elasticsearch.svc.cluster.local"
-# elasticsearchAdminUser: "admin"
 # elasticsearchAdminPassword: "securepass"
 # tls:
 #   caCert: |

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -93,6 +93,7 @@ elasticsearchTLSVerify: true
 # Sample data shown below.
 
 # elasticsearchHost: "logs-db-service.elasticsearch.svc.cluster.local"
+# elasticsearchAdminUser: "admin"
 # elasticsearchAdminPassword: "securepass"
 # tls:
 #   caCert: |


### PR DESCRIPTION
This PR makes it possible to configure an elasticsearch username as part of the lagoon-logs-concentrator chart values.yml file.