### PR TITLE
feat: add harbor values to build-deploy template

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.11.2
+version: 0.11.3
 
 appVersion: v0.4.1

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -48,6 +48,13 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election=true"
+        {{- if .Values.harbor.enabled }}
+        - "--enable-harbor=true"
+        - "--harbor-password={{ .Values.harbor.adminPassword }}"
+        - "--harbor-username={{ .Values.harbor.adminUser }}"
+        - "--harbor-url={{ .Values.harbor.host }}"
+        - "--harbor-api={{ .Values.harbor.host }}/api"
+        {{- end }}
         {{- if .Values.rootlessBuildPods }}
         - "--build-pod-run-as-user=10000"
         - "--build-pod-run-as-group=0"

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -65,6 +65,14 @@ enableServiceMonitor: false
 metrics:
   interval: 30s
 
+# set these to your harbor configuration
+harbor:
+  enabled: false
+  # the following are REQUIRED values if harbor is enabled
+  adminPassword: Harbor12345
+  adminUser: admin
+  host: http://registry.172.16.0.1.nip.io:32080
+
 extraArgs:
 
 # add extra environment variables if required


### PR DESCRIPTION
As this is now the preferred way to communicate with Harbor, instead of having to specify the harbor arguments to remote-controller as extraArgs, they can now be included in the helm chart values as `harbor.*`

