### PR TITLE
Implement CDN logs collection

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.44.0
+version: 0.45.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/README.md
+++ b/charts/lagoon-logging/README.md
@@ -121,6 +121,16 @@ NOTE: If the `logging-operator` chart upgrade doesn't work, just uninstall the h
 helm upgrade --debug --namespace lagoon-logging --reuse-values lagoon-logging lagoon-logging
 ```
 
+## Generating certificates
+
+Some components of this chart use server or client TLS authentication.
+These can be generated using the instructions in the `lagoon-logs-concentrator` chart README.
+
+The convention for SAN and CN naming is along the lines of:
+
+* `logs-dispatcher.cluster1.example.com` for the lagoon-logging "client" and `logs-concentrator.cluster2.example.com` for the `lagoon-logs-concentrator` "server".
+* `cdn.cluster1.example.com` for the CDN "client" and `cdn-logs-collector.cluster1.example.com` for the `cdn-logs-collector` "server".
+
 ## Log export
 
 The `logs-dispatcher` includes support for sending logs to external sinks such as [cloudwatch](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs) or [S3](https://docs.fluentd.org/output/s3).

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -59,3 +59,46 @@ logsDispatcher:
   buffer:
     storageClassName: standard
     size: 4Gi
+
+cdnLogsCollector:
+  enabled: true
+  serviceMonitor:
+    enabled: false
+  replicaCount: 1
+  buffer:
+    storageClassName: standard
+    size: 1Gi
+  serviceType: ClusterIP
+  tls:
+    caCert: |-
+      -----BEGIN CERTIFICATE-----
+      MIIBkzCCATigAwIBAgIUEylWBS30BvLSM7DlTAeiJMqpzF0wCgYIKoZIzj0EAwIw
+      JzElMCMGA1UEAxMcbG9ncy1jYS5jbHVzdGVyMS5leGFtcGxlLmNvbTAeFw0yMTA5
+      MjQwMzMzMDBaFw0zMTA5MjIwMzMzMDBaMCcxJTAjBgNVBAMTHGxvZ3MtY2EuY2x1
+      c3RlcjEuZXhhbXBsZS5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARvdkam
+      oZypQWzQDkAP6lz5vZQTk6vlaoVKGhYfbYh9wpIG5Fd6vZaMVpA2kqkmJ2GuuGRi
+      qyzSWHf6rWYHLCYio0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB
+      /zAdBgNVHQ4EFgQUNQMSQ5RyyBbMTBQXMe5mxykH2Q0wCgYIKoZIzj0EAwIDSQAw
+      RgIhAJWCXW7sJpJf5DLDSMJ5uPu/FpIr53jt4I87TtGdeWpjAiEA7c9U+ncUyGum
+      KumwMVHOT37qXJQlqekzhbjuqrzGAgM=
+      -----END CERTIFICATE-----
+    serverCert: |-
+      -----BEGIN CERTIFICATE-----
+      MIICBjCCAaygAwIBAgIUTxazeWSnnYEe6fyEzDXM3S8x1MowCgYIKoZIzj0EAwIw
+      JzElMCMGA1UEAxMcbG9ncy1jYS5jbHVzdGVyMS5leGFtcGxlLmNvbTAeFw0yMTA5
+      MjQwMzM0MDBaFw0zMTA5MjIwMzM0MDBaMDIxMDAuBgNVBAMTJ2Nkbi1sb2dzLWNv
+      bGxlY3Rvci5jbHVzdGVyMS5leGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49
+      AwEHA0IABFV+AkbcTWNkytQkBHZ/FpA3MK+HA+Ct9OqCSGocrWJBTHZCj9yVnMUs
+      9YVsdxyA/NW4UYo2fonD76CVNDaU16GjgaowgacwDgYDVR0PAQH/BAQDAgWgMBMG
+      A1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFGYfPGoh
+      KNYB+l/QLLx4MZidCyHqMB8GA1UdIwQYMBaAFDUDEkOUcsgWzEwUFzHuZscpB9kN
+      MDIGA1UdEQQrMCmCJ2Nkbi1sb2dzLWNvbGxlY3Rvci5jbHVzdGVyMS5leGFtcGxl
+      LmNvbTAKBggqhkjOPQQDAgNIADBFAiBzVqrMx3FCEt2L4AS1Fp6QpWHz3i+9rozk
+      9wiuLItXYwIhALDp7ukoMWVOxr8ZVyoKcQ3zEUGBLevkTt1rSb6NFxhF
+      -----END CERTIFICATE-----
+    serverKey: |-
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIA/x25g6Q5anX7ivoEb0kmfHxuigJaDdNFu0vvvaFjPNoAoGCCqGSM49
+      AwEHoUQDQgAEVX4CRtxNY2TK1CQEdn8WkDcwr4cD4K306oJIahytYkFMdkKP3JWc
+      xSz1hWx3HID81bhRijZ+icPvoJU0NpTXoQ==
+      -----END EC PRIVATE KEY-----

--- a/charts/lagoon-logging/templates/_helpers.tpl
+++ b/charts/lagoon-logging/templates/_helpers.tpl
@@ -204,3 +204,33 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Create a default fully qualified app name for cdn-logs-collector.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{- define "lagoon-logging.cdnLogsCollector.fullname" -}}
+{{- include "lagoon-logging.fullname" . }}-{{ .Values.cdnLogsCollector.name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lagoon-logging.cdnLogsCollector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-logging.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lagoon-logging.cdnLogsCollector.labels" -}}
+helm.sh/chart: {{ include "lagoon-logging.chart" . }}
+{{ include "lagoon-logging.cdnLogsCollector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.fluent-conf.configmap.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.cdnLogsCollector.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+data:
+  fluent.conf: |
+    <system>
+      workers 2
+      log_level error
+    </system>
+
+    # prometheus metrics
+    <source>
+      @type prometheus
+    </source>
+    <source>
+      @type prometheus_monitor
+    </source>
+    <source>
+      @type prometheus_output_monitor
+    </source>
+
+    <source>
+      @type tcp
+      @id   in_tcp
+      tag   "lagoon.cdn"
+      port  5140
+      <transport tls>
+        ca_path /fluentd/tls/ca.crt
+        cert_path /fluentd/tls/server.crt
+        private_key_path /fluentd/tls/server.key
+        client_cert_auth true
+      </transport>
+      <parse>
+        @type json
+      </parse>
+    </source>
+
+    # uncomment to debug
+    # <filter lagoon.**>
+    #   @type stdout
+    # </filter>
+
+    <match lagoon.**>
+      @type forward
+      @id out_forward
+      # error out early
+      verify_connection_at_startup true
+      <server>
+        port 24226
+        host "{{ include "lagoon-logging.logsDispatcher.fullname" . }}"
+      </server>
+      # buffer chunks by tag
+      <buffer tag>
+        @type file
+        path /fluentd/buffer/forward
+        # buffer params (per worker)
+        total_limit_size 4GB
+        # flush params
+        flush_thread_count 4
+        flush_interval 2s # flush every 2 seconds
+        flush_thread_burst_interval 0 # don't sleep if there is more data to flush
+        retry_max_interval 30s # limit exponential backoff period
+        overflow_action drop_oldest_chunk
+      </buffer>
+    </match>
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.cdnLogsCollector.enabled -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+stringData:
+  ca.crt: |
+    {{- required "A valid .Values.cdnLogsCollector.tls.caCert required!" .Values.cdnLogsCollector.tls.caCert | nindent 4 }}
+  server.crt: |
+    {{- required "A valid .Values.cdnLogsCollector.tls.serverCert required!" .Values.cdnLogsCollector.tls.serverCert | nindent 4 }}
+  server.key: |
+    {{- required "A valid .Values.cdnLogsCollector.tls.serverKey required!" .Values.cdnLogsCollector.tls.serverKey | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.service.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.cdnLogsCollector.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.cdnLogsCollector.serviceType }}
+  selector:
+    {{- include "lagoon-logging.cdnLogsCollector.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: syslog
+    port: 5140
+    protocol: TCP
+    targetPort: syslog
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.servicemonitor.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.cdnLogsCollector.enabled .Values.cdnLogsCollector.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+    monitoring.lagoon.sh/monitorMe: 'true'
+spec:
+  endpoints:
+  - honorLabels: true
+    path: /aggregated_metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "lagoon-logging.cdnLogsCollector.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.cdnLogsCollector.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.cdnLogsCollector.replicaCount }}
+  serviceName: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "lagoon-logging.cdnLogsCollector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/cdn-logs-collector.secret.yaml") . | sha256sum }}
+        checksum/fluent-conf-configmap: {{ include (print $.Template.BasePath "/cdn-logs-collector.fluent-conf.configmap.yaml") . | sha256sum }}
+    {{- with .Values.cdnLogsCollector.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "lagoon-logging.cdnLogsCollector.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "lagoon-logging.logsDispatcher.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.cdnLogsCollector.podSecurityContext | nindent 8 }}
+      initContainers:
+      - image: busybox:musl
+        imagePullPolicy: IfNotPresent
+        name: chown-buffer
+        command:
+        - chown
+        - '100:0'
+        - /fluentd/buffer
+        volumeMounts:
+        - mountPath: /fluentd/buffer/
+          name: buffer
+      containers:
+      - name: fluentd
+        securityContext:
+          {{- toYaml .Values.cdnLogsCollector.securityContext | nindent 10 }}
+        image: "{{ .Values.cdnLogsCollector.image.repository }}:{{ coalesce .Values.cdnLogsCollector.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.cdnLogsCollector.image.pullPolicy }}
+        ports:
+        - containerPort: 5140
+          protocol: TCP
+          name: syslog
+        - containerPort: 24231
+          protocol: TCP
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+        volumeMounts:
+        - mountPath: /fluentd/buffer/
+          name: buffer
+        - mountPath: /fluentd/etc/fluent.conf
+          name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
+          subPath: fluent.conf
+        - mountPath: /fluentd/tls/
+          name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
+        resources:
+          {{- toYaml .Values.cdnLogsCollector.resources | nindent 10 }}
+      {{- with .Values.cdnLogsCollector.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cdnLogsCollector.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cdnLogsCollector.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: fluent.conf
+            path: fluent.conf
+          name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
+        name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
+      - secret:
+          defaultMode: 420
+          secretName: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
+        name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
+  volumeClaimTemplates:
+  - metadata:
+      name: buffer
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      {{- with .Values.cdnLogsCollector.buffer.storageClassName }}
+      storageClassName: {{ . }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.cdnLogsCollector.buffer.size }}
+{{- end }}

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -52,6 +52,15 @@ data:
       tag   "lagoon.#{ENV['CLUSTER_NAME']}.router.openshift"
     </source>
 {{- end }}
+{{- if .Values.cdnLogsCollector.enabled }}
+    # cdn logs collected via cdn-logs-collector
+    <source>
+      @type  forward
+      @id    in_cdn
+      port   24226
+      tag   "lagoon.#{ENV['CLUSTER_NAME']}.cdn"
+    </source>
+{{- end }}
 
     #
     # optional sources which can be enabled in the chart
@@ -349,6 +358,17 @@ data:
           index_name router-logs-${record.dig('kubernetes','namespace_labels','lagoon_sh/project')&.gsub("_", "-") || "#{record.dig('kubernetes','namespace_name') || 'unknown_project'}_#{ENV['CLUSTER_NAME']}"}-_-${record.dig('kubernetes','namespace_labels','lagoon_sh/environmentType') || "unknown_environmenttype"}-_-${Time.at(time).strftime("%Y.%m")}
         </record>
       </filter>
+      {{- if .Values.cdnLogsCollector.enabled }}
+      #
+      # add the cdn logs index_name
+      #
+      <filter lagoon.*.cdn>
+        @type record_modifier
+        <record>
+          index_name cdn-logs-_-${ENV['CLUSTER_NAME']}-_-${Time.at(time).strftime("%Y.%m")}
+        </record>
+      </filter>
+      {{- end }}
       {{- if .Values.consolidateServiceIndices }}
       # some cluster services generate namespaces with a random suffix, so
       # consolidate those in a single index for each service

--- a/charts/lagoon-logging/templates/logs-dispatcher.service.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.service.yaml
@@ -17,6 +17,10 @@ spec:
     port: 24225
     protocol: TCP
     targetPort: haproxy-forward
+  - name: cdn-forward
+    port: 24226
+    protocol: TCP
+    targetPort: cdn-forward
   - name: metrics
     port: 24231
     protocol: TCP

--- a/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
@@ -55,6 +55,9 @@ spec:
         - containerPort: 24225
           protocol: TCP
           name: haproxy-forward
+        - containerPort: 24226
+          protocol: TCP
+          name: cdn-forward
         - containerPort: 24231
           protocol: TCP
           name: metrics

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -235,6 +235,50 @@ logsTeeApplication:
 
   affinity: {}
 
+cdnLogsCollector:
+
+  enabled: false
+
+  name: cdn-logs-collector
+
+  replicaCount: 3
+
+  image:
+    repository: uselagoon/logs-dispatcher
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  serviceMonitor:
+    enabled: true
+
+  buffer:
+    size: 8Gi
+    storageClassName: ""
+
+  serviceType: LoadBalancer
+
+  # TLS configuration is required
+  # These should be server certificates, and the CDN should be configured to
+  # present client certificates with the same trust root.
+  tls:
+    caCert: ""
+    serverCert: ""
+    serverKey: ""
+
 # Don't collect logs from these namespaces.
 # Comment out this field to collect from all namespaces.
 excludeNamespaces:


### PR DESCRIPTION
This adds an optional service to the `lagoon-logging` chart that exposes a port which accepts logs via TLS+TCP. It is disabled by default.

Closes: #324
