### PR TITLE
chore: bump remote-controller version

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -19,3 +19,10 @@ type: application
 version: 0.17.0
 
 appVersion: v0.7.0
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Bumped remote-controller to v0.7.0.
+    - kind: added
+      description: Configuration items for build and task pod timeouts

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,6 +16,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.16.0
+version: 0.17.0
 
-appVersion: v0.6.0
+appVersion: v0.7.0

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -156,6 +156,12 @@ spec:
         {{- with .Values.QoSDefault }}
         - "--qos-default={{ . }}"
         {{- end }}
+        {{- with .Values.timeoutForLongRunningBuildPods }}
+        - "--timeout-longrunning-build-pod-cleanup={{ . }}"
+        {{- end }}
+        {{- with .Values.timeoutForLongRunningTaskPods }}
+        - "--timeout-longrunning-task-pod-cleanup={{ . }}"
+        {{- end }}
         {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -79,6 +79,10 @@ extraEnvs:
 
 # the following values are defaults which may be overridden
 
+# the number of hours a build/task pod can run before forcefully cancelled.
+timeoutForLongRunningBuildPods: 6
+timeoutForLongRunningTaskPods: 6
+
 adminLagoonFeatureFlag:
   # Set the memory resource limit for containers deployed by Lagoon.
   containerMemoryLimit: 16Gi


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Bump the `remote-controller` version and add new configuration items for build/task pod timeout settings.