### PR TITLE
fix: upgrade mariadb chart to fix upgrade bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ install-mariadb:
 		--wait \
 		--timeout $(TIMEOUT) \
 		$$($(KUBECTL) get ns mariadb > /dev/null 2>&1 && echo --set auth.rootPassword=$$($(KUBECTL) get secret --namespace mariadb mariadb -o json | $(JQ) -r '.data."mariadb-root-password" | @base64d')) \
-		--version=11.5.7 \
+		--version=12.2.9 \
 		mariadb \
 		bitnami/mariadb
 


### PR DESCRIPTION
This change allows `make install-lagoon-remote` to be run more than once.

Previously we would hit https://github.com/bitnami/charts/issues/15093.

The specific chart version that this PR upgrades to is the latest version of the chart which still uses MariaDB 10.11.x (the LTS minor version of v10). Later versions of the chart upgrade to MariaDB 11, which is outside the scope of this bugfix.

