### PR TITLE
feat: apiDB/keycloakDB startup/readiness/liveness probes and startup/shutdown time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ install-lagoon-core: install-minio
 		--set api.image.repository=$(IMAGE_REGISTRY)/api \
 		--set api.image.tag=$(IMAGE_TAG) \
 		--set apiDB.image.repository=$(IMAGE_REGISTRY)/api-db \
+		--set apiDB.image.tag=testing-updated-db-images \
 		--set apiRedis.image.repository=$(IMAGE_REGISTRY)/api-redis \
 		--set authServer.image.repository=$(IMAGE_REGISTRY)/auth-server \
 		--set autoIdler.enabled=false \
@@ -197,6 +198,7 @@ install-lagoon-core: install-minio
 		--set keycloak.image.repository=$(IMAGE_REGISTRY)/keycloak \
 		--set keycloak.image.tag=$(IMAGE_TAG) \
 		--set keycloakDB.image.repository=$(IMAGE_REGISTRY)/keycloak-db \
+		--set keycloakDB.image.tag=testing-updated-db-images \
 		--set logs2notifications.image.repository=$(IMAGE_REGISTRY)/logs2notifications \
 		--set logs2notifications.email.disabled=true \
 		--set logs2notifications.microsoftteams.disabled=true \

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.41.0
+version: 1.42.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -40,11 +40,13 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: bump lagoon-opensearch-sync version to v0.7.1
-    - kind: changed
-      description: updated to insights-handler:v0.0.2
-    - kind: changed
-      description: pinned insights to trivy:0.48.0
-    - kind: changed
-      description: update lagoon appVersion to v2.17.0
+    - kind: fixed
+      description: apiDB livenessProbe access denied
+    - kind: added
+      description: apiDB readinessProbe uses sql query
+    - kind: added
+      description: apiDB startupProbe waits for init completion
+    - kind: added
+      description: apiDB configurable terminationGracePeriodSeconds
+    - kind: added
+      description: keycloakDB aligns to apiDB

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -36,7 +36,9 @@ api:
 
 apiDB:
   image:
-    repository: uselagoon/api-db
+# TODO - update repo/tag before v2.18 release
+    repository: testlagoon/api-db
+    tag: testing-updated-db-images
   storageSize: 16Gi
   resources:
     requests:
@@ -84,7 +86,9 @@ keycloak:
 
 keycloakDB:
   image:
-    repository: uselagoon/keycloak-db
+# TODO - update repo/tag before v2.18 release
+    repository: testlagoon/keycloak-db
+    tag: testing-updated-db-images
   resources:
     requests:
       cpu: "10m"

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -49,9 +49,10 @@ spec:
         volumeMounts:
         - name: {{ include "lagoon-core.apiDB.fullname" . }}-data
           mountPath: /var/lib/mysql
+      {{- with .Values.apiDB.readinessProbe }}
         readinessProbe:
-          tcpSocket:
-            port: mariadb
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       {{- with .Values.apiDB.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -79,6 +79,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.apiDB.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: {{ include "lagoon-core.apiDB.fullname" . }}-data

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -49,12 +49,14 @@ spec:
         volumeMounts:
         - name: {{ include "lagoon-core.keycloakDB.fullname" . }}-data
           mountPath: /var/lib/mysql
-        livenessProbe:
-          tcpSocket:
-            port: mariadb
+      {{- with .Values.keycloakDB.readinessProbe }}
         readinessProbe:
-          tcpSocket:
-            port: mariadb
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.keycloakDB.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       {{- with .Values.keycloakDB.startupProbe }}
         startupProbe:
           {{- toYaml . | nindent 10 }}
@@ -75,6 +77,10 @@ spec:
       {{- end }}
       {{- with .Values.keycloakDB.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keycloakDB.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -304,11 +304,25 @@ keycloakDB:
   additionalEnvs:
   #   FOO: Bar
 
+  terminationGracePeriodSeconds: 30
+
   startupProbe:
     # 60*10s period = 10 minutes
     failureThreshold: 60
     tcpSocket:
       port: mariadb
+
+  livenessProbe:
+    exec:
+      command:
+      - mysqladmin
+      - --connect-timeout=4
+      - ping
+
+  readinessProbe:
+    exec:
+      command:
+      - /usr/share/container-scripts/mysql/readiness-probe.sh
 
 broker:
   replicaCount: 3

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -173,8 +173,11 @@ apiDB:
   startupProbe:
     # 60*10s period = 10 minutes
     failureThreshold: 60
-    tcpSocket:
-      port: mariadb
+    exec:
+      command:
+      - test
+      - -f
+      - /tmp/mariadb-init-complete
 
   livenessProbe:
     exec:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -170,6 +170,8 @@ apiDB:
 
   storageSize: 128Gi
 
+  terminationGracePeriodSeconds: 30
+
   startupProbe:
     # 60*10s period = 10 minutes
     failureThreshold: 60

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -183,6 +183,11 @@ apiDB:
       - --connect-timeout=4
       - ping
 
+  readinessProbe:
+    exec:
+      command:
+      - /usr/share/container-scripts/mysql/readiness-probe.sh
+
 apiRedis:
   image:
     repository: uselagoon/api-redis

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -180,8 +180,6 @@ apiDB:
     exec:
       command:
       - mysqladmin
-      - --host=localhost
-      - --port=3306
       - --connect-timeout=4
       - ping
 


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

## Probes

There are some changes to all the probe types for both apiDB and keycloakDB to fix unnecessary warnings in logs and to prevent premature connections.

#### startupProbe

The [init script](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/entrypoints/9999-mariadb-init.bash) from the `uselagoon/mariadb` base image starts `mysqld` multiple times to install/upgrade the schema, so a TCP probe will signal startup is complete before the init is actually done. The probe is changed to check for a file that signifies init completions. Depends on https://github.com/uselagoon/lagoon-images/pull/957.

#### livenessProbe

`[Warning] Access denied for user 'root'@'127.0.0.1' (using password: YES)`

Using `localhost` and port `3306` forces mysqladmin to connect to `127.0.0.1` via TCP, instead of via socket. The uselagoon/mariadb images only set a root password for `localhost`, so the attempt to authenticate via `127.0.0.1` fails. 

#### readinessProbe

`Aborted connection 178393 to db: 'unconnected' user: 'unauthenticated' host: '10.200.0.25' (This connection closed normally without authentication)`

The current TCP based readiness probe causes an `Aborted connection` log for each check. Changing it to the `readiness-probe.sh` script removes the log and also ensures that mysqld is able to serve SQL requests, not just that it can open a socket.

## Startup/Shutdown

In the case of a db with a lot of data that has a larger than default buffer pool and/or log file, there can be issues with the 30 second shutdown and startup timeouts that make it impossible to recover from a crash.

This PR makes the `terminationGracePeriodSeconds` configurable to allow more time for a complete shutdown.