### PR TITLE
update lagoon-core to v2.9.2 and introduce more actions debug

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -71,7 +71,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       with:
         version: v0.14.0
-        node_image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+        node_image: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
         config: test-suite.kind-config.yaml
 
     - name: Install kubectl
@@ -127,20 +127,13 @@ jobs:
         tar -xf ./gojq_v0.11.1_linux_amd64.tar.gz
         sudo cp /tmp/gojq_v0.11.1_linux_amd64/gojq /usr/local/bin/jq
 
-    # Uncomment this snippet in your PR to enable the debug action
-    # https://github.com/marketplace/actions/debugging-with-tmate
-    #
-    # Continue after getting a shell via: `touch continue`
-    #
-    # - name: Install kubens and kubectl alias
-    #   run: |
-    #     cd /tmp
-    #     curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens_v0.9.1_linux_x86_64.tar.gz
-    #     tar -xf ./kubens_v0.9.1_linux_x86_64.tar.gz
-    #     sudo cp /tmp/kubens /usr/local/bin/kubens
-    #     sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
+    - name: Install kubens and kubectl alias
+      run: |
+        cd /tmp
+        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens_v0.9.1_linux_x86_64.tar.gz
+        tar -xf ./kubens_v0.9.1_linux_x86_64.tar.gz
+        sudo cp /tmp/kubens /usr/local/bin/kubens
+        sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc
 
     - name: Helm-install the test fixtures and fill lagoon-test/ci/linter-values.yaml
       if: |
@@ -154,6 +147,24 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: docker system prune -f -a --volumes
 
+    - name: Check API is responsive
+      if: |
+        (steps.list-changed.outputs.changed == 'true') ||
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
+      run: |
+        curl http://lagoon-api.$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/status
+        timeout 60 kubectl exec -n lagoon lagoon-core-api-db-0 -- sh -c "mysql -e 'show tables;' "
+
+    # Uncomment this snippet in your PR to enable the debug action
+    # https://github.com/marketplace/actions/debugging-with-tmate
+    
+    # Continue after getting a shell via: `touch continue`
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 5
+      continue-on-error: true
+
     - name: Run chart-testing (install) on lagoon-test
       if: |
         (steps.list-changed.outputs.changed == 'true') ||
@@ -162,17 +173,32 @@ jobs:
 
     # the following steps gather various debug information on test failure
 
-    - name: Inspect lagoon-remote pods
+    - name: See if api-db is to blame
       if: failure()
       run: |
-        kubectl describe pods --namespace=lagoon --selector=app.kubernetes.io/name=lagoon-remote
-        kubectl logs --tail=80 --namespace=lagoon --prefix --timestamps --all-containers --selector=app.kubernetes.io/name=lagoon-remote
+        curl http://lagoon-api.$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/status
+        timeout 60 kubectl exec -n lagoon lagoon-core-api-db-0 -- sh -c "mysql -e 'show tables;' "
+
+    - name: Inspect lagoon-test pods
+      if: failure()
+      run: |
+        kubectl get pods -A --selector=app.kubernetes.io/name=lagoon-test
+        kubectl describe pods --namespace=lagoon --selector=app.kubernetes.io/name=lagoon-test
+        kubectl logs --namespace=lagoon --prefix --timestamps --tail=-1 --all-containers --selector=app.kubernetes.io/name=lagoon-test
+
+    - name: Inspect lagoon-remote and lagoon-build-deploy pods
+      if: failure()
+      run: |
+        kubectl get pods -A -l 'app.kubernetes.io/instance in (lagoon-remote, lagoon-build-deploy)'
+        kubectl describe pods --namespace=lagoon -l 'app.kubernetes.io/instance in (lagoon-remote, lagoon-build-deploy)'
+        kubectl logs --namespace=lagoon --prefix --timestamps --tail=-1 --all-containers -l 'app.kubernetes.io/instance in (lagoon-remote, lagoon-build-deploy)'
 
     - name: Inspect lagoon-core pods
       if: failure()
       run: |
-        kubectl describe pods --namespace=lagoon --selector=app.kubernetes.io/name=lagoon-core
-        kubectl logs --tail=80 --namespace=lagoon --prefix --timestamps --all-containers --selector=app.kubernetes.io/name=lagoon-core
+        kubectl get pods -A --selector=app.kubernetes.io/instance=lagoon-core
+        kubectl describe pods --namespace=lagoon --selector=app.kubernetes.io/instance=lagoon-core
+        kubectl logs --namespace=lagoon --prefix --timestamps --tail=-1  --all-containers --selector=app.kubernetes.io/instance=lagoon-core
 
     - name: Inspect any remaining CI namespaces
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,6 @@ install-lagoon-core: install-minio
 		--values ./charts/lagoon-core/ci/linter-values.yaml \
 		$$([ $(IMAGE_TAG) ] && echo '--set imageTag=$(IMAGE_TAG)') \
 		$$([ $(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE) ] && echo '--set overwriteActiveStandbyTaskImage=$(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE)') \
-		--set "harborAdminPassword=none" \
-		--set "harborURL=http://none.com" \
-		--set "registry=none.com" \
 		--set "keycloakAPIURL=http://lagoon-keycloak.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/auth" \
 		--set "lagoonAPIURL=http://lagoon-api.$$($(KUBECTL) get nodes -o jsonpath='{.items[0].status.addresses[0].address}').nip.io:32080/graphql" \
 		--set actionsHandler.image.repository=$(IMAGE_REGISTRY)/actions-handler \

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.9.1
+appVersion: v2.9.2
 
 dependencies:
 - name: nats

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -1,12 +1,14 @@
 # Any values defined here are not used anywhere other than lint/CI.
 
+# To be deprecated - see uselagoon/lagoon#2907
+harborURL: http://disabled-only-use-harbor-via-deploy-controller.invalid
+harborAdminPassword: not-needed
+registry: disabled-only-use-harbor-via-deploy-controller.invalid
+
 # used in api
 elasticsearchURL: http://opendistro-es-client-service.opendistro-es.svc.cluster.local:9200
-harborURL: http://harbor:1234
-harborAdminPassword: harbor123
 kibanaURL: http://opendistro-es-kibana-svc.opendistro-es.svc.cluster.local:443
 logsDBAdminPassword: admin
-registry: registry.example.com:5000
 s3FilesAccessKeyID: minio
 s3FilesBucket: lagoon-files
 s3FilesHost: http://minio:9000


### PR DESCRIPTION
lagoon-core only release to match https://github.com/uselagoon/lagoon/releases/tag/v2.9.2


It also adds some reworked default settings for Harbor (using the *.invalid domain to ensure that it doesn't return), and adding additional debug steps into the github action