### PR TITLE
feat: bump logging-operator dependency for lagoon-logging chart

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.15.0
-digest: sha256:260dfa5444356e25afdd030e5865b64f359a107c0562b92e33fd14ac216c5d7a
-generated: "2021-10-29T11:28:56.125892878+08:00"
+  version: 3.17.3
+digest: sha256:3fcd9f977a737ea57bf18a4ffa2e587146f1ff87400c99b5dfcd134a5cdb8321
+generated: "2022-04-05T21:06:58.40979978+08:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.58.0
+version: 0.59.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -30,5 +30,5 @@ appVersion: v2.5.0
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: ~3.15.0
+  version: ~3.17.0
   condition: logging-operator.enabled


### PR DESCRIPTION
Bump `logging-operator` to the latest v3.17.3.