### PR TITLE
chore: bump remote-controller version in lagoon-remote

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.14.3
+  version: 0.15.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -14,5 +14,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.18.0
-digest: sha256:3012e54049d120650b0ab4e6af134e8641ae588a19423ffebfacfa30f440e077
-generated: "2022-09-13T09:48:39.26951397+08:00"
+digest: sha256:bebff0f36b3944e203344f5fc9c5dacff35c6a253c0e5c5d16ae649bcebbe217
+generated: "2022-10-05T09:10:46.336962729+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.61.1
+version: 0.62.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -27,7 +27,7 @@ appVersion: v2.9.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.14.0
+  version: ~0.15.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
