### PR TITLE
Add networkpolicy for docker-host

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.60.0
+version: 0.61.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/templates/docker-host.networkpolicy.yaml
+++ b/charts/lagoon-remote/templates/docker-host.networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "lagoon-remote.dockerHost.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.dockerHost.labels" . | nindent 4 }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/environment
+          operator: Exists
+      podSelector:
+        matchExpressions:
+        - key: lagoon.sh/buildName
+          operator: Exists
+  podSelector:
+    matchLabels:
+      {{- include "lagoon-remote.dockerHost.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
This improves the isolation of the lagoon namespace in remote clusters.
