### PR TITLE
lagoon-core appVersion v2.9.1

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,10 +21,10 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.9.0
+appVersion: v2.9.1


### PR DESCRIPTION
This release is only documentation and kubectl-build-deploy-dind related - no changes to any core services.

lagoon-core only release of https://github.com/uselagoon/lagoon/releases/tag/v2.9.1