### PR TITLE
Update dockerhost deployment

### DIFF
--- a/charts/lagoon-remote/templates/docker-host.deployment.yaml
+++ b/charts/lagoon-remote/templates/docker-host.deployment.yaml
@@ -56,7 +56,7 @@ spec:
           value: {{ . | quote }}
         {{- end }}
         - name: DOCKER_HOST
-          value: localhost
+          value: tcp://localhost:2375
         - name: REGISTRY
           value: {{ .Values.dockerHost.registry | quote }}
         - name: REPOSITORY_TO_UPDATE

--- a/charts/lagoon-remote/templates/docker-host.deployment.yaml
+++ b/charts/lagoon-remote/templates/docker-host.deployment.yaml
@@ -63,11 +63,6 @@ spec:
           value: {{ .Values.dockerHost.repositoryToUpdate | quote }}
         - name: PRUNE_IMAGES_UNTIL
           value: {{ .Values.dockerHost.pruneImagesUntil | quote }}
-        - name: CRONJOBS
-          value: |
-            22 1 * * * /lagoon/cronjob.sh "/prune-images.sh"
-            22 */4 * * * /lagoon/cronjob.sh "/remove-exited.sh"
-            */15 * * * * /lagoon/cronjob.sh "/update-images.sh"
         ports:
         - containerPort: 2375
           protocol: TCP


### PR DESCRIPTION
In conjunction with https://github.com/uselagoon/lagoon-service-images/pull/25

- Removes cronjob env vars as they've been re-written in Go via https://github.com/uselagoon/lagoon-service-images/pull/25
- Specifies protocol and port for use with the Go docker client

