### PR TITLE
chore: bump lagoon-build-deploy version

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.18.2
-digest: sha256:ba96097ba5751e7c5669cdaeb90dca02d1e35c1fc6b3713834daf18d89f52105
-generated: "2022-11-11T19:37:25.47337239+11:00"
+digest: sha256:9b96ce17cd70d6530d5bbbaa6a3de8f5a6f3f3130b8650c8bcaf4e2ec06eca40
+generated: "2022-11-12T10:38:41.332054599+11:00"

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.15.0
+  version: 0.17.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.2
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.18.0
-digest: sha256:bebff0f36b3944e203344f5fc9c5dacff35c6a253c0e5c5d16ae649bcebbe217
-generated: "2022-10-05T09:10:46.336962729+11:00"
+  version: 0.18.2
+digest: sha256:ba96097ba5751e7c5669cdaeb90dca02d1e35c1fc6b3713834daf18d89f52105
+generated: "2022-11-11T19:37:25.47337239+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.66.0
+version: 0.67.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -50,5 +50,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Bumped lagoon-build-deploy to v0.17.0.
-    - kind: changed
-      description: Bumped nats to v0.18.2.

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,11 +19,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.65.0
+version: 0.66.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.15.0
+  version: ~0.17.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri
@@ -46,4 +46,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Bumped ssh-portal to v0.22.0.
+      description: Bumped lagoon-build-deploy to v0.17.0.
+    - kind: changed
+      description: Bumped nats to v0.18.2.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

This bumps the `lagoon-build-deploy` version to the latest `v0.17.0` chart version.
