### PR TITLE
Feature/insights handler trivy server

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.38.0
+version: 1.39.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -40,7 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: require minimum Kubernetes 1.23
-    - kind: changed
-      description: removed autoscaling api version helper
+    - kind: added
+      description: Insights trivy service

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -465,6 +465,35 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create a default fully qualified app name for insights-trivy.
+*/}}
+{{- define "lagoon-core.insightsTrivy.fullname" -}}
+{{- include "lagoon-core.fullname" . }}-insights-trivy
+{{- end }}
+
+{{/*
+Common labels insights-trivy.
+*/}}
+{{- define "lagoon-core.insightsTrivy.labels" -}}
+helm.sh/chart: {{ include "lagoon-core.chart" . }}
+{{ include "lagoon-core.insightsTrivy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels insights-trivy.
+*/}}
+{{- define "lagoon-core.insightsTrivy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-core.insightsTrivy.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
 Create a default fully qualified app name for logs2notifications.
 */}}
 {{- define "lagoon-core.logs2notifications.fullname" -}}

--- a/charts/lagoon-core/templates/insights-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/insights-handler.deployment.yaml
@@ -74,6 +74,12 @@ spec:
           value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}/graphql
         - name: HTTP_LISTEN_PORT
           value: "3000"
+      {{- if .Values.insightsTrivy.enabled }}
+        - name: PROBLEMS_FROM_SBOM
+          value: "true"
+        - name: TRIVY_SERVER_ENDPOINT
+          value: http://{{ include "lagoon-core.insightsTrivy.fullname" . }}:{{ .Values.insightsTrivy.service.port }}
+      {{- end }}
       {{- range $key, $val := .Values.insightsHandler.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/lagoon-core/templates/insights-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/insights-handler.deployment.yaml
@@ -74,11 +74,11 @@ spec:
           value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}/graphql
         - name: HTTP_LISTEN_PORT
           value: "3000"
-      {{- if .Values.insightsTrivy.enabled }}
+      {{- if .Values.insightsHandler.trivy.enabled }}
         - name: PROBLEMS_FROM_SBOM
           value: "true"
         - name: TRIVY_SERVER_ENDPOINT
-          value: http://{{ include "lagoon-core.insightsTrivy.fullname" . }}:{{ .Values.insightsTrivy.service.port }}
+          value: http://{{ include "lagoon-core.insightsTrivy.fullname" . }}:{{ .Values.insightsHandler.trivy.service.port }}
       {{- end }}
       {{- range $key, $val := .Values.insightsHandler.additionalEnvs }}
         - name: {{ $key }}

--- a/charts/lagoon-core/templates/insights-trivy.deployment.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.deployment.yaml
@@ -28,6 +28,7 @@ spec:
         imagePullPolicy: {{ .Values.insightsTrivy.image.pullPolicy }}
         resources:
           {{- toYaml .Values.insightsTrivy.resources | nindent 10 }}
+        command: ["trivy", "server", "--cache-dir=/tmp", "--listen=0.0.0.0:4954", "-d"]
         ports:
             - containerPort: 4954
               protocol: TCP

--- a/charts/lagoon-core/templates/insights-trivy.deployment.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.insightsTrivy.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-core.insightsTrivy.fullname" . }}
+  labels:
+    {{- include "lagoon-core.insightsTrivy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.insightsTrivy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+    {{- with .Values.insightsTrivy.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "lagoon-core.insightsTrivy.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml (coalesce .Values.insightsTrivy.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
+      containers:
+      - name: insights-trivy
+        securityContext:
+          {{- toYaml .Values.insightsTrivy.securityContext | nindent 10 }}
+        image: "{{ .Values.insightsTrivy.image.repository }}:{{ coalesce .Values.insightsTrivy.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.insightsTrivy.image.pullPolicy }}
+        resources:
+          {{- toYaml .Values.insightsTrivy.resources | nindent 10 }}
+        ports:
+            - containerPort: 4954
+              protocol: TCP
+              name: TCP-4954
+        livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 4954
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 4954
+      {{- with .Values.insightsTrivy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.insightsTrivy.fullname" . }}
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.insightsTrivy.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.insightsTrivy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/insights-trivy.deployment.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.deployment.yaml
@@ -31,12 +31,12 @@ spec:
         ports:
             - containerPort: 4954
               protocol: TCP
-              name: TCP-4954
+              name: tcp-4954
         livenessProbe:
             httpGet:
               path: /healthz
               port: 4954
-          readinessProbe:
+        readinessProbe:
             httpGet:
               path: /healthz
               port: 4954

--- a/charts/lagoon-core/templates/insights-trivy.deployment.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.insightsTrivy.enabled -}}
+{{- if .Values.insightsHandler.trivy.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,22 +12,22 @@ spec:
   template:
     metadata:
       annotations:
-    {{- with .Values.insightsTrivy.podAnnotations }}
+    {{- with .Values.insightsHandler.trivy.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
         {{- include "lagoon-core.insightsTrivy.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
-        {{- toYaml (coalesce .Values.insightsTrivy.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
+        {{- toYaml (coalesce .Values.insightsHandler.trivy.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
       containers:
       - name: insights-trivy
         securityContext:
-          {{- toYaml .Values.insightsTrivy.securityContext | nindent 10 }}
-        image: "{{ .Values.insightsTrivy.image.repository }}:{{ coalesce .Values.insightsTrivy.image.tag .Values.imageTag .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.insightsTrivy.image.pullPolicy }}
+          {{- toYaml .Values.insightsHandler.trivy.securityContext | nindent 10 }}
+        image: "{{ .Values.insightsHandler.trivy.image.repository }}:{{ coalesce .Values.insightsHandler.trivy.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.insightsHandler.trivy.image.pullPolicy }}
         resources:
-          {{- toYaml .Values.insightsTrivy.resources | nindent 10 }}
+          {{- toYaml .Values.insightsHandler.trivy.resources | nindent 10 }}
         command: ["trivy", "server", "--cache-dir=/tmp", "--listen=0.0.0.0:4954", "-d"]
         ports:
             - containerPort: 4954
@@ -41,7 +41,7 @@ spec:
             httpGet:
               path: /healthz
               port: 4954
-      {{- with .Values.insightsTrivy.nodeSelector }}
+      {{- with .Values.insightsHandler.trivy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -65,10 +65,10 @@ spec:
                   values:
                   - {{ .Release.Name }}
               topologyKey: kubernetes.io/hostname
-      {{- with .Values.insightsTrivy.affinity }}
+      {{- with .Values.insightsHandler.trivy.affinity }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.insightsTrivy.tolerations }}
+      {{- with .Values.insightsHandler.trivy.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/lagoon-core/templates/insights-trivy.service.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.service.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.insightsTrivy.service.type }}
   ports:
   - port: {{ .Values.insightsTrivy.service.port }}
-    targetPort: TCP-4954
+    targetPort: 4954
     name: TCP
   selector:
     {{- include "lagoon-core.insightsTrivy.selectorLabels" . | nindent 4 }}

--- a/charts/lagoon-core/templates/insights-trivy.service.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.insightsTrivy.enabled -}}
+{{- if .Values.insightsHandler.trivy.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "lagoon-core.insightsTrivy.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.insightsTrivy.service.type }}
+  type: {{ .Values.insightsHandler.trivy.service.type }}
   ports:
-  - port: {{ .Values.insightsTrivy.service.port }}
+  - port: {{ .Values.insightsHandler.trivy.service.port }}
     targetPort: 4954
     name: tcp-4954
   selector:

--- a/charts/lagoon-core/templates/insights-trivy.service.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
   - port: {{ .Values.insightsTrivy.service.port }}
     targetPort: 4954
-    name: TCP
+    name: tcp-4954
   selector:
     {{- include "lagoon-core.insightsTrivy.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/lagoon-core/templates/insights-trivy.service.yaml
+++ b/charts/lagoon-core/templates/insights-trivy.service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.insightsTrivy.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-core.insightsTrivy.fullname" . }}
+  labels:
+    {{- include "lagoon-core.insightsTrivy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.insightsTrivy.service.type }}
+  ports:
+  - port: {{ .Values.insightsTrivy.service.port }}
+    targetPort: TCP-4954
+    name: TCP
+  selector:
+    {{- include "lagoon-core.insightsTrivy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -592,6 +592,12 @@ insightsHandler:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+insightsTrivy:
+  enabled: false
+  service:
+    type: ClusterIP
+    port: 4954
+
 logs2notifications:
   enabled: true
   replicaCount: 2

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -618,6 +618,9 @@ insightsHandler:
     # targetMemoryUtilizationPercentage: 80
 
 insightsTrivy:
+  image:
+    repository: aquasec/trivy
+    tag: latest
   enabled: false
   service:
     type: ClusterIP

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -616,15 +616,14 @@ insightsHandler:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
-
-insightsTrivy:
-  image:
-    repository: aquasec/trivy
-    tag: latest
-  enabled: false
-  service:
-    type: ClusterIP
-    port: 4954
+  trivy:
+    enabled: false
+    image:
+      repository: aquasec/trivy
+      tag: latest
+    service:
+      type: ClusterIP
+      port: 4954
 
 logs2notifications:
   enabled: true


### PR DESCRIPTION
This PR introduces a Trivy server component for problems generation for lagoon-core.

If enabled (via setting `.Values.insightsTrivy.enabled=true`) this will change the insights-handler's deployment to include  env vars to enable Trivy scans of incoming SBOMS, as well as spinning up a Trivy server instance.

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
