### PR TITLE
Update db migration handling and lagoon-core appVersion v2.14.1

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.25.1
+version: 1.26.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.13.0
+appVersion: v2.14.0
 
 dependencies:
 - name: nats
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: added a job to handle migrations instead of utilizing the api init container
+    - kind: changed
+      description: update Lagoon appVersion to v2.14.0

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -27,7 +27,7 @@ version: 1.26.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.14.0
+appVersion: v2.14.1
 
 dependencies:
 - name: nats
@@ -43,4 +43,4 @@ annotations:
     - kind: changed
       description: added a job to handle migrations instead of utilizing the api init container
     - kind: changed
-      description: update Lagoon appVersion to v2.14.0
+      description: update Lagoon appVersion to v2.14.1

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.25.0
+version: 1.25.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.13.0
+      description: added a job to handle migrations instead of utilizing the api init container

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -75,6 +75,12 @@ app.kubernetes.io/component: {{ include "lagoon-core.api.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{/*
+Create a default fully qualified app name for api-migratedb-job.
+*/}}
+{{- define "lagoon-core.apiMigrateDB.fullname" -}}
+{{- include "lagoon-core.fullname" . }}-api-migratedb
+{{- end }}
 
 
 {{/*

--- a/charts/lagoon-core/templates/api-db.job.yaml
+++ b/charts/lagoon-core/templates/api-db.job.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Job
+metadata:
+  name: api-db-migration-job
+  labels:
+    {{- include "lagoon-core.api.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    spec:
+      restartPolicy: Never
+      securityContext:
+          {{- toYaml .Values.api.securityContext | nindent 10 }}
+      terminationGracePeriodSeconds: 120
+      containers:
+      - name: api-init
+        args:
+        - ./node_modules/.bin/knex migrate:list --cwd /app/services/api/database;
+          ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database
+        image: {{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        securityContext:
+          {{- toYaml .Values.api.securityContext | nindent 10 }}
+        env:
+        - name: API_DB_HOST
+          value: {{ include "lagoon-core.apiDB.fullname" . }}
+        - name: API_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.apiDB.fullname" . }}
+              key: API_DB_PASSWORD
+        - name: LAGOON_VERSION
+          value: {{ .Chart.AppVersion | replace "-" "." }}
+      {{- range $key, $val := .Values.api.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+      {{- end }}           
+    {{- with .Values.api.nodeSelector }}
+    nodeSelector:
+      {{ toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.api.tolerations }}
+    tolerations:
+      {{ toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -199,32 +199,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-      - name: api-init
-        args:
-        - ./node_modules/.bin/knex migrate:list --cwd /app/services/api/database;
-          ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database;
-        command:
-        - /bin/sh
-        - -c
-        securityContext:
-          {{- toYaml .Values.api.securityContext | nindent 10 }}
-        image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-        env:
-        - name: API_DB_HOST
-          value: {{ include "lagoon-core.apiDB.fullname" . }}
-        - name: API_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "lagoon-core.apiDB.fullname" . }}
-              key: API_DB_PASSWORD
-        - name: LAGOON_VERSION
-          value: {{ .Chart.AppVersion | replace "-" "." }}
-      {{- range $key, $val := .Values.api.additionalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-      {{- end }}
         resources:
           {{- toYaml .Values.api.resources | nindent 10 }}
       {{- with .Values.api.nodeSelector }}

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -199,13 +199,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        resources:
-          {{- toYaml .Values.api.resources | nindent 10 }}
-      {{- with .Values.api.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.api.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/charts/lagoon-core/templates/api.migratedb.job.yaml
+++ b/charts/lagoon-core/templates/api.migratedb.job.yaml
@@ -19,7 +19,7 @@ spec:
           {{- toYaml .Values.api.securityContext | nindent 10 }}
       terminationGracePeriodSeconds: 120
       containers:
-      - name: api-init
+      - name: api-migratedb
         args:
         - ./node_modules/.bin/knex migrate:list --cwd /app/services/api/database;
           ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database

--- a/charts/lagoon-core/templates/api.migratedb.job.yaml
+++ b/charts/lagoon-core/templates/api.migratedb.job.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       restartPolicy: Never
       securityContext:
-          {{- toYaml .Values.api.securityContext | nindent 10 }}
+          {{- toYaml .Values.api.securityContext | nindent 8 }}
       terminationGracePeriodSeconds: 120
       containers:
       - name: api-migratedb

--- a/charts/lagoon-core/templates/api.migratedb.job.yaml
+++ b/charts/lagoon-core/templates/api.migratedb.job.yaml
@@ -1,18 +1,18 @@
-apiVersion: v1
+apiVersion: batch/v1
 kind: Job
 metadata:
-  name: api-db-migration-job
+  name: {{ include "lagoon-core.apiMigrateDB.fullname" . }}
   labels:
     {{- include "lagoon-core.api.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-5"
 spec:
-  selector:
-    matchLabels:
-      {{- include "lagoon-core.api.selectorLabels" . | nindent 6 }}
+  backoffLimit: 2
   template:
     metadata:
+      labels:
+        {{- include "lagoon-core.api.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       securityContext:

--- a/charts/lagoon-core/templates/api.migratedb.job.yaml
+++ b/charts/lagoon-core/templates/api.migratedb.job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "lagoon-core.api.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": post-install, pre-upgrade
     "helm.sh/hook-weight": "-5"
 spec:
   backoffLimit: 2

--- a/charts/lagoon-core/templates/api.migratedb.job.yaml
+++ b/charts/lagoon-core/templates/api.migratedb.job.yaml
@@ -43,12 +43,14 @@ spec:
       {{- range $key, $val := .Values.api.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}
-      {{- end }}           
-    {{- with .Values.api.nodeSelector }}
-    nodeSelector:
-      {{ toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.api.tolerations }}
-    tolerations:
-      {{ toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+        resources:
+          {{- toYaml .Values.api.resources | nindent 10 }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.21.0
+  version: 0.21.1
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -11,5 +11,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.18.3
-digest: sha256:e966d8557fe3b2320e8a5de60d97ac07b09abde1582f4d64ab5464b2c8a3c0fe
-generated: "2023-03-28T11:42:36.364832993+11:00"
+digest: sha256:2eb0c097563b20360e6775e20be53a9e1a80ec6ae2a0151a9557aa7282f739e0
+generated: "2023-03-29T19:42:25.75332838+11:00"

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.19.0
+  version: 0.21.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -11,5 +11,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.18.3
-digest: sha256:8a65f7fdd1dd221e3e780b71b9c3e31e6918cb93f6e652527afc6302c294ab34
-generated: "2023-02-03T12:00:16.291578794+11:00"
+digest: sha256:e966d8557fe3b2320e8a5de60d97ac07b09abde1582f4d64ab5464b2c8a3c0fe
+generated: "2023-03-28T11:42:36.364832993+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,11 +19,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.75.0
+version: 0.76.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.19.0
+  version: ~0.21.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri
@@ -45,4 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update ssh-portal service to v0.28.0
+      description: update lagoon-build-deploy subchart to 0.21.0

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 
 version: 0.44.0
 
-appVersion: v2.14.0
+appVersion: v2.14.1
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -21,4 +21,4 @@ appVersion: v2.14.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.14.0
+      description: update Lagoon appVersion to v2.14.1

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -11,9 +11,9 @@ kubeVersion: ">= 1.21.0-0"
 
 type: application
 
-version: 0.43.0
+version: 0.44.0
 
-appVersion: v2.13.0
+appVersion: v2.14.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -21,4 +21,4 @@ appVersion: v2.13.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.13.0
+      description: update Lagoon appVersion to v2.14.0


### PR DESCRIPTION
Moves the functionality of the initContainer into a Job utilizing a chart hook.
This should the resolve the migration lock issues noted in #553.

closes #553 
