### PR TITLE
Lagoon Core resource requests

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.30.0
+version: 1.31.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: bump lagoon-opensearch-sync version to v0.7.0
+      description: add resource requests to lagoon-core deployments

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -80,6 +80,9 @@ authServer:
   replicaCount: 1
   image:
     repository: uselagoon/auth-server
+  resources:
+    requests:
+      cpu: "10m"
 
 webhooks2tasks:
   replicaCount: 1

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -27,15 +27,24 @@ api:
   replicaCount: 1
   image:
     repository: uselagoon/api
+  resources:
+    requests:
+      cpu: "10m"
 
 apiDB:
   image:
     repository: uselagoon/api-db
   storageSize: 16Gi
+  resources:
+    requests:
+      cpu: "10m"
 
 apiRedis:
   image:
     repository: uselagoon/api-redis
+  resources:
+    requests:
+      cpu: "10m"
 
 # TODO - update repo/tag before v2.11 release
 actionsHandler:
@@ -46,10 +55,16 @@ actionsHandler:
 keycloak:
   image:
     repository: uselagoon/keycloak
+  resources:
+    requests:
+      cpu: "10m"
 
 keycloakDB:
   image:
     repository: uselagoon/keycloak-db
+  resources:
+    requests:
+      cpu: "10m"
 
 broker:
   replicaCount: 1
@@ -57,6 +72,9 @@ broker:
     enabled: false
   image:
     repository: uselagoon/broker
+  resources:
+    requests:
+      cpu: "10m"
 
 authServer:
   replicaCount: 1
@@ -67,21 +85,33 @@ webhooks2tasks:
   replicaCount: 1
   image:
     repository: uselagoon/webhooks2tasks
+  resources:
+    requests:
+      cpu: "10m"
 
 webhookHandler:
   replicaCount: 1
   image:
     repository: uselagoon/webhook-handler
+  resources:
+    requests:
+      cpu: "10m"
 
 ui:
   replicaCount: 1
   image:
     repository: uselagoon/ui
+  resources:
+    requests:
+      cpu: "10m"
 
 backupHandler:
   replicaCount: 1
   image:
     repository: uselagoon/backup-handler
+  resources:
+    requests:
+      cpu: "10m"
 
 insightsHandler:
   image:
@@ -102,6 +132,9 @@ ssh:
   replicaCount: 1
   image:
     repository: uselagoon/ssh
+  resources:
+    requests:
+      cpu: "10m"
 
 sshPortalAPI:
   enabled: true

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -514,6 +514,11 @@ actionsHandler:
   additionalEnvs:
   #   FOO: Bar
 
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "10m"
+
 backupHandler:
   enabled: true
   replicaCount: 2

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -124,7 +124,10 @@ api:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "500m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -155,7 +158,10 @@ apiDB:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -188,7 +194,10 @@ apiRedis:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -209,7 +218,10 @@ keycloak:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -251,7 +263,10 @@ keycloakDB:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "100m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -289,7 +304,10 @@ broker:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -345,7 +363,10 @@ authServer:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -370,7 +391,10 @@ webhooks2tasks:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -395,7 +419,10 @@ webhookHandler:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -437,7 +464,10 @@ ui:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -497,7 +527,10 @@ backupHandler:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -539,7 +572,10 @@ insightsHandler:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -577,7 +613,10 @@ logs2notifications:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -602,7 +641,10 @@ drushAlias:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -644,7 +686,10 @@ ssh:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "500m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -674,7 +719,10 @@ workflows:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -762,7 +810,10 @@ sshPortalAPI:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -811,7 +862,10 @@ opensearchSync:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar
@@ -829,7 +883,10 @@ sshToken:
 
   securityContext: {}
 
-  resources: {}
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
 
   additionalEnvs:
   #   FOO: Bar


### PR DESCRIPTION
Add resource requests to Lagoon Core deployments.

We have studied the actual running data for lagoon-core components for a medium-scale cluster, and are proposing a basic set of cpu resource requests.

This is a breakdown of the requested values. As this configuration of Lagoon Core requires approx 4GB RAM and 3 CPU cores to run in production, you may need to provide your own request values if you are resource constrained, or are running additional services in your cluster

See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes for an explanation of the mebibytes and milliCPU terms

For the services marked with an asterisk (*) as the adoption of these services rises, we may need to alter their requests accordingly

| service                | mem request (Mi) | cpu request (milliCPU) |
|------------------------|-------------|-------------|
| api                    | 256         | 500         |
| api-db                 | 512         | 500         |
| api-redis              | 64          | 50          |
| keycloak               | 1024        | 500         |
| keycloak-db            | 512         | 100         |
| broker                 | 1024        | 500         |
| auth-server            | 64          | 50          |
| webhooks2tasks         | 64          | 50          |
| webhook-handler        | 128         | 50          |
| ui                     | 128         | 50          |
| actions-handler        | 16          | 10          |
| backup-handler         | 32          | 50          |
| insights-handler *     | 32          | 10          |
| logs2notifications     | 16          | 10          |
| drush-alias            | 8           | 10          |
| ssh                    | 128         | 500         |
| workflows              | 16          | 10          |
| ssh-portal-api *       | 8           | 10          |
| lagoon-opensearch-sync * | 8           | 10          |
| ssh-token *            | 8           | 10          |
|                        |             |             |
| Total                  | 4048        | 2980        |

