### PR TITLE
Switch logs-concentrator default configuration from Elasticsearch to Opensearch

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,4 +19,16 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.42.0
+version: 0.43.0
+
+# This section is used to collect a changelog for artifacthub.io
+# It should be started afresh for each release
+# Valid supported kinds are added, changed, deprecated, removed, fixed and security
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Use version v3.1.0 of logs-concentrator which adds the opensearch fluentd plugin.
+    - kind: changed
+      description: Switch default chart configuration from Elasticsearch to Opensearch.
+    - kind: removed
+      description: Default chart support for Elasticsearch.

--- a/charts/lagoon-logs-concentrator/README.md
+++ b/charts/lagoon-logs-concentrator/README.md
@@ -1,7 +1,7 @@
 # Logs Concentrator
 
 This service collects logs from logs-dispatchers (both local and remote) using
-fluentd's forward protocol, and sends them to Elasticsearch.
+fluentd's forward protocol, and sends them to Opensearch.
 
 ## Configuration
 

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -1,7 +1,7 @@
 # values for CI linting and testing
-elasticsearchHost: "logs-db-service.elasticsearch.svc.cluster.local"
-elasticsearchAdminUser: "admin"
-elasticsearchAdminPassword: "securepass"
+opensearchHost: "logs-db-service.opensearch.svc.cluster.local"
+opensearchAdminUser: "admin"
+opensearchAdminPassword: "securepass"
 tls:
   caCert: |-
     -----BEGIN CERTIFICATE-----

--- a/charts/lagoon-logs-concentrator/ci/linter-values.yaml
+++ b/charts/lagoon-logs-concentrator/ci/linter-values.yaml
@@ -41,8 +41,8 @@ users:
   password: "securepass"
 - username: "example2"
   password: "securepass"
-# allow fluentd to start without connecting to ES
-verifyESVersionAtStartup: false
+# allow fluentd to start without connecting to Opensearch
+verifyOSVersionAtStartup: false
 serviceMonitor:
   enabled: false
 

--- a/charts/lagoon-logs-concentrator/templates/NOTES.txt
+++ b/charts/lagoon-logs-concentrator/templates/NOTES.txt
@@ -2,4 +2,4 @@ Thank you for installing {{ .Chart.Name }}.
 
 Your release is named {{ .Release.Name }}.
 
-Your logs are now being sent to {{ default "http" .Values.elasticsearchScheme }}://{{ .Values.elasticsearchHost }}:{{ default "9200" .Values.elasticsearchHostPort }}
+Your logs are now being sent to {{ default "http" .Values.opensearchScheme }}://{{ .Values.opensearchHost }}:{{ default "9200" .Values.opensearchHostPort }}

--- a/charts/lagoon-logs-concentrator/templates/env.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/env.configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
 data:
-  ELASTICSEARCH_HOST: {{ required "A valid .Values.elasticsearchHost required!" .Values.elasticsearchHost }}
-{{- if .Values.elasticsearchHostPort }}
-  ELASTICSEARCH_HOST_PORT: {{ .Values.elasticsearchHostPort | quote }}
+  OPENSEARCH_HOST: {{ required "A valid .Values.opensearchHost required!" .Values.opensearchHost }}
+{{- if .Values.opensearchHostPort }}
+  OPENSEARCH_HOST_PORT: {{ .Values.opensearchHostPort | quote }}
 {{- end }}
-{{- if .Values.elasticsearchScheme }}
-  ELASTICSEARCH_SCHEME: {{ .Values.elasticsearchScheme }}
+{{- if .Values.opensearchScheme }}
+  OPENSEARCH_SCHEME: {{ .Values.opensearchScheme }}
 {{- end }}

--- a/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
@@ -99,8 +99,8 @@ data:
 {{- if not .Values.opensearchTLSVerify }}
       ssl_verify false
 {{- end }}
-{{- if not .Values.verifyESVersionAtStartup }}
-      verify_es_version_at_startup false
+{{- if not .Values.verifyOSVersionAtStartup }}
+      verify_os_version_at_startup false
 {{- end }}
 {{- if .Values.opensearchCACert }}
       ca_file /fluentd/es-tls/ca.crt

