### PR TITLE
Update api-data-watcher-pusher startup probe

### DIFF
--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -11,6 +11,14 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.40.0
+version: 0.41.0
 
 appVersion: v2.10.0
+
+# This section is used to collect a changelog for artifacthub.io
+# It should be started afresh for each release
+# Valid supported kinds are added, changed, deprecated, removed, fixed and security
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Use new startup probe on api-data-watcher-pusher.

--- a/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml
+++ b/charts/lagoon-test/templates/local-api-data-watcher-pusher.deployment.yaml
@@ -49,16 +49,13 @@ spec:
               key: JWTSECRET
         - name: TOKEN
           value: {{ required "A valid .Values.token required!" .Values.token | quote }}
-        readinessProbe:
+        startupProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            # this container uses wget to inject test fixtures into the lagoon api.
-            # once wget stops running, it's good to go.
-            - "for i in $(seq 4); do pgrep wget && exit 1 || sleep 1; done"
-          initialDelaySeconds: 32
-          timeoutSeconds: 8
+            - test
+            - -f
+            - /tmp/api-data-pushed
+          failureThreshold: 90
         resources:
           {{- toYaml .Values.localAPIDataWatcherPusher.resources | nindent 10 }}
       {{- with .Values.localAPIDataWatcherPusher.nodeSelector }}


### PR DESCRIPTION
Update the api-data-watcher-pusher startup probe for the new readiness file added in https://github.com/uselagoon/lagoon/pull/3348

This is a draft because the linked PR won't make into a Lagoon release until v2.12.0, at which point this PR can be rebased.