### PR TITLE
Logging operator update

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,6 +21,7 @@ jobs:
         helm repo add amazeeio https://amazeeio.github.io/charts/
         helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
         helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+        helm repo add kube-logging https://kube-logging.github.io/helm-charts
     - name: Generate helm templates
       run: |
         cd charts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         helm repo add amazeeio https://amazeeio.github.io/charts/
         helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
         helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+        helm repo add kube-logging https://kube-logging.github.io/helm-charts
 
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@v1.5.0

--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
-  repository: https://kubernetes-charts.banzaicloud.com
-  version: 3.17.10
-digest: sha256:293ac5ba13713b7edcc8fb655e8fd402c6d466c57edcdc9886f1336b39815b8c
-generated: "2022-11-28T22:12:54.57492083+08:00"
+  repository: https://kube-logging.github.io/helm-charts
+  version: 4.2.3
+digest: sha256:bcfec23e091d887e7892f70bddbcf33a09195e4140372028b25f8e16cf54436f
+generated: "2023-06-14T14:13:35.857841045+08:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -23,8 +23,8 @@ version: 0.77.0
 
 dependencies:
 - name: logging-operator
-  repository: https://kubernetes-charts.banzaicloud.com
-  version: ~3.17.0
+  repository: https://kube-logging.github.io/helm-charts
+  version: ~4.2.0
   condition: logging-operator.enabled
 
 # This section is used to collect a changelog for artifacthub.io

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.77.0
+version: 0.78.0
 
 dependencies:
 - name: logging-operator
@@ -32,5 +32,8 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: add chart option to configure logging-operator subchart metrics, and enable the fluentbit ServiceMonitor by default
+    - kind: changed
+      description: bump the logging-operator chart dependency to v4.2.3
+      links:
+        - name: Release Notes
+          url: https://github.com/uselagoon/lagoon-charts/releases/tag/lagoon-logging-0.78.0

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "lagoon-logging.labels" . | nindent 4 }}
 spec:
+  enableRecreateWorkloadOnImmutableFieldChange: true
   fluentd:
     security:
       podSecurityContext:

--- a/default.ct.yaml
+++ b/default.ct.yaml
@@ -10,6 +10,7 @@ chart-repos:
 - amazeeio=https://amazeeio.github.io/charts/
 - gatekeeper=https://open-policy-agent.github.io/gatekeeper/charts
 - nats=https://nats-io.github.io/k8s/helm/charts/
+- kube-logging=https://kube-logging.github.io/helm-charts
 excluded-charts:
 - lagoon-test
 - lagoon-gatekeeper


### PR DESCRIPTION
This PR updates the logging operator, which is the underlying log collection system of the `lagoon-logging` chart.

Importantly, this update requires some manual CRD updates to be applied after the chart is upgraded, if upgrading from an earlier version of `lagoon-logging`:

```bash
helm repo add kube-logging https://kube-logging.github.io/helm-charts
helm show crds kube-logging/logging-operator --version 4.2.3 | kubectl apply --server-side --force-conflicts -f -
```

I'll also add the instructions above to the release notes.