### PR TITLE
Lagoon opensearch sync

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.0
+version: 1.17.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -1,4 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
@@ -619,5 +618,35 @@ Selector labels ssh-portal-api.
 {{- define "lagoon-core.sshPortalAPI.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-core.sshPortalAPI.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+{{/*
+Create a default fully qualified app name for opensearch-sync.
+*/}}
+{{- define "lagoon-core.opensearchSync.fullname" -}}
+{{- include "lagoon-core.fullname" . }}-opensearch-sync
+{{- end }}
+
+{{/*
+Common labels opensearch-sync.
+*/}}
+{{- define "lagoon-core.opensearchSync.labels" -}}
+helm.sh/chart: {{ include "lagoon-core.chart" . }}
+{{ include "lagoon-core.opensearchSync.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels opensearch-sync.
+*/}}
+{{- define "lagoon-core.opensearchSync.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-core.opensearchSync.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -10,6 +10,7 @@ This somewhat complex logic is intended to:
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
 {{- $keycloakServiceAPIClientSecret := coalesce .Values.keycloakServiceAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_SERVICE_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_SERVICE_API_CLIENT_SECRET" | empty)) }}
+{{- $keycloakLagoonOpensearchSyncClientSecret := coalesce .Values.keycloakLagoonOpensearchSyncClientSecret (ternary uuidv4 (index $data "KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonAdminPassword := coalesce .Values.keycloakLagoonAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | empty)) }}
 {{/* set the variable globally for access in NOTES */}}
 {{- $_ := set .Values "keycloakLagoonAdminPassword" $keycloakLagoonAdminPassword -}}
@@ -26,4 +27,5 @@ stringData:
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}
   KEYCLOAK_AUTH_SERVER_CLIENT_SECRET: {{ $keycloakAuthServerClientSecret | quote }}
   KEYCLOAK_SERVICE_API_CLIENT_SECRET: {{ $keycloakServiceAPIClientSecret | quote }}
+  KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET: {{ $keycloakLagoonOpensearchSyncClientSecret | quote }}
   KEYCLOAK_LAGOON_ADMIN_PASSWORD: {{ $keycloakLagoonAdminPassword | quote }}

--- a/charts/lagoon-core/templates/opensearch-sync.deployment.yaml
+++ b/charts/lagoon-core/templates/opensearch-sync.deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.opensearchSync.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-core.opensearchSync.fullname" . }}
+  labels:
+    {{- include "lagoon-core.opensearchSync.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.opensearchSync.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/keycloak.secret: {{ include (print $.Template.BasePath "/keycloak.secret.yaml") . | sha256sum }}
+        checksum/api.secret: {{ include (print $.Template.BasePath "/api.secret.yaml") . | sha256sum }}
+        checksum/api-db.secret: {{ include (print $.Template.BasePath "/api-db.secret.yaml") . | sha256sum }}
+        checksum/opensearch-sync.secret: {{ include (print $.Template.BasePath "/opensearch-sync.secret.yaml") . | sha256sum }}
+    {{- with .Values.opensearchSync.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "lagoon-core.opensearchSync.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml (coalesce .Values.opensearchSync.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
+      containers:
+      - name: lagoon-opensearch-sync
+        securityContext:
+          {{- toYaml .Values.opensearchSync.securityContext | nindent 10 }}
+        image: "{{ .Values.opensearchSync.image.repository }}:{{ coalesce .Values.opensearchSync.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.opensearchSync.image.pullPolicy }}
+        command:
+        - "/lagoon-opensearch-sync"
+        env:
+        {{- if .Values.opensearchSync.debug }}
+        - name: DEBUG
+          value: "true"
+        {{- end }}
+        - name: API_DB_ADDRESS
+          value: {{ include "lagoon-core.apiDB.fullname" . }}
+        - name: API_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.apiDB.fullname" . }}
+              key: API_DB_PASSWORD
+        - name: KEYCLOAK_BASE_URL
+          value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/
+        - name: KEYCLOAK_CLIENT_ID
+          value: lagoon-opensearch-sync
+        - name: KEYCLOAK_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET
+        - name: OPENSEARCH_BASE_URL
+          value: {{ required "A valid .Values.elasticsearchURL required!" .Values.elasticsearchURL | quote }}
+        - name: OPENSEARCH_DASHBOARDS_BASE_URL
+          value: {{ required "A valid .Values.kibanaURL required!" .Values.kibanaURL | quote }}
+        - name: OPENSEARCH_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.api.fullname" . }}
+              key: LOGSDB_ADMIN_PASSWORD
+        - name: OPENSEARCH_CA_CERTIFICATE
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.opensearchSync.fullname" . }}
+              key: OPENSEARCH_CA_CERTIFICATE
+      {{- range $key, $val := .Values.opensearchSync.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
+        resources:
+          {{- toYaml .Values.opensearchSync.resources | nindent 10 }}
+      {{- with .Values.opensearchSync.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.opensearchSync.fullname" . }}
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.opensearchSync.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.opensearchSync.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/opensearch-sync.secret.yaml
+++ b/charts/lagoon-core/templates/opensearch-sync.secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.opensearchSync.enabled -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-core.opensearchSync.fullname" . }}
+  labels:
+    {{- include "lagoon-core.opensearchSync.labels" . | nindent 4 }}
+stringData:
+  OPENSEARCH_CA_CERTIFICATE: {{ required "A valid .Values.opensearchSync.opensearchCACertificate required!" .Values.opensearchSync.caCertificate | quote }}
+{{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -783,10 +783,10 @@ sshPortalAPI:
 opensearchSync:
   enabled: false
   image:
-    repository: ghcr.io/uselagoon/lagoon-opensearch-sync/lagoon-opensearch-sync
+    repository: ghcr.io/uselagoon/lagoon-opensearch-sync
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.4.0"
+    tag: "v0.4.1"
 
   # debug logging toggle
   debug: false

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -779,3 +779,29 @@ sshPortalAPI:
     type: ClusterIP
     ports:
       metrics: 9911
+
+opensearchSync:
+  enabled: false
+  image:
+    repository: ghcr.io/uselagoon/lagoon-opensearch-sync/lagoon-opensearch-sync
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.4.0"
+
+  # debug logging toggle
+  debug: false
+
+  # root certificate for the server certificate presented by opensearch
+  opensearchCACertificate: |
+  # -----BEGIN CERTIFICATE-----
+  # ...
+  # -----END CERTIFICATE-----
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar


### PR DESCRIPTION
This PR adds [lagoon-opensearch-sync](https://github.com/uselagoon/lagoon-opensearch-sync) to the lagoon-core chart.

This new service is disabled by default, so nothing changes when upgrading an existing lagoon-core installation.

It is also disabled in CI since it has a hard requirement on an Opensearch service.
