### PR TITLE
convert api-redis to redis-persistent

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.36.0
+version: 1.37.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,10 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: add additional metrics to broker
-    - kind: changed
-      description: update lagoon-ssh-token and lagoon-ssh-portal-api to v0.30.1
-    - kind: changed
-      description: update NATS chart dependency to v0.19.17
-    - kind: changed
-      description: update Lagoon appVersion to v2.15.4
+      description: convert api-redis to redis-persistent

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -45,6 +45,8 @@ apiRedis:
   resources:
     requests:
       cpu: "10m"
+  persistence:
+    enabled: false
 
 # TODO - update repo/tag before v2.11 release
 actionsHandler:

--- a/charts/lagoon-core/templates/api-redis.deployment.yaml
+++ b/charts/lagoon-core/templates/api-redis.deployment.yaml
@@ -36,6 +36,10 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.api.fullname" . }}
               key: REDIS_PASSWORD
+        {{- if .Values.apiRedis.persistence.enabled }}
+        - name: FLAVOR
+          value: persistent
+        {{- end }}
       {{- range $key, $val := .Values.apiRedis.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}
@@ -43,9 +47,11 @@ spec:
         ports:
         - name: redis
           containerPort: 6379
+        {{- if .Values.apiRedis.persistence.enabled }}
         volumeMounts:
         - name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
           mountPath: /data
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: redis
@@ -54,10 +60,12 @@ spec:
             port: redis
         resources:
           {{- toYaml .Values.apiRedis.resources | nindent 10 }}
+      {{- if .Values.apiRedis.persistence.enabled }}
       volumes:
       - name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
         persistentVolumeClaim:
           claimName: {{ include "lagoon-core.apiRedis.fullname" . }}-data
+      {{- end }}
       {{- with .Values.apiRedis.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -70,6 +78,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.apiRedis.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
@@ -79,3 +88,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.apiRedis.storageSize | quote }}
+  {{- end }}

--- a/charts/lagoon-core/templates/api-redis.deployment.yaml
+++ b/charts/lagoon-core/templates/api-redis.deployment.yaml
@@ -43,6 +43,9 @@ spec:
         ports:
         - name: redis
           containerPort: 6379
+        volumeMounts:
+        - name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
+          mountPath: /data
         livenessProbe:
           tcpSocket:
             port: redis
@@ -51,6 +54,10 @@ spec:
             port: redis
         resources:
           {{- toYaml .Values.apiRedis.resources | nindent 10 }}
+      volumes:
+      - name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
+        persistentVolumeClaim:
+          claimName: {{ include "lagoon-core.apiRedis.fullname" . }}-data
       {{- with .Values.apiRedis.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -63,3 +70,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.apiRedis.storageSize | quote }}

--- a/charts/lagoon-core/templates/api-redis.pvc.yaml
+++ b/charts/lagoon-core/templates/api-redis.pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiRedis.persistence.enabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,7 +10,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.apiRedis.storage.size | quote }}
-  {{- with .Values.apiRedis.storage.className }}
+      storage: {{ .Values.apiRedis.persistence.size | quote }}
+  {{- with .Values.apiRedis.persistence.className }}
   storageClassName: {{ . | quote }}
   {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/api-redis.pvc.yaml
+++ b/charts/lagoon-core/templates/api-redis.pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lagoon-core.apiRedis.fullname" . }}-data
+  labels:
+    {{- include "lagoon-core.apiRedis.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.apiRedis.storage.size | quote }}
+  {{- with .Values.apiRedis.storage.className }}
+  storageClassName: {{ . | quote }}
+  {{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -200,7 +200,10 @@ apiRedis:
       cpu: "50m"
 
   additionalEnvs:
-  #   FOO: Bar
+    FLAVOR: persistent
+
+  storage:
+    size: 8Gi
 
   service:
     type: ClusterIP

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -199,10 +199,8 @@ apiRedis:
       memory: "64Mi"
       cpu: "50m"
 
-  additionalEnvs:
-    FLAVOR: persistent
-
-  storage:
+  persistence:
+    enabled: true
     size: 8Gi
 
   service:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -201,7 +201,7 @@ apiRedis:
 
   persistence:
     enabled: true
-    size: 8Gi
+    size: 1Gi
 
   service:
     type: ClusterIP


### PR DESCRIPTION
This PR adds a persistence.enabled option to api-redis that, when enabled:
* creates the PVC, volume  and mount
* sets the necessary variable to enable the persistence settings

I've set the default storage size to 1Gi and disabled it in CI.