### PR TITLE
chore: bump lagoon-build-deploy subchart

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.21.1
+  version: 0.22.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -11,5 +11,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.18.3
-digest: sha256:2eb0c097563b20360e6775e20be53a9e1a80ec6ae2a0151a9557aa7282f739e0
-generated: "2023-03-29T19:42:25.75332838+11:00"
+digest: sha256:10455412d7c67ba412139825412301795bce15d2d21476324c147aa88d0cdd10
+generated: "2023-05-08T13:23:41.167070051+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,11 +19,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.76.0
+version: 0.77.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.21.0
+  version: ~0.22.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri
@@ -45,4 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon-build-deploy subchart to 0.21.0
+      description: update lagoon-build-deploy subchart to 0.22.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Bump the lagoon-build-deploy subchart to v0.22.0 which contains remote-controller v0.12.0.
