### PR TITLE
SSH portal bugfix

### DIFF
--- a/charts/lagoon-core/Chart.lock
+++ b/charts/lagoon-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.18.3
-digest: sha256:23ec68e1604f1b9f90bd9571e7e17c6101524be61b304de03f378a31a6c55fbd
-generated: "2022-11-24T11:53:36.184266854+11:00"
+  version: 0.19.17
+digest: sha256:9c58fc4ddeec7b86f5ef2cf1996a48a7e09d9bd4aa149971e2525a6f05649bf8
+generated: "2023-07-28T09:49:46.220986689+08:00"

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.35.0
+version: 1.36.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -31,7 +31,7 @@ appVersion: v2.15.3
 
 dependencies:
 - name: nats
-  version: ~0.18.0
+  version: ~0.19.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
 
@@ -41,4 +41,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.15.3
+      description: update lagoon-ssh-token and lagoon-ssh-portal-api to v0.30.1
+    - kind: changed
+      description: update NATS chart dependency to v0.19.17

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -809,7 +809,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.30.0"
+    tag: "v0.30.1"
 
   podAnnotations: {}
 
@@ -882,7 +882,7 @@ sshToken:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.30.0"
+    tag: "v0.30.1"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.18.3
-digest: sha256:09ef09e8f94f0d2840e252552a76b151bf72916c5f4e12f38584ae1807b5293b
-generated: "2023-07-17T14:16:18.328197887+10:00"
+  version: 0.19.17
+digest: sha256:5bf74bd117c2e5ae31d4084a588c52dd9408bbcc54cd0c86abf763d35f583412
+generated: "2023-07-28T09:49:56.393491706+08:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.80.0
+version: 0.81.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -35,7 +35,7 @@ dependencies:
   repository: https://amazeeio.github.io/charts/
   condition: dbaas-operator.enabled
 - name: nats
-  version: ~0.18.0
+  version: ~0.19.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
 
@@ -45,4 +45,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon-build-deploy to v0.24.0
+      description: update lagoon-ssh-portal to v0.30.1
+    - kind: changed
+      description: update NATS chart dependency to v0.19.17

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -122,7 +122,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.30.0"
+    tag: "v0.30.1"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
This PR updates the lagoon-ssh-portal components with the fix from https://github.com/uselagoon/lagoon-ssh-portal/pull/249.

It also updates the NATS chart dependencies to the latest minor release.
