### PR TITLE
Reduce DNS cache TTL in logs-dispatcher configuration

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.74.2
+version: 0.74.3
 
 dependencies:
 - name: logging-operator
@@ -33,4 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Use version v3.3.0 of logs-dispatcher for the cdn logs collector.
+      description: Reduce DNS cache TTL from 6 hours to 1 hour to adapt to DNS changes more quickly.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -460,7 +460,7 @@ data:
           keepalive true # makes sure the connection is not recreated every second
           keepalive_timeout 10m # reconnect after 10mins in order to handle DNS changes, etc.
           # avoid persistent DNS cache in case the server IP changes
-          expire_dns_cache 21600 # refresh cached DNS every 6 hours
+          expire_dns_cache 3600 # refresh cached DNS every hour
           <server>
             port "#{ENV['LOGS_FORWARD_HOST_PORT']}"
             host "#{ENV['LOGS_FORWARD_HOST']}"


### PR DESCRIPTION
This improves the speed at which the logging system adapts to DNS changes while keeping query load minimal.
