### PR TITLE
Bump SSH portal services

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.23.0
+version: 1.24.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,6 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: introduced minimum kubernetes version 1.21
-    - kind: changed
-      description: update Lagoon appVersion to v2.12.0
+      description: update ssh-token and ssh-portal-api services to v0.28.0

--- a/charts/lagoon-core/templates/ssh-portal-api.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-portal-api.deployment.yaml
@@ -43,6 +43,10 @@ spec:
         - name: DEBUG
           value: "true"
         {{- end }}
+        {{- if .Values.blockDeveloperSSH }}
+        - name: BLOCK_DEVELOPER_SSH
+          value: "true"
+        {{- end }}
         - name: KEYCLOAK_BASE_URL
           value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/
         - name: KEYCLOAK_SERVICE_API_CLIENT_SECRET

--- a/charts/lagoon-core/templates/ssh-token.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-token.deployment.yaml
@@ -38,6 +38,10 @@ spec:
         - name: DEBUG
           value: "true"
         {{- end }}
+        {{- if .Values.blockDeveloperSSH }}
+        - name: BLOCK_DEVELOPER_SSH
+          value: "true"
+        {{- end }}
         - name: KEYCLOAK_BASE_URL
           value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/
         - name: KEYCLOAK_AUTH_SERVER_CLIENT_SECRET

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -84,6 +84,15 @@ podSecurityContext:
 # on the service level, if not set it falls back to chart appVersion.
 imageTag: ""
 
+# This value is false by default, which means that Developers can SSH to
+# Development environments as per the Lagoon documentation
+# (https://docs.lagoon.sh/administering-lagoon/rbac/#developer).
+# Set this to true to:
+# * block Developers from SSH access to Lagoon environments; and
+# * stop Developers from getting a redirect message when trying to SSH into the
+#   ssh-token service.
+# blockDeveloperSSH: false
+
 # the following services are part of the lagoon-core chart
 
 api:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -747,7 +747,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.27.2"
+    tag: "v0.28.0"
 
   podAnnotations: {}
 
@@ -814,7 +814,7 @@ sshToken:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.27.2"
+    tag: "v0.28.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.74.0
+version: 0.75.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,8 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: introduced minimum kubernetes version 1.21
-    - kind: changed
-      description: update docker-host image to v3.3.0
-    - kind: changed
-      description: update lagoon-build-deploy chart to v0.19.0
+      description: update ssh-portal service to v0.28.0

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -122,7 +122,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.27.2"
+    tag: "v0.28.0"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
This PR bumps the ssh-portal services to v0.28.0 which, among other things, adds support for blocking Developer SSH access. See https://github.com/uselagoon/lagoon-ssh-portal/pull/172 for details.