### PR TITLE
Container memory limit

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,6 +16,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.15.0
+version: 0.16.0
 
 appVersion: v0.6.0

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -214,6 +214,10 @@ spec:
           value: {{ . | quote }}
         {{- end }}
         {{- end }}
+        {{- with .Values.adminLagoonFeatureFlag.containerMemoryLimit }}
+        - name: ADMIN_LAGOON_FEATURE_FLAG_CONTAINER_MEMORY_LIMIT
+          value: {{ . | quote}}
+        {{- end }}
         - name: PENDING_MESSAGE_CRON
           value: {{ .Values.pendingMessageCron | quote }}
         - name: RABBITMQ_HOSTNAME

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -79,6 +79,10 @@ extraEnvs:
 
 # the following values are defaults which may be overridden
 
+adminLagoonFeatureFlag:
+  # Set the memory resource limit for containers deployed by Lagoon.
+  containerMemoryLimit: 16Gi
+
 # rootlessBuildPods tells the build-deploy controller to create build pods
 # which do not run as root. See https://github.com/amazeeio/lagoon/pull/2481
 # for details.


### PR DESCRIPTION
This change supports container memory limits for containers deployed by Lagoon.

See https://github.com/uselagoon/build-deploy-tool/pull/120 for the other part of this feature.
