### PR TITLE
Improve logging filter

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.65.0
+version: 0.66.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -102,3 +102,7 @@ cdnLogsCollector:
       AwEHoUQDQgAEVX4CRtxNY2TK1CQEdn8WkDcwr4cD4K306oJIahytYkFMdkKP3JWc
       xSz1hWx3HID81bhRijZ+icPvoJU0NpTXoQ==
       -----END EC PRIVATE KEY-----
+
+extraExcludeNamespaces:
+- ci-fake-namespace-0
+- ci-fake-namespace-1

--- a/charts/lagoon-logging/templates/clusterflow.yaml
+++ b/charts/lagoon-logging/templates/clusterflow.yaml
@@ -14,6 +14,9 @@ spec:
       {{- with .Values.excludeNamespaces }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- with .Values.extraExcludeNamespaces }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   {{- with .Values.selectNamespaces }}
   - select:
       namespaces:

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -324,6 +324,11 @@ excludeNamespaces:
 - openshift-web-console
 - tiller
 
+# namespaces to exclude in addition to the default list above
+extraExcludeNamespaces: []
+# - extra-namespace-0
+# - extra-namespace-1
+
 # Configure the cluster output buffer.
 # This may require tweaking to handle high volumes of logs.
 clusterOutputBuffer:


### PR DESCRIPTION
Add an extra value to `lagoon-logging` which adds to the list of namespaces excluded from logs capture.

Closes: #321 
