### PR TITLE
chore: Use dedicated service for metrics

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.47.0
+version: 0.48.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -27,4 +27,4 @@ version: 0.47.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update uselagoon/logs-concentrator image to v3.2.0
+      description: use dedicated service for metrics

--- a/charts/lagoon-logs-concentrator/templates/metrics-service.yaml
+++ b/charts/lagoon-logs-concentrator/templates/metrics-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  name: {{ include "lagoon-logs-concentrator.fullname" . }}-metrics
+  labels:
+    metrics-only: "true"
+    {{- include "lagoon-logs-concentrator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "lagoon-logs-concentrator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-logs-concentrator/templates/service.yaml
+++ b/charts/lagoon-logs-concentrator/templates/service.yaml
@@ -15,9 +15,5 @@ spec:
       targetPort: forward
       protocol: TCP
       name: forward
-    - port: 24231
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
   selector:
     {{- include "lagoon-logs-concentrator.selectorLabels" . | nindent 4 }}

--- a/charts/lagoon-logs-concentrator/templates/servicemonitor.yaml
+++ b/charts/lagoon-logs-concentrator/templates/servicemonitor.yaml
@@ -17,5 +17,6 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
+      metrics-only: "true"
       {{- include "lagoon-logs-concentrator.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/lagoon-logs-concentrator/templates/statefulset.yaml
+++ b/charts/lagoon-logs-concentrator/templates/statefulset.yaml
@@ -54,9 +54,11 @@ spec:
         - name: forward
           containerPort: 24224
           protocol: TCP
+        {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: 24231
           protocol: TCP
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: forward

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -46,6 +46,14 @@ service:
   # Annotations to add to the service
   annotations: {}
 
+metrics:
+  enabled: true
+  service:
+    type: ClusterIP
+    port: 24231
+    # annotations to add to the metrics service
+    annotations: {}
+
 serviceMonitor:
   enabled: true
 


### PR DESCRIPTION
When the main service is used as a load balancer service to allow public
access through mTLS, the metrics should not be exposed on the same
service.
