### PR TITLE
Upgrade nats subchart to v1.2

### DIFF
--- a/charts/lagoon-core/Chart.lock
+++ b/charts/lagoon-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.19.17
-digest: sha256:9c58fc4ddeec7b86f5ef2cf1996a48a7e09d9bd4aa149971e2525a6f05649bf8
-generated: "2023-07-28T09:49:46.220986689+08:00"
+  version: 1.0.3
+digest: sha256:437a0a6fea805b16ec2d292a0cf9bbba8084e09448c9d9b5ae7fcae1be14bb47
+generated: "2023-09-20T12:18:17.665626036+08:00"

--- a/charts/lagoon-core/Chart.lock
+++ b/charts/lagoon-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 1.0.3
-digest: sha256:437a0a6fea805b16ec2d292a0cf9bbba8084e09448c9d9b5ae7fcae1be14bb47
-generated: "2023-09-20T12:18:17.665626036+08:00"
+  version: 1.2.5
+digest: sha256:9ef2d1dfe07187fbf9680ee525bced5d5a460349cd3b1fd06fc32b843481e238
+generated: "2024-10-18T11:48:49.486819359+11:00"

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.48.0
+version: 1.49.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -31,7 +31,7 @@ appVersion: v2.21.0
 
 dependencies:
 - name: nats
-  version: ~0.19.0
+  version: ~1.0.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
 
@@ -41,21 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.21.0
-      links:
-        - name: lagoon-core v2.21.0 release
-          url: https://github.com/uselagoon/lagoon/releases/tag/v2.21.0
-    - kind: changed
-      description: update insights-handler to v0.0.6
-      links:
-        - name: insights-remote v0.0.6 release
-          url: https://github.com/uselagoon/insights-handler/releases/tag/v0.0.6
-    - kind: changed
-      description: update ssh-portal and ssh-token to v0.37.2
-      links:
-        - name: ssh-portal v0.37.2 release
-          url: https://github.com/uselagoon/lagoon-ssh-portal/releases/tag/v0.37.2
-    - kind: changed
-      description: add broker-flag-enable pre-upgrade job
-    - kind: changed
-      description: add KEYCLOAK_FRONTEND_URL variable to api deployment
+      description: update NATS chart dependency to v1.0.x

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -31,7 +31,7 @@ appVersion: v2.21.0
 
 dependencies:
 - name: nats
-  version: ~1.0.0
+  version: ~1.2.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
 
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update NATS chart dependency to v1.0.x
+      description: update NATS chart dependency to v1.2.x

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -267,9 +267,10 @@ workflows:
 # enable nats cluster (and optionally natsbox debugger)
 nats:
   enabled: true
-  cluster:
-    name: lagoon-core-ci-example
-  # natsbox:
+  config:
+    cluster:
+      name: lagoon-core-ci-example
+  # natsBox:
   #   enabled: true
   #   # additional labels are required due to the network policy
   #   additionalLabels:
@@ -297,7 +298,7 @@ natsConfig:
         iYmI+nuDxvSE7s/u5hhmh+wCIQDXoxiQvQuokI06j6W1K5UgR6h9dUoKeTFQIqXp
         uKPLhg==
         -----END CERTIFICATE-----
-      server.crt: |
+      tls.crt: |
         -----BEGIN CERTIFICATE-----
         MIICGDCCAb6gAwIBAgIUJC6a9n2zJYl7nOZ2AutYhyjVmQswCgYIKoZIzj0EAwIw
         HjEcMBoGA1UEAxMTbmF0cy1jYS5leGFtcGxlLmNvbTAeFw0yNDA0MTUwNDA4MDBa
@@ -312,7 +313,7 @@ natsConfig:
         CaKsntUSiMDTZSYvEtLb+ZxOn71RnDYP4JUCIG6TZVFfMiYPZ0gGLMRMf666E3bB
         0U5vgRqQhghJPbpM
         -----END CERTIFICATE-----
