### PR TITLE
chore: bump remote-controller version in lagoon-remote

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.14.1
+  version: 0.14.2
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.2
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.17.4
-digest: sha256:a029afa14623c46743f4462d9d7215c3efe2011c9f20427ab8ab072206248795
-generated: "2022-08-04T15:26:51.933315573+08:00"
+  version: 0.17.5
+digest: sha256:fd2ad3c260cabb389c06febe704c6ce5a6eb0fae8795a89264d80137bc6e0ca5
+generated: "2022-09-07T13:24:28.243368426+10:00"

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.14.2
+  version: 0.14.3
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -14,5 +14,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.17.5
-digest: sha256:fd2ad3c260cabb389c06febe704c6ce5a6eb0fae8795a89264d80137bc6e0ca5
-generated: "2022-09-07T13:24:28.243368426+10:00"
+digest: sha256:c6cdc05c1598917566eb3f36ba46a1ed6395ee5683a0ef9d8faafa3733f3c9a5
+generated: "2022-09-08T18:02:11.468925679+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.58.1
+version: 0.58.2
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
