### PR TITLE
Bump remote-controller to version 0.13.0

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,11 +16,11 @@ kubeVersion: ">= 1.21.0-0"
 
 type: application
 
-version: 0.22.0
+version: 0.22.1
 
-appVersion: v0.12.0
+appVersion: v0.12.1
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller appVersion to v0.12.0
+      description: update remote-controller appVersion to v0.12.1

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -24,3 +24,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update remote-controller appVersion to v0.13.0
+    - kind: changed
+      description: introduced new values to eventually deprecate taskAPIHost, taskSSHHost, and taskSSHPort. See values.yaml for details

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,11 +16,11 @@ kubeVersion: ">= 1.21.0-0"
 
 type: application
 
-version: 0.22.1
+version: 0.23.0
 
-appVersion: v0.12.1
+appVersion: v0.13.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller appVersion to v0.12.1
+      description: update remote-controller appVersion to v0.13.0

--- a/charts/lagoon-build-deploy/ci/linter-values.yaml
+++ b/charts/lagoon-build-deploy/ci/linter-values.yaml
@@ -2,6 +2,8 @@ rabbitMQUsername: lagoon
 rabbitMQPassword: ci
 rabbitMQHostname: lagoon-core-broker
 lagoonTargetName: ci-local-control-k8s
-taskSSHHost: lagoon-core-ssh.lagoon.svc
-taskSSHPort: 2020
-taskAPIHost: http://lagoon-core-api.lagoon.svc:80
+sshPortalHost: lagoon-remote-ssh-portal.lagoon.svc
+sshPortalPort: 22
+lagoonTokenHost: lagoon-core-token.lagoon.svc
+lagoonTokenPort: 22
+lagoonAPIHost: http://lagoon-core-api.lagoon.svc:80

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -178,27 +178,27 @@ spec:
         - name: OVERRIDE_BUILD_DEPLOY_DIND_IMAGE
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.sshPortalHost }}
+        {{- with .Values.sshPortalHost | default .Values.taskSSHHost}}
         - name: LAGOON_CONFIG_SSH_HOST
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.sshPortalPort }}
+        {{- with .Values.sshPortalPort | default .Values.taskSSHPort }}
         - name: LAGOON_CONFIG_SSH_PORT
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.taskSSHHost }}
+        {{- with .Values.lagoonTokenHost | default .Values.taskSSHHost }}
         - name: LAGOON_CONFIG_TOKEN_HOST
           value: {{ . | quote }}
         - name: TASK_SSH_HOST
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.taskSSHPort }}
+        {{- with .Values.lagoonTokenPort | default .Values.taskSSHPort }}
         - name: LAGOON_CONFIG_TOKEN_PORT
           value: {{ . | quote }}
         - name: TASK_SSH_PORT
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.taskAPIHost }}
+        {{- with .Values.lagoonAPIHost | default .Values.taskAPIHost }}
         - name: LAGOON_CONFIG_API_HOST
           value: {{ . | quote }}
         - name: TASK_API_HOST

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -178,15 +178,29 @@ spec:
         - name: OVERRIDE_BUILD_DEPLOY_DIND_IMAGE
           value: {{ . | quote }}
         {{- end }}
+        {{- with .Values.sshPortalHost }}
+        - name: LAGOON_CONFIG_SSH_HOST
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.sshPortalPort }}
+        - name: LAGOON_CONFIG_SSH_PORT
+          value: {{ . | quote }}
+        {{- end }}
         {{- with .Values.taskSSHHost }}
