### PR TITLE
Updates insights-remote clusterrole to access ns and secrets

### DIFF
--- a/charts/lagoon-insights-remote/Chart.yaml
+++ b/charts/lagoon-insights-remote/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm chart for Lagoon remote insights
 home: https://github.com/uselagoon/lagoon-charts
 icon: https://raw.githubusercontent.com/uselagoon/lagoon-charts/main/icon.png
 maintainers:
-- name: bomoko
-  email: blaize.kaye@amazee.io
-  url: https://amazee.io
+  - name: bomoko
+    email: blaize.kaye@amazee.io
+    url: https://amazee.io
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lagoon-insights-remote/templates/clusterrole.yaml
+++ b/charts/lagoon-insights-remote/templates/clusterrole.yaml
@@ -5,9 +5,18 @@ metadata:
   labels:
     {{- include "lagoon-insights-remote.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - "*"
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - secrets
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - namespaces


### PR DESCRIPTION
Newer versions of insights-remote need to CRUD secrets as well as read namespace details - this is to support a mechanism that injects tokens into environments that can be used to write facts and problems to a local web services.
The token is used to secure the process and is linked to the environment name.
