### PR TITLE
docker-host: disable selinux relabeling

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.42.0
+version: 0.43.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -63,6 +63,10 @@ dockerHost:
 
   securityContext:
     privileged: true
+    seLinuxOptions:
+      # Ensures selinux relabeling is disabled, this would case the container never to start
+      # as there can be so many files in the persistent storage
+      type: spc_t
 
   resources: {}
 


### PR DESCRIPTION
Ensures selinux relabeling is disabled for the docker-host, this would case the container never to start as there can be so many files in the persistent storage.

This only applies for k8s distributions that have selinux enabled (like OpenShift 4). Other k8s distributions should ignore this.

Example in `cri-o` where this is implemented:
https://github.com/cri-o/cri-o/blob/7048f2440217bbb2d6b5b7cfdbad052a4b8527f1/server/container_create_linux.go#L284-L288