### PR TITLE
chore: update docker-host to v3.5.0 and build-deploy to 0.27.0

### DIFF
--- a/charts/lagoon-docker-host/Chart.yaml
+++ b/charts/lagoon-docker-host/Chart.yaml
@@ -16,10 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.2.0
+version: 0.3.0
 
-appVersion: v3.3.0
-
+appVersion: v3.5.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -27,4 +26,4 @@ appVersion: v3.3.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: require minimum Kubernetes 1.23
+      description: update docker-host from v3.3.0 to v3.5.0

--- a/charts/lagoon-docker-host/README.md
+++ b/charts/lagoon-docker-host/README.md
@@ -1,4 +1,4 @@
 # Lagoon Docker Host
 
-This chart installs a docker hpst service for [Lagoon](https://github.com/amazeeio/lagoon/).
+This chart installs a docker host service for [Lagoon](https://github.com/amazeeio/lagoon/).
 Install this chart into the cluster you want to deploy workloads to.

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.26.4
+  version: 0.27.0
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
   version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.19.17
-digest: sha256:474fd1780a647f467a7120a0ad75fc1cd02bb3e6a7b964a75a4c5bbaefb4344b
-generated: "2024-03-13T12:56:47.068393312+11:00"
+digest: sha256:74251b724e5ec44ea22509659b9529927beff2c3d4b9168cc16e349859928198
+generated: "2024-05-29T12:52:38.643703661+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.90.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.26.0
+  version: ~0.27.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dbaas-operator
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update docker-host from v3.3.0 to v3.5.0
+    - kind: changed
+      description: update lagoon-build-deploy from 0.26.4 to 0.27.0

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.89.0
+version: 0.90.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,17 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: bump ssh-portal from v0.34.0 to version v0.36.0
-      links:
-        - name: ssh-portal releases
-          url: https://github.com/uselagoon/lagoon-ssh-portal/releases
-    - kind: changed
-      description: bump insights-remote from v0.0.9 to version v0.0.10
-      links:
-        - name: ssh-portal releases
-          url: https://github.com/uselagoon/insights-remote/releases/tag/v0.0.10
-    - kind: changed
-      description: bump remote-calculator from v0.5.3 to version v0.6.0
-      links:
-        - name: ssh-portal releases
-          url: https://github.com/uselagoon/storage-calculator/releases/tag/v0.6.0
+      description: update docker-host from v3.3.0 to v3.5.0

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -27,7 +27,7 @@ dockerHost:
     repository: uselagoon/docker-host
     pullPolicy: Always
     # Overrides the image tag whose default is "latest".
-    tag: "v3.3.0"
+    tag: "v3.5.0"
 
   name: docker-host
 


### PR DESCRIPTION
This PR updates the version of the docker-host image to v3.5.0 - which contains the update to v26 of docker.

And also closes #636 