### PR TITLE
fix: bump the keycloak startup probe timeout to 15m

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.67.2
+version: 0.67.3
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - test
             - -f
             - /tmp/keycloak-config-complete
-          failureThreshold: 30
+          failureThreshold: 45
           periodSeconds: 20
         resources:
           {{- toYaml .Values.keycloak.resources | nindent 10 }}


### PR DESCRIPTION
Keycloak sometimes takes >10 minutes to start - I've seen Keycloak get killed before completing configuration both locally and in lagoon-charts CI.

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
