### PR TITLE
chore: update storage-calculator to v0.5.3

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.88.0
+version: 0.88.1
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,16 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update storage-calculator to v0.5.2
-    - kind: changed
-      description: added metrics to storage-calculator
-    - kind: removed
-      description: removed dioscuri subchart, activestandby is handled via a Lagoon task directly now
-    - kind: changed
-      description: updated insights-remote version to v0.0.9
-    - kind: changed
-      description: update lagoon-build-deploy to 0.26.4
-    - kind: changed
-      description: update ssh-portal to v0.34.0
-    - kind: added
-      description: add support for logs access via SSH
+      description: update storage-calculator to v0.5.3

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -373,4 +373,4 @@ storageCalculator:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.5.2
+    tag: v0.5.3


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Updates the lagoon-remote chart to use the latest version of the storage-calculator