### PR TITLE
bump ssh portal

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.44.0
+version: 1.45.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -41,6 +41,12 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: add SSH_ENDPOINT vars to api service
+      description: bump ssh-portal-api from v0.30.1 to version v0.36.0
+      links:
+        - name: ssh-portal-api releases
+          url: https://github.com/uselagoon/lagoon-ssh-portal/releases
     - kind: changed
-      description: update Lagoon appVersion to v2.18.2
+      description: bump ssh-token from v0.30.1 to version v0.36.0
+      links:
+        - name: ssh-token releases
+          url: https://github.com/uselagoon/lagoon-ssh-portal/releases

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -869,7 +869,7 @@ sshPortalAPI:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.30.1"
+    tag: "v0.36.0"
 
   podAnnotations: {}
 
@@ -942,7 +942,7 @@ sshToken:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.30.1"
+    tag: "v0.36.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.88.1
+version: 0.89.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,4 +41,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update storage-calculator to v0.5.3
+      description: bump ssh-portal from v0.34.0 to version v0.36.0
+      links:
+        - name: ssh-portal releases
+          url: https://github.com/uselagoon/lagoon-ssh-portal/releases

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -126,7 +126,7 @@ sshPortal:
     repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.34.0"
+    tag: "v0.36.0"
 
   service:
     type: LoadBalancer


### PR DESCRIPTION
Note that this version of ssh-portal-api depends on https://github.com/uselagoon/lagoon/pull/3721 (which is why CI currently fails).