### PR TITLE
appVersion: v2.4.1

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.63.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.4.0
+appVersion: v2.4.1

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.62.1
+version: 0.63.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.3.0
+appVersion: v2.4.0

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -25,7 +25,7 @@ version: 0.56.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.4.0
+appVersion: v2.4.1
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,13 +19,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.55.0
+version: 0.56.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.3.0
+appVersion: v2.4.0
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -414,7 +414,26 @@ data:
           index_name lagoon-logs-${record['project']}-_-all_environments-_-${Time.at(time).strftime("%Y.%m")}
         </record>
       </filter>
-
+      #
+      # exclude the lagoon logs for running builds, and legacy task: updates
+      #
+      <filter lagoon.*.lagoon>
+        @type grep
+        <or>
+          <exclude>
+            key $.meta.buildPhase
+            pattern ^running$
+          </exclude>
+          <exclude>
+            key $.meta.buildStatus
+            pattern ^running$
+          </exclude>
+          <exclude>
+            key $.event
+            pattern ^task:builddeploy-kubernetes:*
+          </exclude>
+        </or>
+      </filter>
       #
       # forward all to logs-concentrator
       #

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.0
+version: 0.31.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.3.0
+appVersion: v2.4.0

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.31.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.4.0
+appVersion: v2.4.1

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -22,7 +22,7 @@ version: 0.46.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.4.0
+appVersion: v2.4.1
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,11 +18,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.45.1
+version: 0.46.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.3.0
+appVersion: v2.4.0
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -12,4 +12,4 @@ type: application
 
 version: 0.31.0
 
-appVersion: v2.4.0
+appVersion: v2.4.1

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.30.0
+version: 0.31.0
 
-appVersion: v2.3.0
+appVersion: v2.4.0


### PR DESCRIPTION
lagoon-chart release for https://github.com/uselagoon/lagoon/releases/tag/v2.4.1 (v2.4.0 was skipped, and doesn't have a corresponding lagoon-chart release)