### PR TITLE
chore: update storage-calcluator and add metrics monitor

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.87.0
+version: 0.88.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -45,10 +45,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: remove insights-remote service if not enabled
-    - kind: removed
-      description: removed old kubernetes build deploy references
+      description: update storage-calculator to v0.5.1
     - kind: changed
-      description: updated to insights-remote:v0.0.8
-    - kind: changed
-      description: updated lagoon-build-deploy chart to v0.26.3
+      description: added metrics to storage-calculator

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -98,3 +98,5 @@ sshPortal:
 
 storageCalculator:
   enabled: true
+  serviceMonitor:
+    enabled: false

--- a/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
@@ -35,10 +35,14 @@ spec:
         command:
         - /manager
         args:
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=0.0.0.0:8080"
+        - "--prometheus-metrics=true"
         {{- with .Values.storageCalculator.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 8080
         env:
         {{- range $name, $value := .Values.storageCalculator.extraEnvs }}
         - name: {{ .name }}

--- a/charts/lagoon-remote/templates/storage-calculator.service.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.storageCalculator.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}-metrics
+  labels:
+    metrics-only: "true"
+    {{- include "lagoon-remote.storageCalculator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.storageCalculator.metricsService.type }}
+  ports:
+  - port: {{ .Values.storageCalculator.metricsService.ports.metrics }}
+    targetPort: metrics
+    name: metrics
+  selector:
+    {{- include "lagoon-remote.storageCalculator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-remote/templates/storage-calculator.servicemonitor.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.storageCalculator.enabled .Values.storageCalculator.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.storageCalculator.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      metrics-only: "true"
+      {{- include "lagoon-remote.storageCalculator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -362,8 +362,16 @@ storageCalculator:
     # template
     name:
 
+  metricsService:
+    type: ClusterIP
+    ports:
+      metrics: 9912
+
+  serviceMonitor:
+    enabled: true
+
   image:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.2.3
+    tag: v0.5.1


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Updates storage calculator to the latest version 0.5.0 which contains metrics endpoints and additional dependency updates. Also adds support to the chart to expose the metrics.