### PR TITLE
fix: avoid installing the registry multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ install-lagoon-remote: install-lagoon-build-deploy install-lagoon-core install-m
 # Do not install without lagoon-core
 #
 .PHONY: install-lagoon-build-deploy
-install-lagoon-build-deploy: install-lagoon-core install-registry
+install-lagoon-build-deploy: install-lagoon-core
 	$(HELM) dependency build ./charts/lagoon-build-deploy/
 	$(HELM) upgrade \
 		--install \
@@ -287,6 +287,11 @@ install-lagoon-build-deploy: install-lagoon-core install-registry
 		$$([ $(LAGOON_FEATURE_FLAG_DEFAULT_RWX_TO_RWO) ] && echo '--set lagoonFeatureFlagDefaultRWX2RWO=$(LAGOON_FEATURE_FLAG_DEFAULT_RWX_TO_RWO)') \
 		lagoon-build-deploy \
 		./charts/lagoon-build-deploy
+
+# allow skipping registry install for install-lagoon-remote target
+ifneq ($(SKIP_INSTALL_REGISTRY),true)
+install-lagoon-build-deploy: install-registry
+endif
 
 #
 # The following targets facilitate local development only and aren't used in CI.


### PR DESCRIPTION
While the fill-test-ci-values target's dependency on install-registry was correctly manipulated by the SKIP_INSTALL_REGISTRY variable, the install-lagoon-build-deploy target had a hard-coded dependency on install-registry. The result was that the registry would get installed multiple times anyway via the fill-test-ci-values target via an indirect dependency.

Fix that by removing the dependency that install-lagoon-build-deploy has on install-registry when SKIP_INSTALL_REGISTRY=true.

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
