### PR TITLE
Support Keycloak migrations via the API init-container

### DIFF
--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -27,7 +27,9 @@ keycloakAdminEmail: admin@example.com
 api:
   replicaCount: 1
   image:
-    repository: uselagoon/api
+# TODO - update repo/tag before v2.18 release
+    repository: testlagoon/api
+    tag: main
   resources:
     requests:
       cpu: "10m"
@@ -47,7 +49,6 @@ apiRedis:
     requests:
       cpu: "10m"
 
-# TODO - update repo/tag before v2.11 release
 actionsHandler:
   replicaCount: 1
   image:
@@ -71,7 +72,9 @@ keycloak:
       replyTo: lagoon@example.com
       envelopeFrom: lagoon@example.com
   image:
-    repository: uselagoon/keycloak
+# TODO - update repo/tag before v2.18 release
+    repository: testlagoon/keycloak
+    tag: main
   resources:
     requests:
       cpu: "10m"

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -30,6 +30,12 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml (coalesce .Values.api.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
+      initContainers:
+        - command:
+            - "node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
+          image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          name: migrations
       containers:
       - name: api
         securityContext:

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -32,6 +32,8 @@ spec:
         {{- toYaml (coalesce .Values.api.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
       initContainers:
         - command:
+            - "sh"
+            - "-c"
             - "node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
           image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -31,46 +31,46 @@ spec:
       securityContext:
         {{- toYaml (coalesce .Values.api.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
       initContainers:
-        - command:
-            - "sh"
-            - "-c"
-            - "node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
-          image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          name: migrations
-          env:
-          - name: API_DB_HOST
-            value: {{ include "lagoon-core.apiDB.fullname" . }}
-          - name: API_DB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "lagoon-core.apiDB.fullname" . }}
-                key: API_DB_PASSWORD
-          - name: KEYCLOAK_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "lagoon-core.keycloak.fullname" . }}
-                key: KEYCLOAK_ADMIN_PASSWORD
-          - name: KEYCLOAK_ADMIN_USER
-            value: {{ .Values.keycloakAdminUser | quote }}
-          - name: KEYCLOAK_API_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "lagoon-core.keycloak.fullname" . }}
-                key: KEYCLOAK_API_CLIENT_SECRET
-          - name: KEYCLOAK_URL
-            {{- if .Values.keycloakFrontEndURL }}
-            value: {{ .Values.keycloakFrontEndURL }}
-            {{- else if .Values.keycloak.ingress.enabled }}
-            value: https://{{ index .Values.keycloak.ingress.hosts 0 "host" }}
-            {{- else }}
-            value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}
-            {{- end }}
-          - name: REDIS_HOST
-            value: {{ include "lagoon-core.apiRedis.fullname" . }}
-          envFrom:
-          - secretRef:
-              name: {{ include "lagoon-core.api.fullname" . }}
+      - command:
+        - "sh"
+        - "-c"
+        - "node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
+        image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+        name: migrations
+        env:
+        - name: API_DB_HOST
+          value: {{ include "lagoon-core.apiDB.fullname" . }}
+        - name: API_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.apiDB.fullname" . }}
+              key: API_DB_PASSWORD
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_ADMIN_PASSWORD
+        - name: KEYCLOAK_ADMIN_USER
+          value: {{ .Values.keycloakAdminUser | quote }}
+        - name: KEYCLOAK_API_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_API_CLIENT_SECRET
+        - name: KEYCLOAK_URL
+          {{- if .Values.keycloakFrontEndURL }}
+          value: {{ .Values.keycloakFrontEndURL }}
+          {{- else if .Values.keycloak.ingress.enabled }}
+          value: https://{{ index .Values.keycloak.ingress.hosts 0 "host" }}
+          {{- else }}
+          value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}
+          {{- end }}
+        - name: REDIS_HOST
+          value: {{ include "lagoon-core.apiRedis.fullname" . }}
+        envFrom:
+        - secretRef:
+            name: {{ include "lagoon-core.api.fullname" . }}
       containers:
       - name: api
         securityContext:

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -38,6 +38,39 @@ spec:
           image: "{{ .Values.api.image.repository }}:{{ coalesce .Values.api.image.tag .Values.imageTag .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           name: migrations
+          env:
+          - name: API_DB_HOST
+            value: {{ include "lagoon-core.apiDB.fullname" . }}
+          - name: API_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "lagoon-core.apiDB.fullname" . }}
+                key: API_DB_PASSWORD
+          - name: KEYCLOAK_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "lagoon-core.keycloak.fullname" . }}
+                key: KEYCLOAK_ADMIN_PASSWORD
+          - name: KEYCLOAK_ADMIN_USER
+            value: {{ .Values.keycloakAdminUser | quote }}
+          - name: KEYCLOAK_API_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "lagoon-core.keycloak.fullname" . }}
+                key: KEYCLOAK_API_CLIENT_SECRET
+          - name: KEYCLOAK_URL
+            {{- if .Values.keycloakFrontEndURL }}
+            value: {{ .Values.keycloakFrontEndURL }}
+            {{- else if .Values.keycloak.ingress.enabled }}
+            value: https://{{ index .Values.keycloak.ingress.hosts 0 "host" }}
+            {{- else }}
+            value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}
+            {{- end }}
+          - name: REDIS_HOST
+            value: {{ include "lagoon-core.apiRedis.fullname" . }}
+          envFrom:
+          - secretRef:
+              name: {{ include "lagoon-core.api.fullname" . }}
       containers:
       - name: api
         securityContext:

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -53,6 +53,19 @@ spec:
         - name: KEYCLOAK_ADMIN_EMAIL
           value: {{ . | quote }}
         {{- end }}
+        - name: LAGOON_DB_HOST
+          value: {{ include "lagoon-core.apiDB.fullname" . }}
+        - name: LAGOON_DB_VENDOR
+          value: mariadb
+        - name: LAGOON_DB_USER
+          value: api
+        - name: LAGOON_DB_DATABASE
+          value: infrastructure
+        - name: LAGOON_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.apiDB.fullname" . }}
+              key: API_DB_PASSWORD
       {{- range $key, $val := .Values.keycloak.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -48,3 +48,5 @@ annotations:
       description: removed dioscuri subchart, activestandby is handled via a Lagoon task directly now
     - kind: changed
       description: updated insights-remote version to v0.0.9
+    - kind: changed
+      description: added initcontainer to api to handle keycloak migrations


### PR DESCRIPTION
This PR adds the keycloak migrations to the initcontainer run in the API

https://github.com/uselagoon/lagoon/pull/3612