### PR TITLE
fix: handle forward target hosts with dynamic DNS

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.74.0
+version: 0.74.1
 
 dependencies:
 - name: logging-operator
@@ -32,5 +32,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update logs-dispatcher to v3.3.0.
+    - kind: fixed
+      description: Handle forward target hosts with dynamic DNS.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -459,6 +459,8 @@ data:
           # endpoint
           keepalive true # makes sure the connection is not recreated every second
           keepalive_timeout 10m # reconnect after 10mins in order to handle DNS changes, etc.
+          # avoid persistent DNS cache in case the server IP changes
+          expire_dns_cache 21600 # refresh cached DNS every 6 hours
           <server>
             port "#{ENV['LOGS_FORWARD_HOST_PORT']}"
             host "#{ENV['LOGS_FORWARD_HOST']}"


### PR DESCRIPTION
This fixes a bug with the logs dispatcher where a stale DNS cache causes logs to be dropped.
