### PR TITLE
Bump logs dispatcher

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.73.0
+version: 0.74.0
 
 dependencies:
 - name: logging-operator
@@ -33,4 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Update logging-operator dependency to v3.17.10
+      description: Update logs-dispatcher to v3.3.0.

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -19,7 +19,7 @@ logsDispatcher:
     repository: uselagoon/logs-dispatcher
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is "latest".
-    tag: "v3.2.0"
+    tag: "v3.3.0"
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
Closes #509 by bumping the logs-dispatcher image to a version containing a fluentd k8s plugin version which logs missing pod errors at `debug` the way the plugin used to in v2.