### PR TITLE
fix: refactor keycloak admin user variable

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.67.3
+version: 0.67.4
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -69,16 +69,13 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.fullname" . }}-secrets
               key: JWTSECRET
-        - name: KEYCLOAK_ADMIN_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "lagoon-core.keycloak.fullname" . }}
-              key: KEYCLOAK_ADMIN_USER
         - name: KEYCLOAK_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
               key: KEYCLOAK_ADMIN_PASSWORD
+        - name: KEYCLOAK_ADMIN_USER
+          value: {{ .Values.keycloakAdminUser | quote }}
         - name: KEYCLOAK_API_CLIENT_SECRET
           valueFrom:
             secretKeyRef:

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -39,6 +39,8 @@ spec:
             -Djava.awt.headless=true
         - name: DB_ADDR
           value: {{ include "lagoon-core.keycloakDB.fullname" . }}
+        - name: KEYCLOAK_ADMIN_USER
+          value: {{ .Values.keycloakAdminUser | quote }}
       {{- range $key, $val := .Values.keycloak.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -6,7 +6,6 @@ This somewhat complex logic is intended to:
 */}}
 {{- $data := index (lookup "v1" "Secret" .Release.Namespace (include "lagoon-core.keycloak.fullname" .)) "data" | default dict }}
 {{- $keycloakDBPassword := coalesce .Values.keycloakDBPassword (ternary (randAlpha 32) (index $data "DB_PASSWORD" | default "" | b64dec) (index $data "DB_PASSWORD" | empty)) }}
-{{- $keycloakAdminUser := coalesce .Values.keycloakAdminUser (ternary "admin" (index $data "KEYCLOAK_ADMIN_USER" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_USER" | empty)) }}
 {{- $keycloakAdminPassword := coalesce .Values.keycloakAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_ADMIN_PASSWORD" | empty)) }}
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
@@ -22,7 +21,6 @@ metadata:
     {{- include "lagoon-core.keycloak.labels" . | nindent 4 }}
 stringData:
   DB_PASSWORD: {{ $keycloakDBPassword | quote }}
-  KEYCLOAK_ADMIN_USER: {{ $keycloakAdminUser }}
   KEYCLOAK_ADMIN_PASSWORD: {{ $keycloakAdminPassword }}
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}
   KEYCLOAK_AUTH_SERVER_CLIENT_SECRET: {{ $keycloakAuthServerClientSecret | quote }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -39,7 +39,6 @@
 
 # apiDBPassword:
 # jwtSecret:
-# keycloakAdminUser:
 # keycloakAdminPassword:
 # keycloakAPIClientSecret:
 # keycloakAuthServerClientSecret:
@@ -61,6 +60,8 @@ imagePullSecrets: []
 rabbitMQUsername: lagoon
 
 k8upS3Endpoint: ""
+
+keycloakAdminUser: admin
 
 # Set to an empty string to support Harbor v1.x.x
 harborAPIVersion: v2.0


### PR DESCRIPTION
This changes the way the keycloak admin user is added to simplify it and
align it with the way we handle default non-sensitive values in the rest
of the chart.

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
