### PR TITLE
Remove old lagoon-gatekeeper install instructions

### DIFF
--- a/charts/lagoon-gatekeeper/README.md
+++ b/charts/lagoon-gatekeeper/README.md
@@ -2,18 +2,6 @@
 
 This chart installs the [gatekeeper](https://github.com/open-policy-agent/gatekeeper) admission controller as well as policies tailored for Lagoon.
 
-## Installation
-
-Gatekeeper works by generating CRDs of `constraints` from `constrainttemplates`.
-This means that when you first install Gatekeeper, the CRDs are not created until Gatekeeper parses the configured `constrainttemplates` and creates the associated CRDs.
-
-For this reason this chart must be installed in two stages:
-
-1. install chart with default values. Wait for gatekeeper to create the `*.constraints.gatekeeper.sh` CRDs (`kubectl get crd -w`).
-2. install with `--set=constraints.create=true`.
-
-The `constraints.create=false` value stops the chart from trying to create any custom resources which aren't yet defined.
-
 ## Policy and chart configuration
 
 There is currently no other configuration for this chart.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
The need to use `--set=constraints.create=true` was removed in https://github.com/uselagoon/lagoon-charts/commit/45499092472b472250b0afddf41562f6f45b138a.