### PR TITLE
Enable liveness probe for fluentbit daemonset

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.61.0
+version: 0.62.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -12,8 +12,11 @@ spec:
         fsGroup: 0
     scaling:
       replicas: {{ .Values.fluentdReplicaCount }}
-{{- if or .Values.fluentbitPrivileged .Values.fluentbitTolerations }}
   fluentbit:
+    # Enable a default liveness check to avoid stuck pods.
+    # At the time of writing this just hits the metrics endpoint.
+    # https://github.com/banzaicloud/logging-operator/blob/master/pkg/sdk/logging/api/v1beta1/logging_types.go#L452-L467
+    livenessDefaultCheck: true
   {{- if .Values.fluentbitPrivileged }}
     security:
       securityContext:
@@ -23,7 +26,4 @@ spec:
     tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- else }}
-  fluentbit: {}
-{{- end }}
   controlNamespace: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
The `logging-operator` chart, which is a dependency of `lagoon-logging`, uses a fluentbit daemonset to collect container logs from the nodes in the cluster. Occasionally fluentbit gets into a state where it appears to be "frozen" and no longer sends logs.

This change enables the default liveness probe for fluentbit which will hopefully restart the pod automatically when it enters this error state.