### PR TITLE
Restore optional Docker runtime compatibility to lagoon-logging

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.43.0
+version: 0.44.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -153,7 +153,11 @@ data:
     # the last "format none" block is a catch-all for unmatched messages.
     <filter lagoon.*.container>
       @type parser
+{{- if eq .Values.containerRuntime "docker" }}
+      key_name log
+{{- else }}
       key_name message
+{{- end }}
       reserve_data true
       <parse>
         @type multi_format
@@ -207,7 +211,11 @@ data:
     # keys in the top-level log object.
     <filter lagoon.*.router.nginx>
       @type parser
+{{- if eq .Values.containerRuntime "docker" }}
+      key_name log
+{{- else }}
       key_name message
+{{- end }}
       reserve_time true
       reserve_data true
       remove_key_name_field true

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -334,6 +334,15 @@ fluentbitTolerations:
   key: lagoon.sh/lb
   operator: Exists
 
+# This chart assumes the container runtime is containerd, which puts the log
+# message in the `message` field of the log record.
+#
+# If the container runtime is docker, then the log message is in the `log`
+# field instead. Set value to `docker` to enable docker compatible log parsing.
+# Currently the only valid values are `docker` or an empty string (the
+# default).
+containerRuntime: ""
+
 # The values below must be supplied during installation.
 # Certificates should be provided in PEM format, and are generated as described
 # in the README for the lagoon-logs-concentrator chart.


### PR DESCRIPTION
https://github.com/uselagoon/lagoon-charts/pull/310 made a change to lagoon-logging which meant it was no longer compatible with the `docker` container runtime in favour of compatibility with `containerd`.

This PR restores optional `docker` compatibility since it seems `docker` will be with us for a while yet. The default is still assumes `containerd` container runtime.
