### PR TITLE
Expose the metrics configuration of the Logging Operator subchart

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.76.0
+version: 0.77.0
 
 dependencies:
 - name: logging-operator
@@ -33,4 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: added chart option to inject a configuration snippet for post-processing router logs
+      description: add chart option to configure logging-operator subchart metrics, and enable the fluentbit ServiceMonitor by default

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -12,6 +12,10 @@ spec:
         fsGroup: 0
     scaling:
       replicas: {{ .Values.fluentdReplicaCount }}
+  {{- with .Values.fluentdMetrics }}
+    metrics:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   fluentbit:
     # Enable a default liveness check to avoid stuck pods.
     # At the time of writing this just hits the metrics endpoint.
@@ -25,5 +29,9 @@ spec:
   {{- with .Values.fluentbitTolerations }}
     tolerations:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.fluentbitMetrics }}
+    metrics:
+    {{- toYaml . | nindent 6 }}
   {{- end }}
   controlNamespace: {{ .Release.Namespace | quote }}

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -261,6 +261,18 @@ fluentbitTolerations:
   key: lagoon.sh/spot
   operator: Exists
 
+# Expose metrics of the Logging Operator's fluentbit daemonset and fluentd
+# statefulset via a Prometheus Operator compatible ServiceMonitor object.
+#
+# The fluentd serviceMonitor is disabled by default until a use-case is found.
+#
+# See here for full documentation of this field:
+# https://kube-logging.dev/docs/operation/logging-operator-monitoring/#metrics-variables
+fluentbitMetrics:
+  serviceMonitor: true
+# fluentdMetrics:
+#   serviceMonitor: true
+
 # This chart assumes the container runtime is containerd, which puts the log
 # message in the `message` field of the log record.
 #


### PR DESCRIPTION
This change exposes the metrics configuration of the Logging Operator subchart and enables the fluentbit daemonset's ServiceMonitor by default.

Closes: #570 