### PR TITLE
Allow docker-host network policy to be optionally disabled

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.61.0
+version: 0.61.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-remote/templates/docker-host.networkpolicy.yaml
+++ b/charts/lagoon-remote/templates/docker-host.networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dockerHost.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,3 +21,4 @@ spec:
       {{- include "lagoon-remote.dockerHost.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Ingress
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -61,6 +61,10 @@ dockerHost:
     #
     # className: managed-premium
 
+  networkPolicy:
+    # Specifies whether the docker-host network policy should be enabled
+    enabled: true
+
   serviceAccount:
     # Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Currently the docker-host network policy is enforced with no way to disable it without removing it manually.

closes #485 
