### PR TITLE
chore: add legacy registry passthrough support

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,11 +16,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.26.3
+version: 0.26.4
 
-appVersion: v0.15.4
+appVersion: v0.15.5
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: added clusterroles for tasks and builds
+      description: added legacy registry passthrough support

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -167,6 +167,9 @@ spec:
         {{- with .Values.timeoutForLongRunningTaskPods }}
         - "--timeout-longrunning-task-pod-cleanup={{ . }}"
         {{- end }}
+        {{- with .Values.unauthenticatedRegistry }}
+        - "--unauthenticated-registry={{ . }}"
+        {{- end }}
         {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -6,6 +6,10 @@ rabbitMQHostname: ""
 rabbitMQPassword: ""
 rabbitMQUsername: ""
 
+# This is here due to the removal of the passthrough from core https://github.com/uselagoon/lagoon/pull/3659
+# if you leveraged this value in your core, you should ensure you update your remotes with this value to reflect what you previously had provided in core
+# unauthenticatedRegistry: registry.lagoon.svc:5000
+
 # NOTE!! lagoon api/host/port values if left empty fall back to the task api/host/port values
 # taskSSHHost/lagoonTokenHost is the hostname for the lagoon token service
 # taskSSHHost will be deprecated in favor of lagoonTokenHost


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Just adds the legacy registry passthrough support to the build-deploy chart since it is going to be removed from core https://github.com/uselagoon/lagoon/pull/3659