### PR TITLE
Bump ssh-portal and associated services

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.32.0
+version: 1.33.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: add resource requests to lagoon-core deployments
+      description: update lagoon-ssh-portal-api and lagoon-ssh-token to v0.30.0

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -809,7 +809,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.28.0"
+    tag: "v0.30.0"
 
   podAnnotations: {}
 
@@ -882,7 +882,7 @@ sshToken:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.28.0"
+    tag: "v0.30.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.78.1
+version: 0.79.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,4 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon-build-deploy subchart to 0.23.1
+      description: update lagoon-ssh-portal to v0.30.0

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -120,9 +120,9 @@ sshPortal:
   replicaCount: 2
   image:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.28.0"
+    tag: "v0.30.0"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
Bump ssh-portal and associated services to the latest release `v0.30.0`.

This updates k8s API libraries for better compatibility with new versions of kubernetes, and also fixes some bugs:

* https://github.com/uselagoon/lagoon-ssh-portal/pull/197
* https://github.com/uselagoon/lagoon-ssh-portal/pull/207
* https://github.com/uselagoon/lagoon-ssh-portal/pull/240

This change also closes https://github.com/uselagoon/lagoon/issues/3431.
