### PR TITLE
Use Keycloak startup readiness signalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ TESTS = [api]
 # IMAGE_TAG controls the tag used for container images in the lagoon-core,
 # lagoon-remote, and lagoon-test charts. If IMAGE_TAG is not set, it will fall
 # back to the version set in the CI values file, then to the chart default.
-IMAGE_TAG =
+IMAGE_TAG = main
 # IMAGE_REGISTRY controls the registry used for container images in the
 # lagoon-core, lagoon-remote, and lagoon-test charts. If IMAGE_REGISTRY is not
 # set, it will fall back to the version set in the chart values files. This
 # only affects lagoon-core, lagoon-remote, and the fill-test-ci-values target.
-IMAGE_REGISTRY = uselagoon
+IMAGE_REGISTRY = testlagoon
 # if OVERRIDE_BUILD_DEPLOY_DIND_IMAGE is not set, it will fall back to the
 # controller default (uselagoon/kubectl-build-deploy-dind:latest).
 OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.63.0
+version: 0.63.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -85,7 +85,8 @@ apiRedis:
 
 keycloak:
   image:
-    repository: uselagoon/keycloak
+    repository: testlagoon/keycloak
+    tag: main
 
 keycloakDB:
   image:

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -53,12 +53,10 @@ spec:
           httpGet:
             path: /
             port: http-8080
-          initialDelaySeconds: 90
         readinessProbe:
           httpGet:
             path: /
             port: http-8080
-          initialDelaySeconds: 90
         startupProbe:
           exec:
             command:

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -60,10 +60,12 @@ spec:
             port: http-8080
           initialDelaySeconds: 90
         startupProbe:
-          httpGet:
-            path: /
-            port: http-8080
-          failureThreshold: 20
+          exec:
+            command:
+            - test
+            - -f
+            - /tmp/keycloak-config-complete
+          failureThreshold: 30
           periodSeconds: 20
         resources:
           {{- toYaml .Values.keycloak.resources | nindent 10 }}


### PR DESCRIPTION
This PR uses the startup readiness signalling implemented in https://github.com/uselagoon/lagoon/pull/3042 to ensure the Keycloak pod does not become `Ready` in the k8s API until its configuration is complete.