### PR TITLE
appVersion: v2.8.3

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.8.1
+appVersion: v2.8.3


### PR DESCRIPTION
lagoon-core release v2.8.3 technically only updated the kubectl-build-deploy-dind image, but this release will align the versions again.