### PR TITLE
Bump CDN logs collector image version

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.74.1
+version: 0.74.2
 
 dependencies:
 - name: logging-operator
@@ -33,4 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Handle forward target hosts with dynamic DNS.
+      description: Use version v3.3.0 of logs-dispatcher for the cdn logs collector.

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -121,7 +121,7 @@ cdnLogsCollector:
     repository: uselagoon/logs-dispatcher
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is "latest".
-    tag: "v3.1.0"
+    tag: "v3.3.0"
 
   podAnnotations: {}
 


### PR DESCRIPTION
Bump the image used by the CDN logs collector to the latest logs-dispatcher image. I missed this when I bumped the logs-dispatcher image in a previous PR.