### PR TITLE
Bump ssh-portal and ssh-portal-api versions

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.14.0
+version: 1.15.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated NATS sub-chart to 0.18.2
+      description: Update ssh-portal-api to latest version.

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -791,7 +791,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.22.0"
+    tag: "v0.24.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.67.0
+version: 0.68.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -49,4 +49,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Bumped lagoon-build-deploy to v0.17.0.
+      description: Update ssh-portal to latest version.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -119,7 +119,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.22.0"
+    tag: "v0.24.0"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
No functional changes, but ssh-portal has been refactored, more test coverage, and JWT validation improvements.
