### PR TITLE
Feature - Enable post-build scanning in insights-remote

### DIFF
--- a/charts/lagoon-remote/templates/docker-host.networkpolicy.yaml
+++ b/charts/lagoon-remote/templates/docker-host.networkpolicy.yaml
@@ -16,6 +16,14 @@ spec:
         matchExpressions:
         - key: lagoon.sh/buildName
           operator: Exists
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/environment
+          operator: Exists
+      podSelector:
+        matchExpressions:
+        - key: insights.lagoon.sh/imagescanner
+          operator: Exists
   podSelector:
     matchLabels:
       {{- include "lagoon-remote.dockerHost.selectorLabels" . | nindent 6 }}

--- a/charts/lagoon-remote/templates/insights-remote.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.clusterrole.yaml
@@ -6,27 +6,64 @@ metadata:
   labels:
     {{- include "lagoon-remote.insightsRemote.labels" . | nindent 4 }}
 rules:
-  - verbs:
-      - '*'
-    apiGroups:
-      - ''
-    resources:
-      - configmaps
-      - secrets
-      - pods
-      - deployments
-  - verbs:
-      - '*'
-    apiGroups:
-      - 'apps'
-    resources:
-      - deployments
-  - verbs:
-      - get
-      - watch
-      - list
-    apiGroups:
-      - ''
-    resources:
-      - namespaces
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
   {{- end }}

--- a/charts/lagoon-remote/templates/insights-remote.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.clusterrole.yaml
@@ -13,6 +13,14 @@ rules:
     resources:
       - configmaps
       - secrets
+      - pods
+      - deployments
+  - verbs:
+      - '*'
+    apiGroups:
+      - 'apps'
+    resources:
+      - deployments
   - verbs:
       - get
       - watch

--- a/charts/lagoon-remote/templates/insights-remote.deployment.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.deployment.yaml
@@ -42,6 +42,13 @@ spec:
             - name: BURN_AFTER_READING
               value: "TRUE"
             {{- end }}
+            {{- if .Values.insightsRemote.enableBuildScanning }}
+            - name: ENABLE_BUILD_SCANNING
+              value: "TRUE"
+            - name: BUILD_SCANNER_IMAGE
+              value: "{{ coalesce .Values.insightsRemote.buildScannerImage "docker.io/uselagoon/insights-scanner:latest" }}"
+            {{- end }}
+            
             - name: RABBITMQ_ADDRESS
               value: {{ required "A valid rabbitMQHostname required!" $rabbitMQHostname | quote }}
             - name: RABBITMQ_PASSWORD

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -210,7 +210,7 @@ insightsRemote:
   # The following values control whether post-build insights scanning is enabled
   enableBuildScanning: false
   # If enabled, we deploy a particular image into the namespace, this can be overriden by the following
-  #buildScannerImage: 
+  #buildScannerImage: docker.io/uselagoon/insights-scanner:latest
 
   # sets insights configMaps to be removed after being processed
   burnAfterReading: true

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -206,6 +206,12 @@ dbaasHTTPEndpoint: ""
 
 insightsRemote:
   enabled: false
+
+  # The following values control whether post-build insights scanning is enabled
+  enableBuildScanning: false
+  # If enabled, we deploy a particular image into the namespace, this can be overriden by the following
+  #buildScannerImage: 
+
   # sets insights configMaps to be removed after being processed
   burnAfterReading: true
 


### PR DESCRIPTION
This PR supports the introduction of Post-build image scans in the insights-remote controller.

It supports the changes introduced in https://github.com/uselagoon/insights-remote/pull/43

Essentially, the changes are around the cluster role to expand permissions (we now need to be able to CRUD `pods`), as well as allowing customization of the scanner image that's used in the scanning process.

* The post-build image scanning is disabled by default, this is changed with `insightsRemote.enableBuildScanning` set to `true`
* overriding the scan image can be done by explicitly setting `insightsRemote.buildScannerImage` to some image