### PR TITLE
Bump lagoon-core HPAs to autoscaling/v2

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.1
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 - name: shreddedbacon
   email: ben.jackson@amazee.io
   url: https://amazee.io
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.23.0-0"
 
 # Application charts are a collection of templates that can be packaged into
 # versioned archives to be deployed.

--- a/charts/lagoon-core/templates/actions-handler.hpa.yaml
+++ b/charts/lagoon-core/templates/actions-handler.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.actionsHandler.enabled .Values.actionsHandler.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.actionsHandler.fullname" . }}

--- a/charts/lagoon-core/templates/api.hpa.yaml
+++ b/charts/lagoon-core/templates/api.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.api.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.api.fullname" . }}

--- a/charts/lagoon-core/templates/auth-server.hpa.yaml
+++ b/charts/lagoon-core/templates/auth-server.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.authServer.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.authServer.fullname" . }}

--- a/charts/lagoon-core/templates/backup-handler.hpa.yaml
+++ b/charts/lagoon-core/templates/backup-handler.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.backupHandler.enabled .Values.backupHandler.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.backupHandler.fullname" . }}

--- a/charts/lagoon-core/templates/broker.hpa.yaml
+++ b/charts/lagoon-core/templates/broker.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.broker.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.broker.fullname" . }}

--- a/charts/lagoon-core/templates/drush-alias.hpa.yaml
+++ b/charts/lagoon-core/templates/drush-alias.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.drushAlias.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.drushAlias.fullname" . }}

--- a/charts/lagoon-core/templates/insights-handler.hpa.yaml
+++ b/charts/lagoon-core/templates/insights-handler.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.insightsHandler.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.insightsHandler.fullname" . }}

--- a/charts/lagoon-core/templates/logs2notifications.hpa.yaml
+++ b/charts/lagoon-core/templates/logs2notifications.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.logs2notifications.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core..fullname" . }}

--- a/charts/lagoon-core/templates/ssh-portal-api.hpa.yaml
+++ b/charts/lagoon-core/templates/ssh-portal-api.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.sshPortalAPI.enabled .Values.sshPortalAPI.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.sshPortalAPI.fullname" . }}

--- a/charts/lagoon-core/templates/ssh.hpa.yaml
+++ b/charts/lagoon-core/templates/ssh.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ssh.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.ssh.fullname" . }}

--- a/charts/lagoon-core/templates/ui.hpa.yaml
+++ b/charts/lagoon-core/templates/ui.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ui.enabled .Values.ui.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.ui.fullname" . }}

--- a/charts/lagoon-core/templates/webhook-handler.hpa.yaml
+++ b/charts/lagoon-core/templates/webhook-handler.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.webhookHandler.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.webhookHandler.fullname" . }}

--- a/charts/lagoon-core/templates/webhooks2tasks.hpa.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.webhooks2tasks.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-core.webhooks2tasks.fullname" . }}


### PR DESCRIPTION
This change bumps the autoscaling API used by the `lagoon-core` HPAs to `autoscaling/v2`.

This is a breaking change because it means the chart no longer supports kubernetes < 1.23.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126

Closes: #496 
