### PR TITLE
Expose keycloak and api to ui so ui for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,8 @@ install-lagoon-core: install-minio
 		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set overwriteKubectlBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
 		--set "harborAdminPassword=Harbor12345" \
 		--set "harborURL=http://registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
-		--set "keycloakAPIURL=http://localhost:8080/auth" \
-		--set "lagoonAPIURL=http://localhost:7070/graphql" \
+		--set "keycloakAPIURL=http://keycloak.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/auth" \
+		--set "lagoonAPIURL=http://api.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/graphql" \
 		--set "registry=registry.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080" \
 		--set api.image.repository=$(IMAGE_REGISTRY)/api \
 		--set apiDB.image.repository=$(IMAGE_REGISTRY)/api-db \


### PR DESCRIPTION
Expose keycloak and api urls to the UI, this is so the UI deployed can be used locally if installing using make. Currently using the UI locally it tries to redirect to the internal to kubernetes keycloak and api URLs which are not accessible