### PR TITLE
Add service.annotations to ssh and auth-server

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -7,6 +7,7 @@ jobs:
   test-suite:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         test:
         - active-standby-kubernetes

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ install-mongodb:
 		bitnami/mongodb
 
 .PHONY: install-minio
-install-minio:
+install-minio: install-ingress
 	$(HELM) upgrade \
 		--install \
 		--create-namespace \

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.62.0
+version: 0.62.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/auth-server.service.yaml
+++ b/charts/lagoon-core/templates/auth-server.service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "lagoon-core.authServer.fullname" . }}
   labels:
     {{- include "lagoon-core.authServer.labels" . | nindent 4 }}
+  {{- with .Values.authServer.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.authServer.service.type }}
   ports:

--- a/charts/lagoon-core/templates/ssh.service.yaml
+++ b/charts/lagoon-core/templates/ssh.service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "lagoon-core.ssh.fullname" . }}
   labels:
     {{- include "lagoon-core.ssh.labels" . | nindent 4 }}
+  {{- with .Values.ssh.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.ssh.service.type }}
   ports:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -295,6 +295,7 @@ authServer:
   service:
     type: ClusterIP
     port: 80
+    annotations: {}
 
   podAnnotations: {}
 
@@ -710,6 +711,7 @@ ssh:
   service:
     type: ClusterIP
     port: 2020
+    annotations: {}
 
   autoscaling:
     enabled: false


### PR DESCRIPTION
This PR adds a service.annotations option to the Helm Charts for the lagoon-core ssh and auth-server services.

These annotations can be required by service providers to allow additional configuration options.

Tested as:
```
ssh:
  service:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "600"
```
With the resultant service showing the annotation
```
tobybellwood@pop-os:~/sites/lagoon-main (⎈ |kind-lagoon-local:default) $ kubectl get service lagoon-core-ssh -n lagoon -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: lagoon-core
    meta.helm.sh/release-namespace: lagoon
    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "600"
  creationTimestamp: "2022-02-03T01:23:59Z"
  labels:
```

If we need to add annotations to other services, happy to add them into this PR.

Closes #367 