### PR TITLE
fix: lagoon-remote-ssh-core scale permissions

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.92.0
+version: 0.93.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -40,12 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: update values for local development
-    - kind: changed
-      description: bump minimum Kubernetes version to 1.25
-    - kind: changed
-      description: update ssh-portal components to v0.37.0
-      links:
-        - name: ssh-portal release
-          url: https://github.com/uselagoon/lagoon-ssh-portal/releases/tag/v0.37.0
+    - kind: fixed
+      description: lagoon-remote-ssh-core scale permissions

--- a/charts/lagoon-remote/templates/ssh-core.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/ssh-core.clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
In [Lagoon 2.20.0](https://github.com/uselagoon/lagoon/releases/tag/v2.20.0), the `kubectl` binary was upgraded, and it appears to use a different method of scaling deployments that requires an extra permission. This PR adds the ability for the lagoon-remote ssh-core service account to `patch`, in addition to `get` and `update`.