### PR TITLE
Always create sshPortal authorization resources and add a service account token resource

### DIFF
--- a/charts/lagoon-remote/templates/ssh-portal.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sshPortal.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -42,4 +41,3 @@ rules:
   - pods/exec
   verbs:
   - create
-{{- end }}

--- a/charts/lagoon-remote/templates/ssh-portal.clusterrolebinding.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sshPortal.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +12,3 @@ roleRef:
   kind: ClusterRole
   name: {{ include "lagoon-remote.sshPortal.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/charts/lagoon-remote/templates/ssh-portal.serviceaccount.secret.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.serviceaccount.secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ include "lagoon-remote.sshPortal.fullname" . }}-token
+  labels:
+    {{- include "lagoon-remote.sshPortal.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "lagoon-remote.sshPortal.serviceAccountName" . }}

--- a/charts/lagoon-remote/templates/ssh-portal.serviceaccount.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sshPortal.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,4 +8,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}


### PR DESCRIPTION
In order to keep the legacy SSH service in lagoon-core working in recent k8s clusters, a non-expiring token is needed. A sufficiently scoped role and binding already exists for the ssh-portal, so this PR adds the service account token secret that can be used in lagoon-core. Since this is needed even if ssh-portal isn't used, the auth related resources are changed to always be created, even if the ssh-portal service isn't enabled.

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
