### PR TITLE
Bump ssh-portal, ssh-portal-api, and ssh-token service versions

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.19.0
+version: 1.20.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -40,9 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for experimental ssh-token service.
     - kind: changed
-      description: Allow disabling the ssh and auth-server services.
-    - kind: changed
-      description: Update ssh-portal-api to v0.27.0.
+      description: Update ssh-portal-api and ssh-token to v0.27.1.

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -747,7 +747,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.27.0"
+    tag: "v0.27.1"
 
   podAnnotations: {}
 
@@ -814,7 +814,7 @@ sshToken:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.27.0"
+    tag: "v0.27.1"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.70.0
+version: 0.72.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,4 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Update ssh-portal to v0.27.0.
+      description: Update ssh-portal to v0.27.1.

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -122,7 +122,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.27.0"
+    tag: "v0.27.1"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
Upgrade to the latest versions which fix https://github.com/uselagoon/lagoon-ssh-portal/issues/158