--- a/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
@@ -54,20 +54,20 @@ data:
       </metric>
     </filter>
 
-    # send to elasticsearch
+    # send to opensearch
     <match in_forward.**>
-      @type elasticsearch
-      @id out_elasticsearch
-      # be more verbose about elasticsearch problems
+      @type opensearch
+      @id out_opensearch
+      # be more verbose about opensearch problems
       @log_level info
       # ingestion
       target_index_key index_name
       include_timestamp true
       time_key time
       # endpoint
-      host "#{ENV['ELASTICSEARCH_HOST']}"
-      port "#{ENV.fetch('ELASTICSEARCH_HOST_PORT','9200')}"
-      scheme "#{ENV.fetch('ELASTICSEARCH_SCHEME','http')}"
+      host "#{ENV['OPENSEARCH_HOST']}"
+      port "#{ENV.fetch('OPENSEARCH_HOST_PORT','9200')}"
+      scheme "#{ENV.fetch('OPENSEARCH_SCHEME','http')}"
       ssl_min_version TLSv1_2
       ssl_max_version TLSv1_3
       user "#{ENV['LOGSDB_ADMIN_USER']}"
@@ -80,7 +80,7 @@ data:
       log_es_400_reason true
       <buffer tag,index_name>
         @type file
-        path /fluentd/buffer/elasticsearch
+        path /fluentd/buffer/opensearch
         # buffer params (per worker)
         total_limit_size 8GB
         # flush params
@@ -89,20 +89,20 @@ data:
         flush_thread_burst_interval 0     # don't sleep if there are more chunks to be flushed
         retry_max_interval 30s            # limit exponential backoff period
         retry_timeout 12h                 # limit the time spent retrying chunk submission
-        chunk_limit_size 32MB             # chunks cannot be bigger than the max HTTP limit of Elasticsearch (which is 100MB)
+        chunk_limit_size 32MB             # chunks cannot be bigger than the max HTTP limit of Opensearch (which is 100MB)
         overflow_action drop_oldest_chunk # drop chunks once they reach retry limits
       </buffer>
       # silence warnings (these have no effect)
       type_name _doc
       suppress_type_name true
       ssl_version TLSv1_2
-{{- if not .Values.elasticsearchTLSVerify }}
+{{- if not .Values.opensearchTLSVerify }}
       ssl_verify false
 {{- end }}
 {{- if not .Values.verifyESVersionAtStartup }}
       verify_es_version_at_startup false
 {{- end }}
-{{- if .Values.elasticsearchCACert }}
+{{- if .Values.opensearchCACert }}
       ca_file /fluentd/es-tls/ca.crt
 {{- end }}
     </match>

--- a/charts/lagoon-logs-concentrator/templates/secret.yaml
+++ b/charts/lagoon-logs-concentrator/templates/secret.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
 stringData:
   FORWARD_SHARED_KEY: {{ required "A valid .Values.forwardSharedKey required!" .Values.forwardSharedKey }}
-  LOGSDB_ADMIN_USER: {{ .Values.elasticsearchAdminUser }}
-  LOGSDB_ADMIN_PASSWORD: {{ required "A valid .Values.elasticsearchAdminPassword required!" .Values.elasticsearchAdminPassword }}
+  LOGSDB_ADMIN_USER: {{ .Values.opensearchAdminUser }}
+  LOGSDB_ADMIN_PASSWORD: {{ required "A valid .Values.opensearchAdminPassword required!" .Values.opensearchAdminPassword }}
 ---
 apiVersion: v1
 kind: Secret
@@ -40,7 +40,7 @@ stringData:
       password "{{ .password }}"
     </user>
     {{- end }}
-{{- if .Values.elasticsearchCACert }}
+{{- if .Values.opensearchCACert }}
 ---
 apiVersion: v1
 kind: Secret
