### PR TITLE
Lagoon-remote-updates

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.17.0
+  version: 0.18.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -11,5 +11,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.18.2
-digest: sha256:07221e1170df6092501b029e7fc3ae6698b191883cdf1db1bb50e54a02477c2c
-generated: "2022-11-17T13:14:00.077328865+11:00"
+digest: sha256:20ad0e5df3c30e32d133f228812ee159747b57f63cc2d16a065b5e00cbc89b8f
+generated: "2022-11-23T16:27:46.243226121+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -45,4 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated lagoon-build-deploy sub-chart to v0.18.0
+      description: Updated remote-calculator to v0.2.3

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,11 +19,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.69.0
+version: 0.69.1
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.17.0
+  version: ~0.18.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri
@@ -45,6 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Converted to Global variables.
-    - kind: added
-      description: Included Insights Remote instead of subchart.
+      description: Updated lagoon-build-deploy sub-chart to v0.18.0

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -347,4 +347,4 @@ storageCalculator:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.2.1
+    tag: v0.2.3


### PR DESCRIPTION
closes #517 
* Updated remote-calculator to v0.2.3
* Updated lagoon-build-deploy sub-chart to v0.18.0