+        - name: LAGOON_CONFIG_TOKEN_HOST
+          value: {{ . | quote }}
         - name: TASK_SSH_HOST
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.taskSSHPort }}
+        - name: LAGOON_CONFIG_TOKEN_PORT
+          value: {{ . | quote }}
         - name: TASK_SSH_PORT
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.taskAPIHost }}
+        - name: LAGOON_CONFIG_API_HOST
+          value: {{ . | quote }}
         - name: TASK_API_HOST
           value: {{ . | quote }}
         {{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -5,9 +5,19 @@ lagoonTargetName: ""
 rabbitMQHostname: ""
 rabbitMQPassword: ""
 rabbitMQUsername: ""
+
+# taskSSHHost is the hostname for the lagoon token service
 taskSSHHost: ""
+# taskSSHPort is the port number for the lagoon token service
 taskSSHPort: ""
+# taskAPIHost is the lagoon graphql API hostname, omitting the `/graphql, eg: https://api.example.com
 taskAPIHost: ""
+# sshPortalHost is the hostname for this remote clusters ssh portal service
+# eg: lagoon-remote-ssh-portal.lagoon.svc can be used for this for internal cluster communications, but a public dns can also be set
+sshPortalHost: ""
+# sshPortalPort is the port number for this remote clusters ssh portal service
+sshPortalPort: ""
+
 
 # if using controller namespace prefixing, define that prefix here
 # limited to 8 characters (will be truncated by controller if it exceeds this)

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -6,16 +6,29 @@ rabbitMQHostname: ""
 rabbitMQPassword: ""
 rabbitMQUsername: ""
 
-# taskSSHHost is the hostname for the lagoon token service
+# NOTE!! lagoon api/host/port values if left empty fall back to the task api/host/port values
+# taskSSHHost/lagoonTokenHost is the hostname for the lagoon token service
+# taskSSHHost will be deprecated in favor of lagoonTokenHost
 taskSSHHost: ""
-# taskSSHPort is the port number for the lagoon token service
+lagoonTokenHost: ""
+# taskSSHPort/lagoonTokenPort is the port number for the lagoon token service
+# taskSSHPort will be deprecated in favor of lagoonTokenHost
 taskSSHPort: ""
-# taskAPIHost is the lagoon graphql API hostname, omitting the `/graphql, eg: https://api.example.com
+lagoonTokenPort: ""
+# taskAPIHost/lagoonAPIHost is the lagoon graphql API hostname, omitting `/graphql, eg: https://api.example.com
+# taskAPIHost will be deprecated in favor of lagoonAPIHost
 taskAPIHost: ""
+lagoonAPIHost: ""
+
+# NOTE!! sshPortal host/port values if left empty fall back to the task ssh host/port values
+# NOTE!! if `lagoonTokenHost/Port` are configured with the dedicated token service in lagoon core instead of the legacy ssh service in core
+# NOTE!! you will need to define the sshPortalHost/Port values for the ssh-portal that this remote is configured with
+# The sshPortalHost/Port can be configured with the legacy ssh service in core, but it is recommended that it is configured
+# to be the ssh-portal configured for this remote cluster.
 # sshPortalHost is the hostname for this remote clusters ssh portal service
-# eg: lagoon-remote-ssh-portal.lagoon.svc can be used for this for internal cluster communications, but a public dns can also be set
+# the internal service name can be used (eg: lagoon-remote-ssh-portal.lagoon.svc) but a public dns can also be set
 sshPortalHost: ""
-# sshPortalPort is the port number for this remote clusters ssh portal service
+# sshPortalPort is the port number for this remote clusters ssh portal service (public or internal port depending on how the host is configured)
 sshPortalPort: ""
 
 

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -169,6 +169,8 @@ lagoon-build-deploy:
   # taskSSHHost: ""
   # taskSSHPort: ""
   # taskAPIHost: ""
+  # sshPortalHost: ""
+  # sshPortalPort: ""
   # See the parent chart for the full range of values that can be passed here to control builds
   # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-build-deploy/values.yaml
 

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -169,8 +169,6 @@ lagoon-build-deploy:
   # taskSSHHost: ""
   # taskSSHPort: ""
   # taskAPIHost: ""
-  # sshPortalHost: ""
-  # sshPortalPort: ""
   # See the parent chart for the full range of values that can be passed here to control builds
   # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-build-deploy/values.yaml
 


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

This bumps the remote-controller to version 0.13.0 which has a number of changes. One is the ability to now inject some additional variables into builds that are prefixed with `LAGOON_CONFIG_`. These are to deprecate the existing `TASK_API/TASK_SSH` prefixed variables.

As such, this chart also needs to be updated to stage the deprecation of those variables. By default if anyone has already defined the `taskAPI/taskSSH` values, these will be consumed. But if a user chooses to do so, they can define the new values of `lagoonAPIHost`, `lagoonTokenHost/Port` and `sshPortalHost/Port` to point to the new services that will eventually replace the legacy SSH service in Lagoon. 