### PR TITLE
Bump logging operator dependency in lagoon-logging chart

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.17.4
-digest: sha256:8d4fc59f36ccb9dd85cf3485434e58b4de3fe41a40e8852f9e41ba328ce3ad2f
-generated: "2022-04-20T09:32:42.756916636+10:00"
+  version: 3.17.7
+digest: sha256:12db5e3fa5d67bdc4307758150cc57e3ef0c5893095b40735d989935cac2c318
+generated: "2022-06-02T14:25:04.188887195+08:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.64.0
+version: 0.65.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.


### PR DESCRIPTION
This change updates the fluent-bit daemonset from 1.8.15 to 1.9.3 which may help fix some rare log flow reliability issues we have seen in production.