@@ -51,5 +51,5 @@ metadata:
     {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
 stringData:
   ca.crt: |
-    {{- .Values.elasticsearchCACert | nindent 4 }}
+    {{- .Values.opensearchCACert | nindent 4 }}
 {{- end }}

--- a/charts/lagoon-logs-concentrator/templates/statefulset.yaml
+++ b/charts/lagoon-logs-concentrator/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
           name: {{ include "lagoon-logs-concentrator.fullname" . }}-buffer
         - mountPath: /fluentd/tls/
           name: {{ include "lagoon-logs-concentrator.fullname" . }}-tls
-        {{- if .Values.elasticsearchCACert }}
+        {{- if .Values.opensearchCACert }}
         - mountPath: /fluentd/es-tls/
           name: {{ include "lagoon-logs-concentrator.fullname" . }}-es-tls
         {{- end }}
@@ -112,7 +112,7 @@ spec:
           defaultMode: 420
           secretName: {{ include "lagoon-logs-concentrator.fullname" . }}-users
         name: {{ include "lagoon-logs-concentrator.fullname" . }}-users
-      {{- if .Values.elasticsearchCACert }}
+      {{- if .Values.opensearchCACert }}
       - secret:
           defaultMode: 420
           secretName: {{ include "lagoon-logs-concentrator.fullname" . }}-es-tls

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -66,9 +66,9 @@ tolerations: []
 
 affinity: {}
 
-# this is set to false in CI so that the concentrator will start without ES
+# this is set to false in CI so that the concentrator will start without OS
 # being installed
-verifyESVersionAtStartup: true
+verifyOSVersionAtStartup: true
 # Verification of the certificate presented by the opensearch endpoint can
 # be disabled by setting this option to false, which can be useful for CI and
 # manual testing. Do not disable this in production.

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: uselagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is "latest".
-  tag: "v3.0.0"
+  tag: "v3.1.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -69,19 +69,19 @@ affinity: {}
 # this is set to false in CI so that the concentrator will start without ES
 # being installed
 verifyESVersionAtStartup: true
-# Verification of the certificate presented by the elasticsearch endpoint can
+# Verification of the certificate presented by the opensearch endpoint can
 # be disabled by setting this option to false, which can be useful for CI and
 # manual testing. Do not disable this in production.
-elasticsearchTLSVerify: true
+opensearchTLSVerify: true
 
 # The values below must be supplied during installation.
 # Certificates should be provided in PEM format, and are generated as described
 # in the README.
-elasticsearchAdminUser: "admin"
+opensearchAdminUser: "admin"
 
 # Sample data shown below.
-# elasticsearchHost: "logs-db-service.elasticsearch.svc.cluster.local"
-# elasticsearchAdminPassword: "securepass"
+# opensearchHost: "logs-db-service.opensearch.svc.cluster.local"
+# opensearchAdminPassword: "securepass"
 # tls:
 #   caCert: |
 #     -----BEGIN CERTIFICATE-----
@@ -104,14 +104,14 @@ elasticsearchAdminUser: "admin"
 
 # The values below are optional.
 
-# elasticsearchHostPort: "443"  # default 9200
-# elasticsearchScheme: https    # default http
+# opensearchHostPort: "443"  # default 9200
+# opensearchScheme: https    # default http
 # service:
 #   type: LoadBalancer          # default ClusterIP. Set to LoadBalancer to
 #                               # expose the logs-concentrator service
 #                               # publicly.
 #
-# elasticsearchCACert: |        # if elasticsearch is presenting a certificate
+# opensearchCACert: |           # if opensearch is presenting a certificate
 #   -----BEGIN CERTIFICATE----- # signed by a private CA, then define the CA
 #   ...                         # root certificate here.
 #   -----END CERTIFICATE-----


### PR DESCRIPTION
Opensearch and Elasticsearch have now diverged enough that there are separate fluentd plugins for each project.

The old fluentd Elasticsearch plugin doesn't work anymore with Opensearch v2, so this PR switches the default logs-concentrator image to a version which includes the fluentd Opensearch plugin (which supports Opensearch v2), and updates the default fluentd configuration to assume Opensearch log storage rather than Elasticsearch.

Note that this is a breaking change that requires users to update their values files.