### PR TITLE
chore: bump lagoon-build-deploy and lagoon-core

### DIFF
--- a/charts/lagoon-core/Chart.lock
+++ b/charts/lagoon-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.18.2
-digest: sha256:07111301495aa6b86b973b797eda1a333728dbebd2626c54bd935cca43a20dc4
-generated: "2022-11-09T13:25:35.196455291+11:00"
+  version: 0.18.3
+digest: sha256:23ec68e1604f1b9f90bd9571e7e17c6101524be61b304de03f378a31a6c55fbd
+generated: "2022-11-24T11:53:36.184266854+11:00"

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.0
+version: 1.15.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Update ssh-portal-api to latest version.
+      description: Updated nats to v0.18.3

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.18.0
+  version: 0.18.1
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -10,6 +10,6 @@ dependencies:
   version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.18.2
-digest: sha256:20ad0e5df3c30e32d133f228812ee159747b57f63cc2d16a065b5e00cbc89b8f
-generated: "2022-11-23T16:27:46.243226121+11:00"
+  version: 0.18.3
+digest: sha256:1018b08ca55534e25872062782c15d58d4ae03129374ce015e62306ce319b353
+generated: "2022-11-24T11:53:05.091683188+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.69.1
+version: 0.69.2
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,4 +45,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated remote-calculator to v0.2.3
+      description: Updated lagoon-build-deploy to v0.18.1
+    - kind: changed
+      description: Updated nats to v0.18.3


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Updated: lagoon-build-deploy to v0.18.1 and NATS to v0.18.3 in lagoon-remote
Updated: NATS to v0.18.3 in lagoon-core
