### PR TITLE
Bump lagoon-opensearch-sync to v0.7.0

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.29.0
+version: 1.30.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.15.0
+      description: bump lagoon-opensearch-sync version to v0.7.0

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -794,9 +794,9 @@ opensearchSync:
   enabled: false
   image:
     repository: ghcr.io/uselagoon/lagoon-opensearch-sync
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.5.0"
+    tag: "v0.7.0"
 
   # debug logging toggle
   debug: false


### PR DESCRIPTION
This version update fixes a lot of bugs and improves compatibility with the latest versions of Opensearch.

For the full changelog see [here](https://github.com/uselagoon/lagoon-opensearch-sync/compare/v0.5.0...v0.7.0).
