### PR TITLE
update Lagoon appVersion to v2.18.2

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.43.0
+version: 1.44.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,6 +41,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: reduce default replicas for broker to 1
+      description: add SSH_ENDPOINT vars to api service
     - kind: changed
       description: update Lagoon appVersion to v2.18.1

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -27,7 +27,7 @@ version: 1.44.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.18.1
+appVersion: v2.18.2
 
 dependencies:
 - name: nats
@@ -43,4 +43,4 @@ annotations:
     - kind: changed
       description: add SSH_ENDPOINT vars to api service
     - kind: changed
-      description: update Lagoon appVersion to v2.18.1
+      description: update Lagoon appVersion to v2.18.2

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -18,6 +18,8 @@ lagoonUIURL: http://ui:9101
 lagoonWebhookURL: http://webhook:11213
 defaultIngressClassName: nginx
 
+sshTokenEndpoint: ssh-token.example.com
+
 # used in ui
 # lagoonAPIURL: https://api.example.com/graphql
 # keycloakFrontEndURL: https://keycloak.example.com

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -175,6 +175,16 @@ spec:
         - name: S3_FILES_REGION
           value: {{ . | quote }}
         {{- end }}
+      {{- if .Values.sshTokenEndpoint }}
+        - name: SSH_TOKEN_ENDPOINT
+          value: {{ .Values.sshTokenEndpoint | quote }}
+      {{- end }}
+        - name: SSH_TOKEN_ENDPOINT_PORT
+          {{- if .Values.sshToken.enabled }}
+          value: {{ .Values.sshToken.service.ports.sshserver | quote }}
+          {{- else }}
+          value: {{ .Values.ssh.service.port | quote }}
+          {{- end }}
         - name: UI_URL
           {{- if .Values.lagoonUIURL }}
           value: {{ .Values.lagoonUIURL | quote }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -12,8 +12,14 @@
 # s3FilesSecretAccessKey:
 
 # These values are optional.
-
 # overwriteActiveStandbyTaskImage:
+
+# appspecific discovery.json settings
+# This should point to the publicly accessible ssh endpoint as a schema-less
+# URI (either domain or IP) for the ssh-token (or fallback ssh) service
+# e.g. ssh-token.example.com, ssh.example.com or 192.168.0.100
+# The port will be read from the sshToken (or ssh) port value
+# sshTokenEndpoint:
 
 # These values are optional depending on the services Lagoon is integrated with
 # in your environment.

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.88.0
+version: 0.88.1
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,16 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update storage-calculator to v0.5.2
-    - kind: changed
-      description: added metrics to storage-calculator
-    - kind: removed
-      description: removed dioscuri subchart, activestandby is handled via a Lagoon task directly now
-    - kind: changed
-      description: updated insights-remote version to v0.0.9
-    - kind: changed
-      description: update lagoon-build-deploy to 0.26.4
-    - kind: changed
-      description: update ssh-portal to v0.34.0
-    - kind: added
-      description: add support for logs access via SSH
+      description: update storage-calculator to v0.5.3

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -373,4 +373,4 @@ storageCalculator:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.5.2
+    tag: v0.5.3

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.55.0
+version: 0.56.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.18.1
+appVersion: v2.18.2
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -29,4 +29,4 @@ appVersion: v2.18.1
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update Lagoon appVersion to v2.18.1
+      description: update Lagoon appVersion to v2.18.2


### PR DESCRIPTION
This PR updates Lagoon to appVersion v2.18.2
It also updates storage-calculator to v0.5.3
It also adds the logic to API.deployment to present the ssh endpoints for https://github.com/uselagoon/lagoon/pull/3632