### PR TITLE
Changes typo 'hpst' to 'host'

### DIFF
--- a/charts/lagoon-docker-host/README.md
+++ b/charts/lagoon-docker-host/README.md
@@ -1,4 +1,4 @@
 # Lagoon Docker Host
 
-This chart installs a docker hpst service for [Lagoon](https://github.com/amazeeio/lagoon/).
+This chart installs a docker host service for [Lagoon](https://github.com/amazeeio/lagoon/).
 Install this chart into the cluster you want to deploy workloads to.


### PR DESCRIPTION
Was just browsing the source for the docker-host and saw the typo.

Fixed.