### PR TITLE
CDN service annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ Documentation on probes for pod startup is [here](https://kubernetes.io/docs/con
 
 ### Run chart-testing (lint) locally
 
+```bash
+docker run --rm --interactive --detach --network host --name ct "--volume=$(pwd):/workdir" "--workdir=/workdir" --volume=$(pwd)/default.ct.yaml:/etc/ct/ct.yaml quay.io/helmpack/chart-testing:latest cat
+docker exec ct git config --global --add safe.directory /workdir
+docker exec ct ct lint
 ```
-$ docker run --rm --interactive --detach --network host --name ct "--volume=$(pwd):/workdir" "--workdir=/workdir" --volume=$(pwd)/default.ct.yaml:/etc/ct/ct.yaml quay.io/helmpack/chart-testing:latest cat
-$ docker exec ct ct lint
+
+### Run chart-testing (install) locally
+
+Prerequisite: install [ct](https://github.com/helm/chart-testing).
+
+```bash
+kind create cluster -n chart-testing
+ct install --charts=charts/lagoon-logging
+kind delete cluster -n chart-testing
 ```

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.80.0
+version: 0.81.0
 
 dependencies:
 - name: logging-operator
@@ -32,9 +32,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: update uselagoon/logs-dispatcher image to v3.4.0
     - kind: added
-      description: schedule Logging Pods also on infra nodes
-    - kind: added
-      description: ability to configure toleration/affinity on FluentD deployment
+      description: support for annotations on the CDN service

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -68,7 +68,10 @@ cdnLogsCollector:
   buffer:
     storageClassName: standard
     size: 1Gi
-  serviceType: ClusterIP
+  service:
+    type: ClusterIP
+    annotations:
+      sh.lagoon.chart.testKey: lagoonTestValue
   tls:
     caCert: |-
       -----BEGIN CERTIFICATE-----

--- a/charts/lagoon-logging/templates/cdn-logs-collector.service.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.service.yaml
@@ -5,8 +5,12 @@ metadata:
   name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}
   labels:
     {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+  {{- with .Values.cdnLogsCollector.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: {{ .Values.cdnLogsCollector.serviceType }}
+  type: {{ .Values.cdnLogsCollector.service.type }}
   selector:
     {{- include "lagoon-logging.cdnLogsCollector.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/lagoon-logging/templates/tests/cdn-service-annotations.yaml
+++ b/charts/lagoon-logging/templates/tests/cdn-service-annotations.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: service-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-services
+subjects:
+- kind: Group
+  name: system:serviceaccounts # all serviceaccounts
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: service-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-test-cdn-service-annotations
+  labels:
+    {{- include "lagoon-logging.logsDispatcher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: kubectl
+    image: alpine:latest
+    command:
+    - sh
+    args:
+    - "-c"
+    - |
+      set -eu
+      apk add --no-cache kubectl jq
+      kubectl get svc -o json {{ include "lagoon-logging.cdnLogsCollector.fullname" . }} |
+      jq -e '.metadata.annotations["sh.lagoon.chart.testKey"] == "lagoonTestValue"'
+  restartPolicy: Never

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -144,7 +144,9 @@ cdnLogsCollector:
     size: 8Gi
     storageClassName: ""
 
-  serviceType: LoadBalancer
+  service:
+    type: LoadBalancer
+    annotations: {}
 
   # TLS configuration is required
   # These should be server certificates, and the CDN should be configured to


### PR DESCRIPTION
Newer versions of the AWS load balancer controller [change the default behaviour](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations/#lb-scheme) of `LoadBalancer` objects to be internal (private IP address) rather than internet-facing. The interface for making a `LoadBalancer` internet-facing is now an annotation on the k8s service object.

So this PR adds support for annotations on the CDN service, which is the only one intended to be used as a `LoadBalancer`.
