### PR TITLE
chore: add clusterroles for tasks and builds to admin and edit

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,11 +16,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.26.2
+version: 0.26.3
 
 appVersion: v0.15.4
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller to v0.15.4
+      description: added clusterroles for tasks and builds

--- a/charts/lagoon-build-deploy/templates/clusterrolebinding.yaml
+++ b/charts/lagoon-build-deploy/templates/clusterrolebinding.yaml
@@ -12,3 +12,31 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-build-deploy.fullname" . }}-builds
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["crd.lagoon.sh"]
+  resources: ["lagoonbuilds"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "lagoon-build-deploy.fullname" . }}-tasks
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["crd.lagoon.sh"]
+  resources: ["lagoontasks"]
+  verbs: ["*"]


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Just adding the missing clusterroles to the admin role to allow the lagoon namespace deployer service account to interact with builds and tasks within the namespace as required

Currently the deployer service account can interact with all other resources within the namespace during a build, and being able to interact with other builds or tasks that may exist in the namespace would be useful for being able to handle previous build or task cleanups within a build process.
