### PR TITLE
update charts to use the activestandby task image overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ IMAGE_REGISTRY = uselagoon
 # if OVERRIDE_BUILD_DEPLOY_DIND_IMAGE is not set, it will fall back to the
 # controller default (uselagoon/kubectl-build-deploy-dind:latest).
 OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =
+# if OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE is not set, it will fall back to the
+# controller default (uselagoon/task-activestandby:${lagoonVersion}).
+OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE =
 # Overrides the image tag for amazeeio/lagoon-builddeploy whose default is
 # the lagoon-build-deploy chart appVersion.
 OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG =
@@ -176,7 +179,7 @@ install-lagoon-core: install-minio
 		--timeout $(TIMEOUT) \
 		--values ./charts/lagoon-core/ci/linter-values.yaml \
 		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
-		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && echo '--set overwriteKubectlBuildDeployDindImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
+		$$([ $(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE) ] && echo '--set overwriteActiveStandbyTaskImage=$(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE)') \
 		--set "harborAdminPassword=none" \
 		--set "harborURL=http://none.com" \
 		--set "registry=none.com" \

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -8,6 +8,9 @@ maintainers:
 - name: smlx
   email: scott.leggett@amazee.io
   url: https://amazee.io
+- name: shreddedbacon
+  email: ben.jackson@amazee.io
+  url: https://amazee.io
 kubeVersion: ">= 1.19.0-0"
 
 # Application charts are a collection of templates that can be packaged into

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -87,8 +87,8 @@ spec:
           value: {{ required "A valid .Values.kibanaURL required!" .Values.kibanaURL | quote }}
         - name: LAGOON_VERSION
           value: {{ .Chart.AppVersion | replace "-" "." }}
-        {{- with .Values.overwriteKubectlBuildDeployDindImage }}
-        - name: OVERWRITE_KUBECTL_BUILD_DEPLOY_DIND_IMAGE
+        {{- with .Values.overwriteActiveStandbyTaskImage }}
+        - name: OVERWRITE_ACTIVESTANDBY_TASK_IMAGE
           value: {{ . | quote }}
         {{- end }}
         - name: PROJECTSEED

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -54,8 +54,8 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.fullname" . }}-secrets
               key: JWTSECRET
-        {{- with .Values.overwriteKubectlBuildDeployDindImage }}
-        - name: OVERWRITE_KUBECTL_BUILD_DEPLOY_DIND_IMAGE
+        {{- with .Values.overwriteActiveStandbyTaskImage }}
+        - name: OVERWRITE_ACTIVESTANDBY_TASK_IMAGE
           value: {{ . | quote }}
         {{- end }}
         - name: HARBOR_ADMIN_PASSWORD

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -16,7 +16,7 @@
 
 # These values are optional.
 
-# overwriteKubectlBuildDeployDindImage:
+# overwriteActiveStandbyTaskImage:
 
 # These values are optional depending on the services Lagoon is integrated with
 # in your environment.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Lagoon-core uses an old method for calculating the active-standby task image, rather than one that is used during the build/test phase. This PR updates the charts to support providing the image built as part of tests so we can properly use active/standby images in tests.
