### PR TITLE
add additional KEYCLOAK_USER secret

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.67.0
+version: 0.67.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.67.1
+version: 0.67.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -73,12 +73,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
-              key: KEYCLOAK_USER
+              key: KEYCLOAK_ADMIN_USER
         - name: KEYCLOAK_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
-              key: KEYCLOAK_PASSWORD
+              key: KEYCLOAK_ADMIN_PASSWORD
         - name: KEYCLOAK_API_CLIENT_SECRET
           valueFrom:
             secretKeyRef:

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -69,11 +69,16 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.fullname" . }}-secrets
               key: JWTSECRET
+        - name: KEYCLOAK_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_USER
         - name: KEYCLOAK_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
-              key: KEYCLOAK_ADMIN_PASSWORD
+              key: KEYCLOAK_PASSWORD
         - name: KEYCLOAK_API_CLIENT_SECRET
           valueFrom:
             secretKeyRef:

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -22,6 +22,7 @@ metadata:
     {{- include "lagoon-core.keycloak.labels" . | nindent 4 }}
 stringData:
   DB_PASSWORD: {{ $keycloakDBPassword | quote }}
+  KEYCLOAK_ADMIN_PASSWORD: {{ $keycloakAdminPassword }}
   KEYCLOAK_USER: {{ $keycloakAdminUser }}
   KEYCLOAK_PASSWORD: {{ $keycloakAdminPassword }}
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -6,8 +6,7 @@ This somewhat complex logic is intended to:
 */}}
 {{- $data := index (lookup "v1" "Secret" .Release.Namespace (include "lagoon-core.keycloak.fullname" .)) "data" | default dict }}
 {{- $keycloakDBPassword := coalesce .Values.keycloakDBPassword (ternary (randAlpha 32) (index $data "DB_PASSWORD" | default "" | b64dec) (index $data "DB_PASSWORD" | empty)) }}
-{{- $keycloakAdminUser := coalesce .Values.keycloakAdminUser (ternary "admin" (index $data "KEYCLOAK_USER" | default "" | b64dec) (index $data "KEYCLOAK_USER" | empty)) }}
-{{- $keycloakAdminPassword := coalesce .Values.keycloakAdminPassword (index $data "KEYCLOAK_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_PASSWORD" | default "" | b64dec) (randAlpha 32) }}
+{{- $keycloakAdminUser := coalesce .Values.keycloakAdminUser (ternary "admin" (index $data "KEYCLOAK_ADMIN_USER" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_USER" | empty)) }}
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonAdminPassword := coalesce .Values.keycloakLagoonAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | empty)) }}
@@ -22,9 +21,8 @@ metadata:
     {{- include "lagoon-core.keycloak.labels" . | nindent 4 }}
 stringData:
   DB_PASSWORD: {{ $keycloakDBPassword | quote }}
+  KEYCLOAK_ADMIN_USER: {{ $keycloakAdminUser }}
   KEYCLOAK_ADMIN_PASSWORD: {{ $keycloakAdminPassword }}
-  KEYCLOAK_USER: {{ $keycloakAdminUser }}
-  KEYCLOAK_PASSWORD: {{ $keycloakAdminPassword }}
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}
   KEYCLOAK_AUTH_SERVER_CLIENT_SECRET: {{ $keycloakAuthServerClientSecret | quote }}
   KEYCLOAK_LAGOON_ADMIN_PASSWORD: {{ $keycloakLagoonAdminPassword | quote }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -7,6 +7,7 @@ This somewhat complex logic is intended to:
 {{- $data := index (lookup "v1" "Secret" .Release.Namespace (include "lagoon-core.keycloak.fullname" .)) "data" | default dict }}
 {{- $keycloakDBPassword := coalesce .Values.keycloakDBPassword (ternary (randAlpha 32) (index $data "DB_PASSWORD" | default "" | b64dec) (index $data "DB_PASSWORD" | empty)) }}
 {{- $keycloakAdminUser := coalesce .Values.keycloakAdminUser (ternary "admin" (index $data "KEYCLOAK_ADMIN_USER" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_USER" | empty)) }}
+{{- $keycloakAdminPassword := coalesce .Values.keycloakAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_PASSWORD" | empty)) }}
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonAdminPassword := coalesce .Values.keycloakLagoonAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | empty)) }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -6,7 +6,8 @@ This somewhat complex logic is intended to:
 */}}
 {{- $data := index (lookup "v1" "Secret" .Release.Namespace (include "lagoon-core.keycloak.fullname" .)) "data" | default dict }}
 {{- $keycloakDBPassword := coalesce .Values.keycloakDBPassword (ternary (randAlpha 32) (index $data "DB_PASSWORD" | default "" | b64dec) (index $data "DB_PASSWORD" | empty)) }}
-{{- $keycloakAdminPassword := coalesce .Values.keycloakAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_PASSWORD" | empty)) }}
+{{- $keycloakAdminUser := coalesce .Values.keycloakAdminUser (ternary "admin" (index $data "KEYCLOAK_USER" | default "" | b64dec) (index $data "KEYCLOAK_USER" | empty)) }}
+{{- $keycloakAdminPassword := coalesce .Values.keycloakAdminPassword (index $data "KEYCLOAK_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_PASSWORD" | default "" | b64dec) (randAlpha 32) }}
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonAdminPassword := coalesce .Values.keycloakLagoonAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | empty)) }}
@@ -21,7 +22,7 @@ metadata:
     {{- include "lagoon-core.keycloak.labels" . | nindent 4 }}
 stringData:
   DB_PASSWORD: {{ $keycloakDBPassword | quote }}
-  KEYCLOAK_ADMIN_PASSWORD: {{ $keycloakAdminPassword }}
+  KEYCLOAK_USER: {{ $keycloakAdminUser }}
   KEYCLOAK_PASSWORD: {{ $keycloakAdminPassword }}
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}
   KEYCLOAK_AUTH_SERVER_CLIENT_SECRET: {{ $keycloakAuthServerClientSecret | quote }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -22,6 +22,7 @@ metadata:
 stringData:
   DB_PASSWORD: {{ $keycloakDBPassword | quote }}
   KEYCLOAK_ADMIN_PASSWORD: {{ $keycloakAdminPassword }}
+  KEYCLOAK_PASSWORD: {{ $keycloakAdminPassword }}
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}
   KEYCLOAK_AUTH_SERVER_CLIENT_SECRET: {{ $keycloakAuthServerClientSecret | quote }}
   KEYCLOAK_LAGOON_ADMIN_PASSWORD: {{ $keycloakLagoonAdminPassword | quote }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -39,6 +39,7 @@
 
 # apiDBPassword:
 # jwtSecret:
+# keycloakAdminUser:
 # keycloakAdminPassword:
 # keycloakAPIClientSecret:
 # keycloakAuthServerClientSecret:


### PR DESCRIPTION
This PR allows the ability to define an admin username (other than `admin`) for use with Keycloak, but keeps admin as the default (and won't autogenerate a new name)