### PR TITLE
Add ssh-token service

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.18.0
+version: 1.19.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -40,5 +40,9 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: Add support for experimental ssh-token service.
     - kind: changed
-      description: updated drush-alias to v3.1.0 for ssh-portal support
+      description: Allow disabling the ssh and auth-server services.
+    - kind: changed
+      description: Update ssh-portal-api to v0.27.0.

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -118,6 +118,31 @@ sshPortalAPI:
   serviceMonitor:
     enabled: false
 
+sshToken:
+  enabled: true
+  replicaCount: 1
+  debug: true
+  serviceMonitor:
+    enabled: false
+  service:
+    type: NodePort
+    ports:
+      sshserver: 2223
+  hostKeys:
+    ed25519: |
+      -----BEGIN OPENSSH PRIVATE KEY-----
+      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+      QyNTUxOQAAACA/YqlzbdTqR53BHcDhvP0EVepZ66ZIT2HaXSpxdzwhMgAAAIgc+EPKHPhD
+      ygAAAAtzc2gtZWQyNTUxOQAAACA/YqlzbdTqR53BHcDhvP0EVepZ66ZIT2HaXSpxdzwhMg
+      AAAECW61aE011GKLSFBJ82G6oGEOjJSUV3STx16veSvX38kD9iqXNt1OpHncEdwOG8/QRV
+      6lnrpkhPYdpdKnF3PCEyAAAAAAECAwQF
+      -----END OPENSSH PRIVATE KEY-----
+
+controllerhandler:
+  replicaCount: 1
+  image:
+    repository: uselagoon/controllerhandler
+
 imageTag: ""
 
 workflows:

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -643,3 +643,33 @@ app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-core.opensearchSync.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+
+{{/*
+Create a default fully qualified app name for ssh-token.
+*/}}
+{{- define "lagoon-core.sshToken.fullname" -}}
+{{- include "lagoon-core.fullname" . }}-ssh-token
+{{- end }}
+
+{{/*
+Common labels ssh-token.
+*/}}
+{{- define "lagoon-core.sshToken.labels" -}}
+helm.sh/chart: {{ include "lagoon-core.chart" . }}
+{{ include "lagoon-core.sshToken.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels ssh-token.
+*/}}
+{{- define "lagoon-core.sshToken.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-core.sshToken.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -587,13 +587,6 @@ Create a default fully qualified app name for the nats subchart.
 
 
 {{/*
-Create the name of the service account to use for ssh-portal-api.
-*/}}
-{{- define "lagoon-core.sshPortalAPI.serviceAccountName" -}}
-{{- default (include "lagoon-core.sshPortalAPI.fullname" .) .Values.sshPortalAPI.serviceAccount.name }}
-{{- end }}
-
-{{/*
 Create a default fully qualified app name for ssh-portal-api.
 */}}
 {{- define "lagoon-core.sshPortalAPI.fullname" -}}

--- a/charts/lagoon-core/templates/auth-server.deployment.yaml
+++ b/charts/lagoon-core/templates/auth-server.deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssh.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -94,3 +95,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/auth-server.hpa.yaml
+++ b/charts/lagoon-core/templates/auth-server.hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authServer.autoscaling.enabled -}}
+{{- if and .Values.ssh.enabled .Values.authServer.autoscaling.enabled -}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/lagoon-core/templates/auth-server.service.yaml
+++ b/charts/lagoon-core/templates/auth-server.service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssh.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     name: http
   selector:
     {{- include "lagoon-core.authServer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-token.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-token.deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.sshToken.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-core.sshToken.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.sshToken.autoscaling.enabled }}
+  replicas: {{ .Values.sshToken.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.sshToken.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/keycloak.secret: {{ include (print $.Template.BasePath "/keycloak.secret.yaml") . | sha256sum }}
+        checksum/api-db.secret: {{ include (print $.Template.BasePath "/api-db.secret.yaml") . | sha256sum }}
+    {{- with .Values.sshToken.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "lagoon-core.sshToken.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml (coalesce .Values.sshToken.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
+      containers:
+      - name: ssh-token
+        securityContext:
+          {{- toYaml .Values.sshToken.securityContext | nindent 10 }}
+        image: "{{ .Values.sshToken.image.repository }}:{{ coalesce .Values.sshToken.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.sshToken.image.pullPolicy }}
+        command:
+        - "/ssh-token"
+        env:
+        {{- if .Values.sshToken.debug }}
+        - name: DEBUG
+          value: "true"
+        {{- end }}
+        - name: KEYCLOAK_BASE_URL
+          value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/
+        - name: KEYCLOAK_AUTH_SERVER_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_AUTH_SERVER_CLIENT_SECRET
+        - name: KEYCLOAK_SERVICE_API_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_SERVICE_API_CLIENT_SECRET
+        - name: API_DB_ADDRESS
+          value: {{ include "lagoon-core.apiDB.fullname" . }}
+        - name: API_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.apiDB.fullname" . }}
+              key: API_DB_PASSWORD
+        envFrom:
+        - secretRef:
+            name: {{ include "lagoon-core.sshToken.fullname" . }}
+      {{- range $key, $val := .Values.sshToken.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 9948
+          protocol: TCP
+        - name: sshserver
+          containerPort: 2222
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.sshToken.resources | nindent 10 }}
+      {{- with .Values.sshToken.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.sshToken.fullname" . }}
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.sshToken.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sshToken.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-token.hpa.yaml
+++ b/charts/lagoon-core/templates/ssh-token.hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.sshToken.enabled .Values.sshToken.autoscaling.enabled -}}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lagoon-core.sshToken.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lagoon-core.sshToken.fullname" . }}
+  minReplicas: {{ .Values.sshToken.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sshToken.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.sshToken.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.sshToken.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.sshToken.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.sshToken.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-token.secret.yaml
+++ b/charts/lagoon-core/templates/ssh-token.secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.sshToken.enabled -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-core.sshToken.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.sshToken.hostKeys.ecdsa }}
+  HOST_KEY_ECDSA: |-
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.sshToken.hostKeys.ed25519 }}
+  HOST_KEY_ED25519: |-
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.sshToken.hostKeys.rsa }}
+  HOST_KEY_RSA: |-
+    {{- . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-token.service.yaml
+++ b/charts/lagoon-core/templates/ssh-token.service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.sshToken.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-core.sshToken.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.sshToken.service.type }}
+  ports:
+  - port: {{ .Values.sshToken.service.ports.sshserver }}
+    targetPort: sshserver
+    name: sshserver
+  selector:
+    {{- include "lagoon-core.sshToken.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-core.sshToken.fullname" . }}-metrics
+  labels:
+    metrics-only: "true"
+    {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.sshToken.metricsService.type }}
+  ports:
+  - port: {{ .Values.sshToken.metricsService.ports.metrics }}
+    targetPort: metrics
+    name: metrics
+  selector:
+    {{- include "lagoon-core.sshToken.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-token.servicemonitor.yaml
+++ b/charts/lagoon-core/templates/ssh-token.servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.sshToken.enabled .Values.sshToken.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lagoon-core.sshToken.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.sshToken.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh.deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssh.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -98,3 +99,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh.hpa.yaml
+++ b/charts/lagoon-core/templates/ssh.hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ssh.autoscaling.enabled -}}
+{{- if and .Values.ssh.enabled .Values.ssh.autoscaling.enabled -}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/lagoon-core/templates/ssh.service.yaml
+++ b/charts/lagoon-core/templates/ssh.service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssh.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
       name: ssh
   selector:
     {{- include "lagoon-core.ssh.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -745,7 +745,7 @@ sshPortalAPI:
   replicaCount: 2
   image:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "v0.24.0"
 

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -623,6 +623,7 @@ drushAlias:
     # targetMemoryUtilizationPercentage: 80
 
 ssh:
+  enabled: true
   replicaCount: 2
   image:
     repository: uselagoon/ssh

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -747,7 +747,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.24.0"
+    tag: "v0.27.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -806,3 +806,47 @@ opensearchSync:
 
   additionalEnvs:
   #   FOO: Bar
+
+sshToken:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.27.0"
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  serviceMonitor:
+    enabled: true
+
+  service:
+    type: LoadBalancer
+    ports:
+      sshserver: 22
+
+  metricsService:
+    type: ClusterIP
+    ports:
+      metrics: 9948
+
+  # host keys, PEM encoded
+  hostKeys:
+    ecdsa: ""
+    ed25519: ""
+    rsa: ""

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.69.2
+version: 0.70.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,6 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated lagoon-build-deploy to v0.18.1
-    - kind: changed
-      description: Updated nats to v0.18.3
+      description: Update ssh-portal to v0.27.0.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -122,7 +122,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.24.0"
+    tag: "v0.27.0"
 
   service:
     type: LoadBalancer

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -11,6 +11,14 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.40.0
+version: 0.41.0
 
 appVersion: v2.10.0
+
+# This section is used to collect a changelog for artifacthub.io
+# It should be started afresh for each release
+# Valid supported kinds are added, changed, deprecated, removed, fixed and security
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: Add ssh-token environment variables to test container.

--- a/charts/lagoon-test/templates/secret.yaml
+++ b/charts/lagoon-test/templates/secret.yaml
@@ -27,6 +27,8 @@ stringData:
   SSH_PORT: {{ .Values.sshPort | quote }}
   SSH_PORTAL_HOST: {{ .Values.sshPortalHost | quote }}
   SSH_PORTAL_PORT: {{ .Values.sshPortalPort | quote }}
+  SSH_TOKEN_HOST: {{ .Values.sshTokenHost | quote }}
+  SSH_TOKEN_PORT: {{ .Values.sshTokenPort | quote }}
   SSH_PRIVATE_KEY: |
     {{- .Values.sshPrivateKey | nindent 4 }}
   WEBHOOK_HOST: {{ .Values.webhookHost | quote }}

--- a/charts/lagoon-test/values.yaml
+++ b/charts/lagoon-test/values.yaml
@@ -14,6 +14,8 @@ sshHost: lagoon-core-ssh
 sshPort: 2020
 sshPortalHost: lagoon-remote-ssh-portal
 sshPortalPort: 2222
+sshTokenHost: lagoon-core-ssh-token
+sshTokenPort: 2223
 sshPrivateKey: |-
   -----BEGIN RSA PRIVATE KEY-----
   MIIJKAIBAAKCAgEAxGZZrOV7Islo5p51Moabfd1YB8qbHvQZfJDZJmSU4jNxMf8G


### PR DESCRIPTION
lagoon-core:
* Add the [ssh-token](https://github.com/uselagoon/lagoon-ssh-portal#ssh-token) service. This service is disabled by default to avoid an upgrade spinning up a new load balancer on chart upgrade, but it should probably be enabled by default eventually?
* Allow disabling the ssh and auth-server services via `ssh.enabled`.
* Update ssh-portal-api to match ssh-token version.

lagoon-remote:
* Update ssh-portal version to match the other ssh services.

lagoon-test:
* Add ssh-token environment variables to test container.