-      server.key: |
+      tls.key: |
         -----BEGIN EC PRIVATE KEY-----
         MHcCAQEEIBqSIJXbR9H4WChftIW2QwJmGD+5QjlfwBCkspRBcsSHoAoGCCqGSM49
         AwEHoUQDQgAENf2wtlM9sSu330UXgZTkAOZBRkH2V6YZG7rB/7pTtO0yKQmIfr+l

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -622,10 +622,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 
 {{/*
-Create a default fully qualified app name for the nats subchart.
+Create a definition that matches the fully qualified app name for the nats
+subchart.
 */}}
 {{- define "lagoon-core.nats.fullname" -}}
-{{- include "lagoon-core.fullname" . }}-nats
+{{- include "lagoon-core.fullname" . }}-{{ .Values.nats.nameOverride | default "nats" }}
 {{- end }}
 
 

--- a/charts/lagoon-core/templates/nats-concentrator.service.yaml
+++ b/charts/lagoon-core/templates/nats-concentrator.service.yaml
@@ -13,5 +13,5 @@ spec:
     protocol: TCP
     targetPort: 7422
   selector:
-    app.kubernetes.io/name: nats
+    app.kubernetes.io/name: {{ .Values.nats.nameOverride | default "nats" | quote }}
 {{- end }}

--- a/charts/lagoon-core/templates/nats.secret.yaml
+++ b/charts/lagoon-core/templates/nats.secret.yaml
@@ -30,7 +30,7 @@ metadata:
   labels:
     {{- include "lagoon-core.labels" . | nindent 4 }}
 stringData:
