### PR TITLE
Bump ssh-portal version in lagoon-remote and lagoon-core

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -34,3 +34,8 @@ dependencies:
   version: ~0.18.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Bumped ssh-portal-api to v0.22.0.

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.1
+version: 1.13.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -791,7 +791,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.20.1"
+    tag: "v0.22.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.64.0
+version: 0.65.0
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -45,5 +45,5 @@ dependencies:
 
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Support for storage-calculator, disabled by default
+    - kind: changed
+      description: Bumped ssh-portal to v0.22.0.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -119,7 +119,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.20.1"
+    tag: "v0.22.0"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
This is a minor update to the ssh-portal which switches JWT parsing/validation libraries to a better maintained one. See https://github.com/uselagoon/lagoon-ssh-portal/pull/126.
