### PR TITLE
Update lagoon-opensearch-sync

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.26.0
+version: 1.27.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -40,7 +40,7 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
+    - kind: fixed
+      description: reference the Opensearch CA certificate correctly for lagoon-opensearch-sync template
     - kind: changed
-      description: added a job to handle migrations instead of utilizing the api init container
-    - kind: changed
-      description: update Lagoon appVersion to v2.14.1
+      description: update lagoon-opensearch-sync to v0.5.0

--- a/charts/lagoon-core/templates/opensearch-sync.secret.yaml
+++ b/charts/lagoon-core/templates/opensearch-sync.secret.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "lagoon-core.opensearchSync.labels" . | nindent 4 }}
 stringData:
-  OPENSEARCH_CA_CERTIFICATE: {{ required "A valid .Values.opensearchSync.opensearchCACertificate required!" .Values.opensearchSync.caCertificate | quote }}
+  OPENSEARCH_CA_CERTIFICATE: {{ required "A valid .Values.opensearchSync.opensearchCACertificate required!" .Values.opensearchSync.opensearchCACertificate | quote }}
 {{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -796,7 +796,7 @@ opensearchSync:
     repository: ghcr.io/uselagoon/lagoon-opensearch-sync
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.4.1"
+    tag: "v0.5.0"
 
   # debug logging toggle
   debug: false


### PR DESCRIPTION
Fix a typo in the lagoon-opensearch-sync secret template, and bump the version to v0.5.0.