### PR TITLE
chore: update build-deploy version in lagoon-remote

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.27.0
+  version: 0.28.0
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
   version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.19.17
-digest: sha256:74251b724e5ec44ea22509659b9529927beff2c3d4b9168cc16e349859928198
-generated: "2024-05-29T12:52:38.643703661+10:00"
+digest: sha256:6570c9b0a841c10420d28a3fb754569e8922bc5e8e3916c49e13cdb2fb768060
+generated: "2024-06-20T12:17:04.565621295+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,11 +19,11 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.90.0
+version: 0.91.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.27.0
+  version: ~0.28.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dbaas-operator
@@ -41,6 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update docker-host from v3.3.0 to v3.5.0
-    - kind: changed
-      description: update lagoon-build-deploy from 0.26.4 to 0.27.0
+      description: update lagoon-build-deploy from 0.27.0 to 0.28.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Update lagoon-remote with latest build-deploy chart version with crd changes
