### PR TITLE
Startup probes

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -55,6 +55,10 @@ spec:
         readinessProbe:
           tcpSocket:
             port: mariadb
+      {{- with .Values.apiDB.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
         resources:
           {{- toYaml .Values.apiDB.resources | nindent 10 }}
       volumes:

--- a/charts/lagoon-core/templates/broker.statefulset.yaml
+++ b/charts/lagoon-core/templates/broker.statefulset.yaml
@@ -79,6 +79,10 @@ spec:
         readinessProbe:
           tcpSocket:
             port: amqp
+      {{- with .Values.broker.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
         resources:
           {{- toYaml .Values.broker.resources | nindent 10 }}
       volumes:

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -55,6 +55,10 @@ spec:
         readinessProbe:
           tcpSocket:
             port: mariadb
+      {{- with .Values.keycloakDB.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
         resources:
           {{- toYaml .Values.keycloakDB.resources | nindent 10 }}
       volumes:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -233,6 +233,12 @@ keycloakDB:
   additionalEnvs:
   #   FOO: Bar
 
+  startupProbe:
+    # 60*10s period = 10 minutes
+    failureThreshold: 60
+    tcpSocket:
+      port: mariadb
+
 broker:
   replicaCount: 3
   image:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -147,6 +147,12 @@ apiDB:
 
   storageSize: 128Gi
 
+  startupProbe:
+    # 60*10s period = 10 minutes
+    failureThreshold: 60
+    tcpSocket:
+      port: mariadb
+
 apiRedis:
   image:
     repository: uselagoon/api-redis

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -294,6 +294,11 @@ broker:
     #    hosts:
     #      - chart-example.local
 
+  startupProbe:
+    # 60*10s period = 10 minutes
+    failureThreshold: 60
+    tcpSocket:
+      port: amqp
 
 authServer:
   replicaCount: 2


### PR DESCRIPTION
This change just hard-codes a 10 minute maximum startup timeout on the stateful pods `api-db`, `keycloak-db`, and `broker`.

Is it okay being hard-coded? Or should this be configurable? I'm thinking YAGNI, but there might be a use case.

Closes: #424
Closes: #443 
