### PR TITLE
Update README with local caching proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /test-suite.kind-config.yaml
 /test-suite.kind-config.calico.yaml
+/docker_mirror_cache
+/docker_mirror_certs

--- a/README.md
+++ b/README.md
@@ -46,3 +46,42 @@ Documentation on probes for pod startup is [here](https://kubernetes.io/docs/con
 $ docker run --rm --interactive --detach --network host --name ct "--volume=$(pwd):/workdir" "--workdir=/workdir" --volume=$(pwd)/default.ct.yaml:/etc/ct/ct.yaml quay.io/helmpack/chart-testing:latest cat
 $ docker exec ct ct lint
 ```
+
+### Run lagoon-remote and lagoon-core in a local kind cluster
+
+#### Create the kind cluster
+
+```shell
+make create-kind-cluster
+```
+
+#### Configure local cache
+
+This step is optional but makes local image pulls much faster.
+
+Start the local image registry cache in another terminal:
+
+```shell
+docker run --rm -it \
+    --name docker_registry_proxy \
+    --net kind \
+    --hostname docker-registry-proxy \
+    -e ENABLE_MANIFEST_CACHE=true \
+    -v $(pwd)/docker_mirror_cache:/docker_mirror_cache \
+    -v $(pwd)/docker_mirror_certs:/ca \
+    -v $(pwd)/resolvers.conf:/etc/nginx/resolvers.conf \
+    -e REGISTRIES="k8s.gcr.io gcr.io quay.io registry.k8s.io" \
+    rpardini/docker-registry-proxy:0.6.4
+```
+
+Configure kind to use the proxy:
+
+```shell
+./configure-kind-node-proxy
+```
+
+#### Install Lagoon Core and Remote
+
+```shell
+make install-lagoon-remote
+```

--- a/configure-kind-node-proxy
+++ b/configure-kind-node-proxy
@@ -1,0 +1,13 @@
+#!/bin/sh
+KIND_NAME=${1-chart-testing}
+SETUP_URL=http://docker-registry-proxy:3128/setup/systemd
+pids=""
+for NODE in $(kind get nodes --name "$KIND_NAME"); do
+	docker exec "$NODE" sh -c "\
+      curl $SETUP_URL \
+      | sed s/docker\.service/containerd\.service/g \
+      | sed '/Environment/ s/$/ \"NO_PROXY=127.0.0.0\/8,10.0.0.0\/8,172.16.0.0\/12,192.168.0.0\/16\"/' \
+      | bash" &
+	pids="$pids $!" # Configure every node in background
+done
+wait $pids # Wait for all configurations to end

--- a/resolvers.conf
+++ b/resolvers.conf
@@ -1,0 +1,1 @@
+resolver 127.0.0.11 ipv6=off;


### PR DESCRIPTION
This PR adds documentation of a nice hack that means all containers of `lagoon-core` will start running in <60s when running locally in `kind` (once the cache is warm). This helps to make local dev of a full lagoon installation a much nicer experience.

![screenshot_2023-09-19-153724](https://github.com/uselagoon/lagoon-charts/assets/861778/a47d1c0a-1cf2-4554-a93f-05eeaf631f3d)