### PR TITLE
Add option to post process router logs

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.75.0
+version: 0.76.0
 
 dependencies:
 - name: logging-operator
@@ -32,5 +32,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: introduced minimum kubernetes version 1.21
+    - kind: added
+      description: added chart option to inject a configuration snippet for post-processing router logs

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -296,6 +296,9 @@ data:
           _dummy_ ${record['kubernetes'].delete('pod_name'); record['kubernetes'].delete('container_name'); record['kubernetes'].delete('pod_id'); nil}
         </record>
       </filter>
+      {{- with .Values.routerLogsPostProcess }}
+        {{- . | nindent 6 }}
+      {{- end }}
       <match lagoon.*.router.nginx>
         @type relabel
         @label @OUTPUT

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -368,6 +368,33 @@ keepIngressNginxController: false
 #
 # fluentbitPrivileged: true
 
+# Optional post-processing of router logs.
+#
+# This value allows you to insert a snippet of fluentd configuration into the
+# router logs processing pipeline directly before output. This can be used to
+# perform additional custom parsing of router logs. Please only use
+# <filter>...</filter>, and do not retag records in this field to avoid
+# breaking the log pipeline.
+#
+# This example will:
+# * set is_facet_page to true if the request_query field contains "f[0]".
+# * set is_search_page to true if the request_query field contains "search_api".
+# * set is_search_bot to true if the http_user_agent field is FooBot or BarBot.
+#
+# routerLogsPostProcess: |-
+#   <filter lagoon.*.router.nginx>
+#     @type record_modifier
+#     <record>
+#       is_facet_page ${!record["request_query"]&.match(/f\[0\]/).nil?}
+#     </record>
+#     <record>
+#       is_search_page ${!record["request_query"]&.match(/search_api/).nil?}
+#     </record>
+#     <record>
+#       is_search_bot ${!record["http_user_agent"]&.match(/\A(FooBot|BarBot)\z/).nil?}
+#     </record>
+#   </filter>
+
 # Install test fixtures into the cluster.
 # This should _only_ be used in a test cluster, because it creates namespaces for testing.
 # Do not set testFixtures.create=true in a production environment.


### PR DESCRIPTION
This feature allows injecting snippets of fluentd configuration into the
router logs processing pipeline directly before the logs are sent to the
output.

This feature is designed to allow injecting logic to manipulate or add
fields to router log records which make the log records easier to use in
Opensearch Dashboards. For example this can be used to inject a boolean
field into log records which can be used instead of a slow Opensearch
regex search.