### PR TITLE
fix lagoon logging test

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.81.0
+version: 0.81.1
 
 dependencies:
 - name: logging-operator
@@ -31,6 +31,16 @@ dependencies:
 # It should be started afresh for each release
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - kind: added
-      description: support for annotations on the CDN service
+    - kind: security
+      description: >
+        Previously the test role and rolebinding were being installed
+        unconditionally. With this change they are only installed when running
+        helm test and then removed.
+
+        Having the role and rolebinding installed unconditionally would mean
+        that any serviceaccount (including the default) would be able to view
+        service objects in the lagoon-logging namespace. This is an unnecessary
+        elevation of privilege, but these service objects do not contain
+        anything sensitive.

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -34,13 +34,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: security
-      description: >
-        Previously the test role and rolebinding were being installed
-        unconditionally. With this change they are only installed when running
-        helm test and then removed.
-
-        Having the role and rolebinding installed unconditionally would mean
-        that any serviceaccount (including the default) would be able to view
-        service objects in the lagoon-logging namespace. This is an unnecessary
-        elevation of privilege, but these service objects do not contain
-        anything sensitive.
+      description: avoid test role and rolebinding being wrongly installed

--- a/charts/lagoon-logging/templates/tests/cdn-service-annotations.yaml
+++ b/charts/lagoon-logging/templates/tests/cdn-service-annotations.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-2"
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["services"]
@@ -18,6 +19,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
 subjects:
 - kind: Group
   name: system:serviceaccounts # all serviceaccounts
@@ -36,6 +38,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
 spec:
   containers:
   - name: kubectl

--- a/charts/lagoon-logging/templates/tests/cdn-service-annotations.yaml
+++ b/charts/lagoon-logging/templates/tests/cdn-service-annotations.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: service-reader
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["services"]
@@ -12,6 +15,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: read-services
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:
 - kind: Group
   name: system:serviceaccounts # all serviceaccounts
@@ -29,6 +35,7 @@ metadata:
     {{- include "lagoon-logging.logsDispatcher.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
   - name: kubectl

--- a/charts/lagoon-logging/templates/tests/test-connection.yaml
+++ b/charts/lagoon-logging/templates/tests/test-connection.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "lagoon-logging.logsDispatcher.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
   - name: nc


### PR DESCRIPTION
- fix: add missing helm hook annotations to test objects
- chore: bump lagoon-logging chart version
