### PR TITLE
update logging operator dependency to 3.17.4

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.17.3
-digest: sha256:3fcd9f977a737ea57bf18a4ffa2e587146f1ff87400c99b5dfcd134a5cdb8321
-generated: "2022-04-05T21:06:58.40979978+08:00"
+  version: 3.17.4
+digest: sha256:8d4fc59f36ccb9dd85cf3485434e58b4de3fe41a40e8852f9e41ba328ce3ad2f
+generated: "2022-04-20T09:32:42.756916636+10:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.60.0
+version: 0.60.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.


### PR DESCRIPTION
the 3.17.3 release of the logging-operator added HostTailer and EventTailer, enabled by default. If the logging operator is installed without the updated CRDs, it will crashloop.

This PR updates the logging-operator to 3.17.4 where they are [disabled by default](https://github.com/banzaicloud/logging-operator/pull/958), whilst we work out how to automate the update of the CRDs after an update

and yes, we could do this, but I just don't know if we should, or how, or where
```
helm show crds banzaicloud-stable/logging-operator --version 3.17.3 | kubectl apply -f -
```


