### PR TITLE
Assorted CI dependency updates

### DIFF
--- a/.github/workflows/lint-test-matrix.yaml
+++ b/.github/workflows/lint-test-matrix.yaml
@@ -11,9 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         kindest_node_version:
-        - v1.21.14@sha256:ad5b7446dd8332439f22a1efdac73670f0da158c00f0a70b45716e7ef3fae20b
-        - v1.23.12@sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
-        - v1.24.6@sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
+        - v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1
+        - v1.22.15@sha256:7d9708c4b0873f0fe2e171e2b1b7f45ae89482617778c1c875f1053d4cef2e41
+        - v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+        - v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -41,7 +42,7 @@ jobs:
     - name: Create kind cluster
       uses: helm/kind-action@v1.4.0
       with:
-        version: v0.14.0
+        version: v0.17.0
         node_image: kindest/node:${{ matrix.kindest_node_version }}
       if: |
         (steps.list-changed.outputs.changed == 'true') ||

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -93,8 +93,8 @@ jobs:
     - name: Create kind cluster
       uses: helm/kind-action@v1.4.0
       with:
-        version: v0.14.0
-        node_image: kindest/node:v1.22.15@sha256:bfd5eaae36849bfb3c1e3b9442f3da17d730718248939d9d547e86bbac5da586
+        version: v0.17.0
+        node_image: kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
       if: |
         (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -76,8 +76,8 @@ jobs:
         (steps.list-changed.outputs.changed == 'true') ||
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       with:
-        version: v0.14.0
-        node_image: kindest/node:v1.23.12@sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
+        version: v0.17.0
+        node_image: kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
         config: test-suite.kind-config.yaml
 
     - name: Install kubectl
@@ -129,15 +129,15 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 'needs-testing'))
       run: |
         cd /tmp
-        curl -sSLO https://github.com/itchyny/gojq/releases/download/v0.11.1/gojq_v0.11.1_linux_amd64.tar.gz
-        tar -xf ./gojq_v0.11.1_linux_amd64.tar.gz
-        sudo cp /tmp/gojq_v0.11.1_linux_amd64/gojq /usr/local/bin/jq
+        curl -sSLO https://github.com/itchyny/gojq/releases/download/v0.12.9/gojq_v0.12.9_linux_amd64.tar.gz
+        tar -xf ./gojq_v0.12.9_linux_amd64.tar.gz
+        sudo cp /tmp/gojq_v0.12.9_linux_amd64/gojq /usr/local/bin/jq
 
     - name: Install kubens and kubectl alias
       run: |
         cd /tmp
-        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens_v0.9.1_linux_x86_64.tar.gz
-        tar -xf ./kubens_v0.9.1_linux_x86_64.tar.gz
+        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_linux_x86_64.tar.gz
+        tar -xf ./kubens_v0.9.4_linux_x86_64.tar.gz
         sudo cp /tmp/kubens /usr/local/bin/kubens
         sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -136,7 +136,7 @@ jobs:
     - name: Install kubens and kubectl alias
       run: |
         cd /tmp
-        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_linux_x86_64.tar.gz
+        curl -sSLO https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_linux_x86_64.tar.gz
         tar -xf ./kubens_v0.9.4_linux_x86_64.tar.gz
         sudo cp /tmp/kubens /usr/local/bin/kubens
         sudo ln -s /usr/local/bin/kubectl /usr/local/bin/kc

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install-postgresql:
 		--namespace postgresql \
 		--wait \
 		--timeout $(TIMEOUT) \
