### PR TITLE
Logging updates

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -36,3 +36,5 @@ annotations:
       description: update uselagoon/logs-dispatcher image to v3.4.0
     - kind: added
       description: schedule Logging Pods also on infra nodes
+    - kind: added
+      description: ability to configure toleration/affinity on FluentD deployment 

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -34,3 +34,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update uselagoon/logs-dispatcher image to v3.4.0
+    - kind: added
+      description: schedule Logging Pods also on infra nodes

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -37,4 +37,4 @@ annotations:
     - kind: added
       description: schedule Logging Pods also on infra nodes
     - kind: added
-      description: ability to configure toleration/affinity on FluentD deployment 
+      description: ability to configure toleration/affinity on FluentD deployment

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.79.0
+version: 0.80.0
 
 dependencies:
 - name: logging-operator
@@ -33,4 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: require minimum Kubernetes 1.23
+      description: update uselagoon/logs-dispatcher image to v3.4.0

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -13,6 +13,14 @@ spec:
         fsGroup: 0
     scaling:
       replicas: {{ .Values.fluentdReplicaCount }}
+  {{- with .Values.fluentdAffinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentdTolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
   {{- with .Values.fluentdMetrics }}
     metrics:
     {{- toYaml . | nindent 6 }}

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -251,6 +251,10 @@ enableDefaultForwarding: true
 # Set how many fluentd pods should be running
 fluentdReplicaCount: 3
 
+fluentdTolerations: []
+
+fluentdAffinity: {}
+
 # Add tolerations to the fluentbit daemonset so that it runs on e.g.
 # load-balancer nodes.
 fluentbitTolerations:

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -248,15 +248,16 @@ consolidateServiceIndices: false
 # sent to a third-party service and not to a central elasticsearch.
 enableDefaultForwarding: true
 
-# Set how many fluentd pods should be running
+# Set how many Fluentd log forwarder pods should be running
 fluentdReplicaCount: 3
 
+# Add tolerations and affinity to the Fluentd log forwarder statefulset to
+# better control where it runs e.g. avoiding spot or load-balancers
 fluentdTolerations: []
-
 fluentdAffinity: {}
 
-# Add tolerations to the fluentbit daemonset so that it runs on e.g.
-# load-balancer nodes.
+# Add tolerations to the Fluent Bit log collector daemonset to define where it
+# runs on to collect data e.g. load-balancer or infra nodes.
 fluentbitTolerations:
 - effect: NoSchedule
   key: lagoon.sh/lb

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -19,7 +19,7 @@ logsDispatcher:
     repository: uselagoon/logs-dispatcher
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is "latest".
-    tag: "v3.3.0"
+    tag: "v3.4.0"
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -121,7 +121,7 @@ cdnLogsCollector:
     repository: uselagoon/logs-dispatcher
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is "latest".
-    tag: "v3.3.0"
+    tag: "v3.4.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -260,6 +260,9 @@ fluentbitTolerations:
 - effect: NoSchedule
   key: lagoon.sh/spot
   operator: Exists
+- effect: NoSchedule
+  key: lagoon.sh/infra
+  operator: Exists
 
 # Expose metrics of the Logging Operator's fluentbit daemonset and fluentd
 # statefulset via a Prometheus Operator compatible ServiceMonitor object.

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.46.0
+version: 0.47.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -27,6 +27,4 @@ version: 0.46.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: require minimum Kubernetes 1.23
-    - kind: changed
-      description: removed autoscaling api version helper
+      description: update uselagoon/logs-concentrator image to v3.2.0

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: uselagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is "latest".
-  tag: "v3.1.0"
+  tag: "v3.2.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR collects a number of improvements to the logging setup in Lagoon.

it:
* updates the versions of the images used in the logs-dispatcher and logs-concentrator
* ensures that Loggin pods also schedule on infra nodes
* Allows users to configure toleration/affinity for FluentD deployments

closes #604 #589 