### PR TITLE
chore: use the new syntax for output variables in github actions

### DIFF
--- a/.github/workflows/lint-test-matrix.yaml
+++ b/.github/workflows/lint-test-matrix.yaml
@@ -31,7 +31,7 @@ jobs:
       run: |
         changed=$(ct list-changed --config ./default.ct.yaml)
         if [[ "$changed" ]]; then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
           echo "$changed"
         fi
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -83,7 +83,7 @@ jobs:
       run: |
         changed=$(ct list-changed --config ./default.ct.yaml)
         if [[ "$changed" ]]; then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
           echo "$changed"
         fi
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -57,7 +57,7 @@ jobs:
       run: |
         changed=$(ct list-changed --config ./test-suite-lint.ct.yaml)
         if [[ "$changed" ]]; then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
           echo "$changed"
         fi
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
