### PR TITLE
Bump NATS subchart dependency

### DIFF
--- a/charts/lagoon-core/Chart.lock
+++ b/charts/lagoon-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.17.4
-digest: sha256:dbaa89b72356bdb7f9c6ec7ff9275b461c306f32d6a9834edd89d0764c1a3b2f
-generated: "2022-08-02T16:03:49.200761388+08:00"
+  version: 0.18.0
+digest: sha256:3e8ec1b8a84fb0142cfd4ffd629822536a5cfb46f1e1bff950a97c322edd2295
+generated: "2022-09-13T09:48:38.604636+08:00"

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.9.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -31,6 +31,6 @@ appVersion: v2.9.2
 
 dependencies:
 - name: nats
-  version: ~0.17.0
+  version: ~0.18.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled

--- a/charts/lagoon-core/README.md
+++ b/charts/lagoon-core/README.md
@@ -168,9 +168,25 @@ Lagoon uses S3 compatible storage for it, it can be configured via these helm va
 - `s3FilesAccessKeyID` - AccessKey for the S3 Bucket
 - `s3FilesSecretAccessKey` - AccessKey Secret for the S3 Bucket
 
-## Securing NATS
+## NATS
 
-This section only applies if using the experimental NATS ssh-portal support.
+This section only applies if using NATS for ssh-portal support.
+NATS and ssh-portal are currently disabled by default.
+
+### Configuring NATS
+
+The minimum configuration required to enable NATS is:
+
+```
+nats:
+  enabled: true
+  cluster:
+    name: lagoon-core-example
+```
+
+Note that the cluster name used in Lagoon Core and each Lagoon Remote _must_ be unique in order for NATS routing to work correctly.
+
+### Securing NATS
 
 Refer to the [NATS TLS documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls) when reading this section.
 
@@ -196,12 +212,12 @@ nats:
 
 See the CI values for an example of this configuration.
 
-### Getting a TLS certificate secret
+#### Getting a TLS certificate secret
 
 Ideally this will be a valid public TLS certificate.
 You can also use a private certificate authority but this is ([not recommended](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls#self-signed-certificates-for-testing) by upstream NATS.
 
-#### Public CA
+##### Public CA
 
 For example, if using `cert-manager`, use something like this:
 ```
@@ -219,7 +235,7 @@ spec:
 ```
 Note that since NATS uses a `LoadBalancer` service (not an `Ingress`) HTTP-01 solver cannot be used.
 
-#### Private CA
+##### Private CA
 
 You can generate a valid CA, leafnode server, and leafnode client certificate using `cfssl` and the configuration files in the `nats-tls/` directory.
 

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -129,6 +129,8 @@ workflows:
 # enable nats cluster (and optionally natsbox debugger)
 nats:
   enabled: true
+  cluster:
+    name: lagoon-core-ci-example
   # natsbox:
   #   enabled: true
   #   # additional labels are required due to the network policy

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.2
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.17.5
-digest: sha256:c6cdc05c1598917566eb3f36ba46a1ed6395ee5683a0ef9d8faafa3733f3c9a5
-generated: "2022-09-08T18:02:11.468925679+10:00"
+  version: 0.18.0
+digest: sha256:3012e54049d120650b0ab4e6af134e8641ae588a19423ffebfacfa30f440e077
+generated: "2022-09-13T09:48:39.26951397+08:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -43,6 +43,6 @@ dependencies:
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-insights-remote.enabled
 - name: nats
-  version: ~0.17.0
+  version: ~0.18.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.59.1
+version: 0.60.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/README.md
+++ b/charts/lagoon-remote/README.md
@@ -35,3 +35,25 @@ helm uninstall lagoon-remote
 ## ServiceAccounts
 
 * The `kubernetesbuilddeploy` serviceaccount is bound to `cluster-admin`.
+
+## NATS
+
+This section only applies if using NATS for ssh-portal support.
+NATS and ssh-portal are currently disabled by default.
+
+### Configuring NATS
+
+The minimum configuration required to enable NATS is:
+
+```
+nats:
+  enabled: true
+  cluster:
+    name: lagoon-remote-example
+```
+
+Note that the cluster name used in Lagoon Core and each Lagoon Remote _must_ be unique in order for NATS routing to work correctly.
+
+### Securing NATS
+
+See the Lagoon Core chart README for instructions for securing NATS.

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -29,6 +29,8 @@ mxoutHost: mxout1.example.com
 
 nats:
   enabled: true
+  cluster:
+    name: lagoon-remote-ci-example
   # natsbox:
   #   enabled: true
   #   # additional labels are required due to the network policy


### PR DESCRIPTION
This PR updates the NATS chart dependency to pull in the new NATS v2.9.0.