### PR TITLE
Adding "baas-" prefix to lagoon-core backup bucket

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.54.2
+version: 0.54.3
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/k8up.schedule.yaml
+++ b/charts/lagoon-core/templates/k8up.schedule.yaml
@@ -14,7 +14,7 @@ spec:
       {{ else if (lookup "backup.appuio.ch/v1alpha1" "Schedule" "" (include "lagoon-core.fullname" .) )}}
       bucket: {{ (lookup "backup.appuio.ch/v1alpha1" "Schedule" "" (include "lagoon-core.fullname" .) ).spec.backend.s3.bucket }}
       {{ else }}
-      bucket: {{ include "lagoon-core.fullname" . }}-{{ randAlphaNum 8 | lower }}
+      bucket: baas-{{ include "lagoon-core.fullname" . }}-{{ randAlphaNum 8 | lower }}
       {{ end }}
       {{ if .Values.k8upS3Endpoint }}
       endpoint: {{ .Values.k8upS3Endpoint }}


### PR DESCRIPTION
This PR adds the `baas-` prefix to the bucket name generated for the lagoon-core chart. This is required for the permissions set up for the `k8up` pod's IAM keys to be allowed to access this bucket.