### PR TITLE
Monitor Lagoon Broker with more details

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.35.0
+version: 1.35.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.15.3
+      description: add additional metrics to broker

--- a/charts/lagoon-core/templates/broker.servicemonitor.yaml
+++ b/charts/lagoon-core/templates/broker.servicemonitor.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   endpoints:
     - port: metrics
+    - interval: 30s
+      params:
+        family:
+          - queue_coarse_metrics
+          - queue_metrics
+      path: /metrics/detailed
+      port: metrics
+      scrapeTimeout: 29s       
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
This tells Prometheus to scrape the lagoon broker more detailed, which allows to monitor the amount of messages and consumers per queue

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
