### PR TITLE
Bump logging-operator dependency

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.17.7
-digest: sha256:12db5e3fa5d67bdc4307758150cc57e3ef0c5893095b40735d989935cac2c318
-generated: "2022-06-02T14:25:04.188887195+08:00"
+  version: 3.17.10
+digest: sha256:293ac5ba13713b7edcc8fb655e8fd402c6d466c57edcdc9886f1336b39815b8c
+generated: "2022-11-28T22:12:54.57492083+08:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.72.0
+version: 0.73.0
 
 dependencies:
 - name: logging-operator
@@ -33,6 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump logs-dispatcher to v3.2.0 and use dots to read lagoon.sh labels
-    - kind: added
-      description: Add integration test suite
+      description: Update logging-operator dependency to v3.17.10


### PR DESCRIPTION
Bump the logging-operator dependency to the latest version which adds support for k8s 1.25+.
