### PR TITLE
chore: remove legacy registry passthrough from core

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.41.0
+version: 1.41.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,10 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: bump lagoon-opensearch-sync version to v0.7.1
-    - kind: changed
-      description: updated to insights-handler:v0.0.2
-    - kind: changed
-      description: pinned insights to trivy:0.48.0
-    - kind: changed
-      description: update lagoon appVersion to v2.17.0
+      description: remove unused legacy registry setting from core

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -3,7 +3,6 @@
 # To be deprecated - see uselagoon/lagoon#2907
 harborURL: http://disabled-only-use-harbor-via-deploy-controller.invalid
 harborAdminPassword: not-needed
-registry: disabled-only-use-harbor-via-deploy-controller.invalid
 
 # used in api
 elasticsearchURL: http://opendistro-es-client-service.opendistro-es.svc.cluster.local:9200

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -126,8 +126,6 @@ spec:
               key: RABBITMQ_USERNAME
         - name: REDIS_HOST
           value: {{ include "lagoon-core.apiRedis.fullname" . }}
-        - name: REGISTRY
-          value: {{ required "A valid .Values.registry required!" .Values.registry | quote }}
         - name: S3_FILES_BUCKET
           value: {{ required "A valid .Values.s3FilesBucket required!" .Values.s3FilesBucket | quote }}
         - name: S3_FILES_HOST

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -94,8 +94,6 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.broker.fullname" . }}
               key: RABBITMQ_USERNAME
-        - name: REGISTRY
-          value: {{ required "A valid .Values.registry required!" .Values.registry | quote }}
       {{- range $key, $val := .Values.webhooks2tasks.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -4,7 +4,6 @@
 # elasticsearchURL:
 # harborURL:
 # kibanaURL:
-# registry:
 # s3BAASSecretAccessKey:
 # s3BAASAccessKeyID:
 # s3FilesAccessKeyID:


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
Removes the setting of the legacy registry passthrough from core due to https://github.com/uselagoon/lagoon/pull/3659