### PR TITLE
chore: bump remote-controller to v0.12.0

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,11 +16,11 @@ kubeVersion: ">= 1.21.0-0"
 
 type: application
 
-version: 0.21.1
+version: 0.22.0
 
-appVersion: v0.11.1
+appVersion: v0.12.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller appVersion to v0.11.1
+      description: update remote-controller appVersion to v0.12.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Update [remote-controller to latest version 0.12.0](https://github.com/uselagoon/remote-controller/releases/tag/v0.12.0)