-  lagoon-core.conf: |
+  accounts.conf: |
     accounts: {
       lagoonRemote: {
         LAGOON_REMOTE = {
@@ -56,26 +56,16 @@ stringData:
       }
     }
     no_auth_user: "lagoon-core-local"
-    leafnodes: {
-      listen: "0.0.0.0:7422"
-      no_advertise: true
-      authorization: {
-        users: [
-        {{- range .Values.natsConfig.users.lagoonRemote }}
-          {
-            user: {{ .user | quote }}
-            password: {{ .password | quote }}
-            account: lagoonRemote
-          },
-        {{- end }}
-        ]
-      }
-      tls: {
-        {{- if .Values.natsConfig.tls.secretData }}
-        ca_file: "/etc/lagoon-core-nats-tls/ca.crt"
-        {{- end }}
-        cert_file: "/etc/lagoon-core-nats-tls/server.crt"
-        key_file: "/etc/lagoon-core-nats-tls/server.key"
-      }
+  leafnodesAuthorization.conf: |
+    authorization: {
+      users: [
+      {{- range .Values.natsConfig.users.lagoonRemote }}
+        {
+          user: {{ .user | quote }}
+          password: {{ .password | quote }}
+          account: lagoonRemote
+        },
+      {{- end }}
+      ]
     }
 {{- end }}

--- a/charts/lagoon-core/templates/ssh-portal-api.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-portal-api.deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{ include "lagoon-core.fullname" . }}-nats-client: "true"
+        lagoon-core-nats-client: "true"
         {{- include "lagoon-core.sshPortalAPI.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
@@ -61,7 +61,7 @@ spec:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
               key: KEYCLOAK_SERVICE_API_CLIENT_SECRET
         - name: NATS_URL
-          value: nats://{{ include "lagoon-core.fullname" . }}-nats
+          value: nats://{{ include "lagoon-core.nats.fullname" . }}
         - name: API_DB_ADDRESS
           value: {{ include "lagoon-core.apiDB.fullname" . }}
         - name: API_DB_PASSWORD

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -815,37 +815,109 @@ workflows:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+# nats subchart is configured for use by lagoon-core
 nats:
   enabled: false
-  # inject additional config
-  additionalVolumes:
-  - name: lagoon-core-nats-tls
-    secret:
-      secretName: lagoon-core-nats-tls
-  additionalVolumeMounts:
-  - name: lagoon-core-nats-tls
-    mountPath: /etc/lagoon-core-nats-tls
-  nats:
-    config:
-    - name: lagoon-core
-      secret:
-        secretName: lagoon-core-nats-conf
-  cluster:
+  # name override provides compatiblity for upgrading nats chart v0.x to v1.x
+  nameOverride: nats1
+  tlsCA:
     enabled: true
-    name: lagoon-core
-    # internal cluster IPs are not routable, so don't advertise them
-    noAdvertise: true
-  natsbox:
+    secretName: lagoon-core-nats-tls
+  # Uncomment this block to enable monitoring if you have Prometheus Operator
+  # installed.
+  # promExporter:
+  #   enabled: true
+  #   podMonitor:
+  #     enabled: true
+  #     # fromNamespaces restricts the namespaces from which monitoring can occur
+  #     # via the NetworkPolicy. At least one namespace name must be listed.
+  #     fromNamespaces:
+  #     - monitoring
+  natsBox:
     enabled: false
+  config:
+    cluster:
+      enabled: true
+      name: lagoon-core
+      # internal cluster IPs are not routable, so don't advertise them
+      noAdvertise: true
+    leafnodes:
+      enabled: true
+      tls:
+        enabled: true
+        secretName: lagoon-core-nats-tls
+        merge:
+          verify: true
+      merge:
+        00$include: ./lagoon-core/leafnodesAuthorization.conf
+    merge:
+      00$include: ./lagoon-core/accounts.conf
+  # Uncomment this block if upgrading from lagoon-core <v1.36.0.
+  # statefulSet:
+  #   patch:
+  #   - op: remove
+  #     path: /spec/selector/matchLabels/app.kubernetes.io~1component
+  podTemplate:
+    patch:
+    - op: add
+      path: /spec/volumes/-
+      value:
+        name: lagoon-core-nats-conf
+        secret:
+          secretName: lagoon-core-nats-conf
+  container:
+    patch:
+    - op: add
+      path: /volumeMounts/-
+      value:
+        name: lagoon-core-nats-conf
+        mountPath: /etc/nats-config/lagoon-core
   # to connect to nats, pods must have the right label
-  networkPolicy:
-    enabled: true
-    allowExternal: false
-    # allow inbound leaf connections
-    extraIngress:
-    - ports:
-      - port: 7422
-        protocol: TCP
+  extraResources:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name:
+        $tplYaml: >
+          {{ include "nats.fullname" $ | quote }}
+      labels:
+        $tplYaml: |
+          {{ include "nats.labels" $ }}
+    spec:
+      policyTypes:
+      - Ingress
+      podSelector:
+        matchLabels:
+          $tplYaml: |
+            {{- include "nats.selectorLabels" $ }}
+      ingress:
+      - from:
+        # pods in this namespace with the correct label can access NATS pods
+        - podSelector:
+            matchLabels:
+              lagoon-core-nats-client: "true"
+        # NATS inter-pod communication is allowed
+        - podSelector:
+            matchLabels:
+              $tplYaml: |
+                {{- include "nats.selectorLabels" $ }}
+      - ports:
+        # allow external inbound leaf node connections (these are authenticated)
+        - port: 7422
+          protocol: TCP
+      # conditionally allow metrics collection
+      - $tplYamlSpread: |
+          {{- if and .Values.promExporter.enabled .Values.promExporter.podMonitor.enabled }}
+          - from:
+            {{- range .Values.promExporter.podMonitor.fromNamespaces }}
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: {{ . | quote }}
+            {{- end }}
+            ports:
+            - port: 7777
+              protocol: TCP
+          {{- end }}
 
 natsService:
   # this service is enabled via nats.enabled
@@ -865,18 +937,22 @@ natsConfig:
     # If the lagoon-core-nats-tls secret should be created by the lagoon-core
     # chart, certificate values can be specified directly in secretData.
     # Configuring TLS this way also allows specifying a custom ca.crt.
+    # The chart expects expects secretData to be specified unless
+    # nats.tlsCA.enabled is set to false.
     #
     # secretData:
     #   ca.crt: |
     #     ...
-    #   server.crt: |
+    #   tls.crt: |
     #     ...
-    #   server.key: |
+    #   tls.key: |
     #     ...
     #
     # If the TLS secret is created outside the lagoon-core chart, it should be
     # named lagoon-core-nats-tls. This secret should contain fields tls.crt and
     # tls.key, and the certificate should be issued by a public authority.
+    # `nats.tlsCA.enabled: false` should be set in this case (it is true by
+    # default).
 
 sshPortalAPI:
   enabled: false

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -818,7 +818,9 @@ workflows:
 # nats subchart is configured for use by lagoon-core
 nats:
   enabled: false
-  # name override provides compatiblity for upgrading nats chart v0.x to v1.x
+  # nameOverride provides compatibility for upgrading nats chart versions.
+  # modifying or setting this in local values.yaml will completely recreate
+  # all the nats resources.
   nameOverride: nats1
   tlsCA:
     enabled: true

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.19.17
-digest: sha256:6570c9b0a841c10420d28a3fb754569e8922bc5e8e3916c49e13cdb2fb768060
-generated: "2024-06-20T12:17:04.565621295+10:00"
+  version: 1.0.3
+digest: sha256:3510c54658e4f70646ef4276185334e66941a4fe68fc8980f8d9ccc0658b56c3
+generated: "2023-09-21T11:20:15.805963522+08:00"

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 1.0.3
-digest: sha256:3510c54658e4f70646ef4276185334e66941a4fe68fc8980f8d9ccc0658b56c3
-generated: "2023-09-21T11:20:15.805963522+08:00"
+  version: 1.2.5
+digest: sha256:8d25a12b60290743ed7dd4a512ba401a1df0afc60da17f50ca467f593068b53b
+generated: "2024-10-18T11:46:28.50935365+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
   repository: https://amazeeio.github.io/charts/
   condition: dbaas-operator.enabled
 - name: nats
-  version: ~1.0.0
+  version: ~1.2.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
 
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update NATS chart dependency to v1.0.x
+      description: update NATS chart dependency to v1.2.x

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.94.0
+version: 0.95.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -31,7 +31,7 @@ dependencies:
   repository: https://amazeeio.github.io/charts/
   condition: dbaas-operator.enabled
 - name: nats
-  version: ~0.19.0
+  version: ~1.0.0
   repository: https://nats-io.github.io/k8s/helm/charts/
   condition: nats.enabled
 
@@ -41,9 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: remove docker-host connection test in CI
-    - kind: changed
-      description: update insights-remote to v0.0.11
-      links:
-        - name: insights-remote v0.0.11 release
-          url: https://github.com/uselagoon/insights-remote/releases/tag/v0.0.11
+      description: update NATS chart dependency to v1.0.x

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -32,16 +32,17 @@ mxoutHost: mxout1.example.com
 
 nats:
   enabled: true
-  cluster:
-    name: lagoon-remote-ci-example
-  # natsbox:
+  config:
+    cluster:
+      name: lagoon-remote-ci-example
+  # natsBox:
   #   enabled: true
   #   # additional labels are required due to the network policy
   #   additionalLabels:
   #     lagoon-remote-nats-client: "true"
 
 natsConfig:
-  coreURL: "nats://ci-ssh-portal:ci-password@lagoon-core-nats-concentrator.lagoon-core.svc:7422"
+  coreURL: "tls://ci-ssh-portal:ci-password@lagoon-core-nats-concentrator.lagoon-core.svc:7422"
   tls:
     secretData:
       ca.crt: |
@@ -56,7 +57,7 @@ natsConfig:
         iYmI+nuDxvSE7s/u5hhmh+wCIQDXoxiQvQuokI06j6W1K5UgR6h9dUoKeTFQIqXp
         uKPLhg==
         -----END CERTIFICATE-----
-      client.crt: |
+      tls.crt: |
         -----BEGIN CERTIFICATE-----
         MIIByDCCAW+gAwIBAgIUJnuRfZT3Viio6HpYvGEehas9qWowCgYIKoZIzj0EAwIw
         HjEcMBoGA1UEAxMTbmF0cy1jYS5leGFtcGxlLmNvbTAeFw0yNDA0MTUwNDA5MDBa
@@ -69,7 +70,7 @@ natsConfig:
         BAMCA0cAMEQCIGaSyihjkNL2DiUg6nftAUb2jXl97Y38cb8R/srWZdaaAiAC9K6r
         jzJR6clzzHTzidSigsyeoBmhv7L6643jfB02HQ==
         -----END CERTIFICATE-----
-      client.key: |
+      tls.key: |
         -----BEGIN EC PRIVATE KEY-----
         MHcCAQEEINvOV43X7WgqNmkg++wNfmU033hwBDpSG7iDWh6ErzCXoAoGCCqGSM49
         AwEHoUQDQgAE5ayAbiEEjfDYHaZPotihXIngy3rj0Pg5kUNHGI7BQWHnmXXFdrOS

--- a/charts/lagoon-remote/templates/_helpers.tpl
+++ b/charts/lagoon-remote/templates/_helpers.tpl
@@ -193,6 +193,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 
 {{/*
+Create a definition that matches the fully qualified app name for the nats
+subchart.
+*/}}
+{{- define "lagoon-remote.nats.fullname" -}}
+{{- include "lagoon-remote.fullname" . }}-{{ .Values.nats.nameOverride | default "nats" }}
+{{- end }}
+
+
+
+{{/*
 Create the name of the service account to use for sshPortal.
 */}}
 {{- define "lagoon-remote.sshPortal.serviceAccountName" -}}

--- a/charts/lagoon-remote/templates/nats.secret.yaml
+++ b/charts/lagoon-remote/templates/nats.secret.yaml
@@ -30,18 +30,18 @@ metadata:
   labels:
     {{- include "lagoon-remote.labels" . | nindent 4 }}
 stringData:
-  lagoon-remote.conf: |
+  leafnodes.conf: |
     leafnodes {
       no_advertise: true
       remotes: [
         {
           url: {{ .Values.natsConfig.coreURL | quote }}
           tls: {
-            {{- if .Values.natsConfig.tls.secretData -}}
-            ca_file: "/etc/lagoon-remote-nats-tls/ca.crt"
+            {{- if .Values.natsConfig.tls.secretData }}
+            ca_file: "/etc/nats-ca-cert/ca.crt"
             {{- end }}
-            cert_file: "/etc/lagoon-remote-nats-tls/client.crt"
-            key_file: "/etc/lagoon-remote-nats-tls/client.key"
+            cert_file: "/etc/nats-certs/leafnodes/tls.crt"
+            key_file: "/etc/nats-certs/leafnodes/tls.key"
           }
         }
       ]

--- a/charts/lagoon-remote/templates/ssh-portal.deployment.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{ include "lagoon-remote.fullname" . }}-nats-client: "true"
+        lagoon-remote-nats-client: "true"
         {{- include "lagoon-remote.sshPortal.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "lagoon-remote.sshPortal.serviceAccountName" . }}
@@ -42,7 +42,7 @@ spec:
           value: "true"
         {{- end }}
         - name: NATS_URL
-          value: nats://{{ include "lagoon-remote.fullname" . }}-nats
+          value: nats://{{ include "lagoon-remote.nats.fullname" . }}
       {{- range $key, $val := .Values.sshPortal.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -296,60 +296,133 @@ insightsRemote:
 
 
 # the nats chart is a subchart which is configured for use by lagoon-remote
+# nats subchart is configured for use by lagoon-remote
 nats:
   enabled: false
-  # inject additional config
-  additionalVolumes:
-  - name: lagoon-remote-nats-tls
-    secret:
-      secretName: lagoon-remote-nats-tls
-  additionalVolumeMounts:
-  - name: lagoon-remote-nats-tls
-    mountPath: /etc/lagoon-remote-nats-tls
-  nats:
-    config:
-    - name: lagoon-remote
-      secret:
-        secretName: lagoon-remote-nats-conf
-  cluster:
+  # name override provides compatiblity for upgrading nats chart v0.x to v1.x
+  nameOverride: nats1
+  tlsCA:
     enabled: true
-    name: lagoon-remote
-    # internal cluster IPs are not routable, so don't advertise them
-    noAdvertise: true
-  natsbox:
+    secretName: lagoon-remote-nats-tls
+  # Uncomment this block to enable monitoring if you have Prometheus Operator
+  # installed.
+  # promExporter:
+  #   enabled: true
+  #   podMonitor:
+  #     enabled: true
+  #     # fromNamespaces restricts the namespaces from which monitoring can occur
+  #     # via the NetworkPolicy. At least one namespace name must be listed.
+  #     fromNamespaces:
+  #     - monitoring
+  natsBox:
     enabled: false
+  config:
+    cluster:
+      enabled: true
+      name: lagoon-remote
+      # internal cluster IPs are not routable, so don't advertise them
+      noAdvertise: true
+    merge:
+      00$include: ./lagoon-remote/leafnodes.conf
+  # Uncomment this block if upgrading from lagoon-remote <v0.82.0.
+  # statefulSet:
+  #   patch:
+  #   - op: remove
+  #     path: /spec/selector/matchLabels/app.kubernetes.io~1component
+  podTemplate:
+    patch:
+    - op: add
+      path: /spec/volumes/-
+      value:
+        name: lagoon-remote-nats-conf
+        secret:
+          secretName: lagoon-remote-nats-conf
+    - op: add
+      path: /spec/volumes/-
+      value:
+        name: lagoon-remote-nats-tls
+        secret:
+          secretName: lagoon-remote-nats-tls
+  container:
+    patch:
+    - op: add
+      path: /volumeMounts/-
+      value:
+        name: lagoon-remote-nats-conf
+        mountPath: /etc/nats-config/lagoon-remote
+    - op: add
+      path: /volumeMounts/-
+      value:
+        name: lagoon-remote-nats-tls
+        mountPath: /etc/nats-certs/leafnodes
   # to connect to nats, pods must have the right label
-  networkPolicy:
-    enabled: true
-    allowExternal: false
-    # allow outbound leaf connection
-    extraEgress:
-    - ports:
-      - port: 7422
-        protocol: TCP
+  extraResources:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name:
+        $tplYaml: >
+          {{ include "nats.fullname" $ | quote }}
+      labels:
+        $tplYaml: |
+          {{ include "nats.labels" $ }}
+    spec:
+      policyTypes:
+      - Ingress
+      podSelector:
+        matchLabels:
+          $tplYaml: |
+            {{- include "nats.selectorLabels" $ }}
+      ingress:
+      - from:
+        # pods in this namespace with the correct label can access NATS pods
+        - podSelector:
+            matchLabels:
+              lagoon-remote-nats-client: "true"
+        # NATS inter-pod communication is allowed
+        - podSelector:
+            matchLabels:
+              $tplYaml: |
+                {{- include "nats.selectorLabels" $ }}
+      # conditionally allow metrics collection
+      - $tplYamlSpread: |
+          {{- if and .Values.promExporter.enabled .Values.promExporter.podMonitor.enabled }}
+          - from:
+            {{- range .Values.promExporter.podMonitor.fromNamespaces }}
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: {{ . | quote }}
+            {{- end }}
+            ports:
+            - port: 7777
+              protocol: TCP
+          {{- end }}
+
 
 # Configuration for the nats subchart
 natsConfig:
-  # coreURL format nats://<username>:<password>@<host>:7422
+  # coreURL format tls://<username>:<password>@<host>:7422
   coreURL: ""
   tls: {}
     # If the lagoon-remote-nats-tls secret should be created by the
     # lagoon-remote chart, certificate values can be specified directly in
     # secretData. Configuring TLS this way also allows specifying a custom
-    # ca.crt.
+    # ca.crt. The chart expects expects secretData to be specified unless
+    # nats.tlsCA.enabled is set to false.
     #
     # secretData:
     #   ca.crt: |
     #     ...
-    #   client.crt: |
+    #   tls.crt: |
     #     ...
-    #   client.key: |
+    #   tls.key: |
     #     ...
     #
     # If the TLS secret is created outside the lagoon-remote chart, it should
     # be named lagoon-remote-nats-tls. This secret should contain fields
     # tls.crt and tls.key, and the certificate should be issued by a public
-    # authority.
+    # authority. `nats.tlsCA.enabled: false` should be set in this case (it is
+    # true by default).
 
 storageCalculator:
   enabled: false

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -299,7 +299,9 @@ insightsRemote:
 # nats subchart is configured for use by lagoon-remote
 nats:
   enabled: false
-  # name override provides compatiblity for upgrading nats chart v0.x to v1.x
+  # nameOverride provides compatibility for upgrading nats chart versions.
+  # modifying or setting this in local values.yaml will completely recreate
+  # all the nats resources.
   nameOverride: nats1
   tlsCA:
     enabled: true


### PR DESCRIPTION
This PR upgrades the NATS subchart dependency to 1.0.

This is a __breaking change__. The NATS chart has completely restructured its configuration between v0.x and v1.x.
So by necessity the NATS subchart configuration of `lagoon-core` and `lagoon-remote` also had to be restructured.
In general, the major upstream change affecting the Lagoon charts is that `nats.*` values have mostly been moved to `nats.config.*`.

In particular, the following values required by the Lagoon charts have changed:

Lagoon Core:

| Old path                                 | New path                              |
| ---                                      | ---                                   |
| `nats.cluster.name`                      | `nats.config.cluster.name`            |
| `natsConfig.tls.secretData."server.crt"` | `natsConfig.tls.secretData."tls.crt"` |
| `natsConfig.tls.secretData."server.key"` | `natsConfig.tls.secretData."tls.key"` |

Lagoon Remote:

| Old path                                 | New path                              |
| ---                                      | ---                                   |
| `nats.cluster.name`                      | `nats.config.cluster.name`            |
| `natsConfig.tls.secretData."client.crt"` | `natsConfig.tls.secretData."tls.crt"` |
| `natsConfig.tls.secretData."client.key"` | `natsConfig.tls.secretData."tls.key"` |

In addition, any other NATS subchart configuration options that may have been added (anything under `nats.*` in the `values.yaml` of `lagoon-core` and `lagoon-remote`) will most likely require updating.

There are upstream notes on the changes in the NATS chart [here](https://github.com/nats-io/k8s/blob/7fcc48ef44a4ecc686f15becec9cc5e283853bbd/helm/charts/nats/UPGRADING.md#update-nats-config-to-new-valuesyaml-schema).

The other change in this PR is that the client certificates presented by Lagoon Remote are now validated by NATS in Lagoon Core (they were not previously validated correctly).
This should not be a breaking change if the previous instructions for generating certificates were followed correctly.

Also note that due to the breaking change this is a major version bump for `lagoon-core` from `v1.x` to `v2.x`.
This is not a major version bump for `lagoon-remote` because that is still at `v0.x`.