### PR TITLE
Lagoon logs concentrator hpa v2

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,4 +19,4 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.42.0
+version: 0.43.0

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 - name: smlx
   email: scott.leggett@amazee.io
   url: https://amazee.io
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.23.0-0"
 
 # Application charts are a collection of templates that can be packaged into
 # versioned archives to be deployed.

--- a/charts/lagoon-logs-concentrator/templates/hpa.yaml
+++ b/charts/lagoon-logs-concentrator/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "lagoon-logs-concentrator.fullname" . }}


### PR DESCRIPTION
This change bumps the autoscaling API used by the `lagoon-logs-concentrator` HPA to `autoscaling/v2`.

This is a breaking change because it means the chart no longer supports kubernetes < 1.23.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126