### PR TITLE
chore: update lagoon-build-deploy to v0.25.0

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.24.0
+  version: 0.25.0
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -11,5 +11,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.19.17
-digest: sha256:5bf74bd117c2e5ae31d4084a588c52dd9408bbcc54cd0c86abf763d35f583412
-generated: "2023-07-28T09:49:56.393491706+08:00"
+digest: sha256:f5484f77cfe25d079752ea3a19b1a93edb3c93e1262c4f310e149843359ff2c1
+generated: "2023-09-20T15:20:44.302630522+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,11 +19,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.82.0
+version: 0.83.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.24.0
+  version: ~0.25.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dioscuri
@@ -44,5 +44,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: add lagoon-remote-ssh-core resources
+    - kind: changed
+      description: update lagoon-build-deploy to v0.25.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Bump lagoon-build-deploy subchart to v0.25.0 to support remote-controller v0.15.0
