### PR TITLE
feat: Add lagoon-remote-ssh-core resources

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.81.0
+version: 0.82.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -44,7 +44,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: update lagoon-ssh-portal to v0.30.1
-    - kind: changed
-      description: update NATS chart dependency to v0.19.17
+    - kind: added
+      description: add lagoon-remote-ssh-core resources

--- a/charts/lagoon-remote/templates/_helpers.tpl
+++ b/charts/lagoon-remote/templates/_helpers.tpl
@@ -156,6 +156,43 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 
 {{/*
+Create the name of the service account to use for sshCore.
+*/}}
+{{- define "lagoon-remote.sshCore.serviceAccountName" -}}
+{{- default (include "lagoon-remote.sshCore.fullname" .) .Values.sshCore.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for sshCore.
+*/}}
+{{- define "lagoon-remote.sshCore.fullname" -}}
+{{- include "lagoon-remote.fullname" . }}-ssh-core
+{{- end }}
+
+{{/*
+Common labels sshCore.
+*/}}
+{{- define "lagoon-remote.sshCore.labels" -}}
+helm.sh/chart: {{ include "lagoon-remote.chart" . }}
+{{ include "lagoon-remote.sshCore.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels sshCore.
+*/}}
+{{- define "lagoon-remote.sshCore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-remote.sshCore.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+{{/*
 Create the name of the service account to use for sshPortal.
 */}}
 {{- define "lagoon-remote.sshPortal.serviceAccountName" -}}

--- a/charts/lagoon-remote/templates/ssh-core.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/ssh-core.clusterrole.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.sshCore.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.sshCore.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.sshCore.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+{{- end }}

--- a/charts/lagoon-remote/templates/ssh-core.clusterrolebinding.yaml
+++ b/charts/lagoon-remote/templates/ssh-core.clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.sshCore.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-remote.sshCore.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.sshCore.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.sshCore.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.sshCore.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/lagoon-remote/templates/ssh-core.secret.yaml
+++ b/charts/lagoon-remote/templates/ssh-core.secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.sshCore.enabled -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ include "lagoon-remote.sshCore.serviceAccountName" . }}-token
+  labels:
+    {{- include "lagoon-remote.sshCore.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "lagoon-remote.sshCore.serviceAccountName" . }}
+{{- end }}

--- a/charts/lagoon-remote/templates/ssh-core.serviceaccount.yaml
+++ b/charts/lagoon-remote/templates/ssh-core.serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.sshCore.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lagoon-remote.sshCore.serviceAccountName" . }}
+  labels:
+    {{- include "lagoon-remote.sshCore.labels" . | nindent 4 }}
+  {{- with .Values.sshCore.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -113,6 +113,17 @@ kubernetesBuildDeploy:
     # If not set, a name is generated using the fullname template.
     name:
 
+# sshCore creates a restricted, non-expiring ServiceAccount token for use by
+# lagoon-core.
+sshCore:
+  enabled: false
+  serviceAccount:
+    annotations: {}
+    # The name of the service account to use.
+    # If not set, a name is generated using the fullname
+    # template
+    name: ""
+
 # sshPortal is an optional service providing low-latency SSH connectivity to
 # Lagoon environments.
 sshPortal:


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
In order to keep the SSH service in lagoon-core working in recent k8s clusters, a non-expiring token is needed. Since the only reason lagoon-core needs a token still is for SSH purposes, this PR creates a new set of resources with a restricted cluster role based on https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount.

The role requirements differ slightly from the existing [ssh-portal role](https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-remote/templates/ssh-portal.clusterrole.yaml).