### PR TITLE
chore: bump lagoon-build-deploy subchart to v0.25.1

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.25.0
+  version: 0.25.1
 - name: dioscuri
   repository: https://amazeeio.github.io/charts/
   version: 0.4.1
@@ -11,5 +11,5 @@ dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.19.17
-digest: sha256:f5484f77cfe25d079752ea3a19b1a93edb3c93e1262c4f310e149843359ff2c1
-generated: "2023-09-20T15:20:44.302630522+10:00"
+digest: sha256:15cf7820f99a3b67bc9a83db2444f54cc08669616616fb684ef39d0318f2698b
+generated: "2023-10-04T15:53:27.449884473+11:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.83.0
+version: 0.83.1
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,4 +45,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon-build-deploy to v0.25.0
+      description: update lagoon-build-deploy to v0.25.1


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
