### PR TITLE
update to latest lagoon-insights-remote

### DIFF
--- a/charts/lagoon-insights-remote/Chart.yaml
+++ b/charts/lagoon-insights-remote/Chart.yaml
@@ -27,4 +27,4 @@ version: 0.1.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.0
+appVersion: v0.0.3

--- a/charts/lagoon-insights-remote/Chart.yaml
+++ b/charts/lagoon-insights-remote/Chart.yaml
@@ -21,10 +21,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: 0.3.0

--- a/charts/lagoon-insights-remote/values.yaml
+++ b/charts/lagoon-insights-remote/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: uselagoon/insights-remote
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "main"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/lagoon-insights-remote/values.yaml
+++ b/charts/lagoon-insights-remote/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: uselagoon/insights-remote
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "main"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
corresponding release for https://github.com/uselagoon/insights-remote/releases/tag/v0.0.3

Changes the chart to use the tagged AppVersion instead of latest.