### PR TITLE
Updates insights handler and remote versions

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -44,3 +44,5 @@ annotations:
       description: remove unused legacy registry setting from core
     - kind: changed
       description: modify keycloak liveness and readiness endpoint
+    - kind: changed
+      description: updated insights-handler to v0.0.4

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -595,7 +595,7 @@ insightsHandler:
     repository: uselagoon/insights-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: main
+    tag: "v0.0.4"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -41,8 +41,10 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update storage-calculator to v0.5.1
+      description: update storage-calculator to v0.5.2
     - kind: changed
       description: added metrics to storage-calculator
     - kind: removed
       description: removed dioscuri subchart, activestandby is handled via a Lagoon task directly now
+    - kind: changed
+      description: updated insights-remote version to v0.0.9

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -215,7 +215,7 @@ insightsRemote:
     repository: uselagoon/insights-remote
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.0.8"
+    tag: "v0.0.9"
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
This PR updates the versions of insights-remote and insights-handler to bring them into line with the currently latest versions of the services.