-		$$($(KUBECTL) get ns postgresql > /dev/null 2>&1 && echo --set auth.postgresPassword=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgresql-password" | @base64d')) \
+		$$($(KUBECTL) get ns postgresql > /dev/null 2>&1 && echo --set auth.postgresPassword=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgres-password" | @base64d')) \
 		--version=11.9.13 \
 		postgresql \
 		bitnami/postgresql
@@ -248,7 +248,7 @@ install-lagoon-remote: install-lagoon-build-deploy install-lagoon-core install-m
 		--set "dbaas-operator.mariadbProviders.development.user=root" \
 		--set "dbaas-operator.postgresqlProviders.development.environment=development" \
 		--set "dbaas-operator.postgresqlProviders.development.hostname=postgresql.postgresql.svc.cluster.local" \
-		--set "dbaas-operator.postgresqlProviders.development.password=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgresql-password" | @base64d')" \
+		--set "dbaas-operator.postgresqlProviders.development.password=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgres-password" | @base64d')" \
 		--set "dbaas-operator.postgresqlProviders.development.port=5432" \
 		--set "dbaas-operator.postgresqlProviders.development.user=postgres" \
 		--set "dbaas-operator.mongodbProviders.development.environment=development" \

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ install-ingress:
 		--set controller.config.proxy-body-size=100m \
 		--set controller.watchIngressWithoutClass=true \
 		--set controller.ingressClassResource.default=true \
-		--version=4.1.3 \
+		--version=4.3.0 \
 		ingress-nginx \
 		ingress-nginx/ingress-nginx
 
@@ -98,7 +98,7 @@ install-registry: install-ingress
 		--set clair.enabled=false \
 		--set notary.enabled=false \
 		--set trivy.enabled=false \
-		--version=1.9.1 \
+		--version=1.10.1 \
 		registry \
 		harbor/harbor
 
@@ -125,7 +125,7 @@ install-mariadb:
 		--wait \
 		--timeout $(TIMEOUT) \
 		$$($(KUBECTL) get ns mariadb > /dev/null 2>&1 && echo --set auth.rootPassword=$$($(KUBECTL) get secret --namespace mariadb mariadb -o json | $(JQ) -r '.data."mariadb-root-password" | @base64d')) \
-		--version=10.5.1 \
+		--version=11.3.4 \
 		mariadb \
 		bitnami/mariadb
 
@@ -139,7 +139,7 @@ install-postgresql:
 		--wait \
 		--timeout $(TIMEOUT) \
 		$$($(KUBECTL) get ns postgresql > /dev/null 2>&1 && echo --set postgresqlPassword=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgresql-password" | @base64d')) \
-		--version=10.16.2 \
+		--version=11.9.13 \
 		postgresql \
 		bitnami/postgresql
 
@@ -167,7 +167,7 @@ install-minio: install-ingress
 		--timeout $(TIMEOUT) \
 		--set auth.rootUser=lagoonFilesAccessKey,auth.rootPassword=lagoonFilesSecretKey \
 		--set defaultBuckets=lagoon-files \
-		--version=11.6.3 \
+		--version=11.10.13 \
 		minio \
 		bitnami/minio
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install-postgresql:
 		--namespace postgresql \
 		--wait \
 		--timeout $(TIMEOUT) \
-		$$($(KUBECTL) get ns postgresql > /dev/null 2>&1 && echo --set postgresqlPassword=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgresql-password" | @base64d')) \
+		$$($(KUBECTL) get ns postgresql > /dev/null 2>&1 && echo --set auth.postgresPassword=$$($(KUBECTL) get secret --namespace postgresql postgresql -o json | $(JQ) -r '.data."postgresql-password" | @base64d')) \
 		--version=11.9.13 \
 		postgresql \
 		bitnami/postgresql


### PR DESCRIPTION
This PR updates the following components in CI:

* Default Kubernetes version to 1.23 for all tests (and matrixes 1.21/1.22/1.24/1.25 for lint-test)
* Updates helm/kind-action to the latest version (and accompanying kindest image updates
* Updates gojq and kubens to latest in test-suite
* Updates ingress-nginx, MinIO and Harbor to most recent helm-charts
* Updates MariaDB, PostgreSQL to more recent compatible versions for DBaaS testing (and fixes chart values update)