### PR TITLE
Fix formatting of the install steps in lagoon-logging README

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.59.0
+version: 0.59.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/README.md
+++ b/charts/lagoon-logging/README.md
@@ -12,68 +12,67 @@ Logs are collated into a single index per lagoon project.
 
 Run these commands in the `charts/` directory (above `lagoon-logging/`).
 
-0. Obtain dependency.
+1. Obtain dependency.
 
-```
-helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
-helm dependency build lagoon-logging
-```
+   ```
+   helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
+   helm dependency build lagoon-logging
+   ```
 
-1. Create a `lagoon-logging.values.yaml` file inside `charts/` directory containing these fields with the relevant values added.
+2. Create a `lagoon-logging.values.yaml` file inside `charts/` directory containing these fields with the relevant values added.
    For required values and documentation see the comment block at the end of the chart's `values.yaml`.
 
-**OpenShift only**
+   **OpenShift only**
 
-You must set allow the fluentbit pods to run in privileged mode, and enable the haproxy logs collector:
+   You must set allow the fluentbit pods to run in privileged mode, and enable the haproxy logs collector:
 
-```
-fluentbitPrivileged: true
-openshiftHaproxyLogsCollector:
-  enabled: true
-```
+   ```
+   fluentbitPrivileged: true
+   openshiftHaproxyLogsCollector:
+     enabled: true
+   ```
 
-2. Test installation.
+3. Test installation.
 
-```
-helm template --debug --namespace lagoon-logging -f ./lagoon-logging.values.yaml lagoon-logging lagoon-logging
-```
+   ```
+   helm template --debug --namespace lagoon-logging -f ./lagoon-logging.values.yaml lagoon-logging lagoon-logging
+   ```
 
-```
-helm upgrade --dry-run --install --debug --create-namespace --namespace lagoon-logging -f ./lagoon-logging.values.yaml lagoon-logging lagoon-logging
-```
+   ```
+   helm upgrade --dry-run --install --debug --create-namespace --namespace lagoon-logging -f ./lagoon-logging.values.yaml lagoon-logging lagoon-logging
+   ```
 
-3. Run installation.
+4. Run installation.
+   ```
+   helm upgrade --install --debug --create-namespace --namespace lagoon-logging -f ./lagoon-logging.values.yaml lagoon-logging lagoon-logging
+   ```
 
-```
-helm upgrade --install --debug --create-namespace --namespace lagoon-logging -f ./lagoon-logging.values.yaml lagoon-logging lagoon-logging
-```
+   **OpenShift only**
 
-**OpenShift only**
+   Give the various serviceaccounts permissions required:
+   ```
+   oc project lagoon-logging
 
-Give the various serviceaccounts permissions required:
-```
-oc project lagoon-logging
+   # fluentd statefulset serviceaccount (logging-operator chart)
+   oc adm policy add-scc-to-user nonroot -z lagoon-logging-fluentd
 
-# fluentd statefulset serviceaccount (logging-operator chart)
-oc adm policy add-scc-to-user nonroot -z lagoon-logging-fluentd
+   # fluentbit daemonset serviceaccount (logging-operator chart)
+   oc adm policy add-scc-to-user privileged -z lagoon-logging-fluentbit
 
-# fluentbit daemonset serviceaccount (logging-operator chart)
-oc adm policy add-scc-to-user privileged -z lagoon-logging-fluentbit
+   # logs-dispatcher statefulset serviceaccount (lagoon-logging chart)
+   oc adm policy add-scc-to-user anyuid -z lagoon-logging-logs-dispatcher
+   ```
 
-# logs-dispatcher statefulset serviceaccount (lagoon-logging chart)
-oc adm policy add-scc-to-user anyuid -z lagoon-logging-logs-dispatcher
-```
+   And make the project network global:
+   ```
+   oc adm pod-network make-projects-global lagoon-logging
+   ```
 
-And make the project network global:
-```
-oc adm pod-network make-projects-global lagoon-logging
-```
+5. Update application-logs and router-logs services
 
-4. Update application-logs and router-logs services
+   The `application-logs` and `router-logs` services in the `lagoon` namespace needs to be updated to point their `externalName` to the `lagoon-logging-logs-dispatcher` service in the `lagoon-logging` namespace (or wherever you've installed it).
 
-The `application-logs` and `router-logs` services in the `lagoon` namespace needs to be updated to point their `externalName` to the `lagoon-logging-logs-dispatcher` service in the `lagoon-logging` namespace (or wherever you've installed it).
-
-If you are migrating from the old lagoon logging infrastructure and want to keep logs flowing to both old and new infrastructure, point these services at the relevant `logs-tee` service in the `lagoon-logging` namespace. The `logs-tee` services then need to have the legacy `endpoint` configured. See the comments in the chart `values.yaml` for an example.
+   If you are migrating from the old lagoon logging infrastructure and want to keep logs flowing to both old and new infrastructure, point these services at the relevant `logs-tee` service in the `lagoon-logging` namespace. The `logs-tee` services then need to have the legacy `endpoint` configured. See the comments in the chart `values.yaml` for an example.
 
 ## View logs
 


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
The markdown was written in a way that splits all the ordered lists into separate `<ol>` elements, this isn't great for accessibility. I was also initially confused about the multiple "Openshift Only" sections.

This rewrite renders everything into a single `<ol>` which makes it clearer that the "Openshift Only" instructions are for the installation step they're listed under. I also started the list from 1 instead of 0 since this is a README, not code
