### PR TITLE
lagoon-core v2.7.1 updates

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.69.0
+version: 0.70.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.7.0
+appVersion: v2.7.1

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,13 +19,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.62.0
+version: 0.63.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.7.0
+appVersion: v2.7.1
 
 dependencies:
 - name: logging-operator

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.35.0
+version: 0.36.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.7.0
+appVersion: v2.7.1

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.10.2
+  version: 0.11.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
-  version: 0.4.0
+  version: 0.4.1
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
-  version: 0.2.2
+  version: 0.3.0
 - name: lagoon-gatekeeper
   repository: https://uselagoon.github.io/lagoon-charts/
   version: 0.3.1
 - name: lagoon-insights-remote
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.1.1
-digest: sha256:6c19c5f3ee236f262932d5239627903e39ace6c3ad8106cb9b06920a21620489
-generated: "2022-04-14T11:31:34.327862+10:00"
+  version: 0.1.2
+digest: sha256:b309d46d9c2c6e669abf65c7991bea050547256c9c7f332add61ae190a9432d5
+generated: "2022-05-03T15:47:38.886119855+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -26,7 +26,7 @@ appVersion: v2.7.1
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.10.0
+  version: ~0.11.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri
@@ -34,7 +34,7 @@ dependencies:
   repository: https://amazeeio.github.io/charts/
   condition: dioscuri.enabled
 - name: dbaas-operator
-  version: ~0.2.0
+  version: ~0.3.0
   repository: https://amazeeio.github.io/charts/
   condition: dbaas-operator.enabled
 - name: lagoon-gatekeeper

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -18,11 +18,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.52.0
+version: 0.53.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: v2.7.0
+appVersion: v2.7.1
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.34.0
+version: 0.35.0
 
-appVersion: v2.7.0
+appVersion: v2.7.1


### PR DESCRIPTION
lagoon-charts release to match https://github.com/uselagoon/lagoon/releases/tag/v2.7.1 and update lagoon-remote dependencies