### PR TITLE
Update lagoon-logging chart, logs-concentrator and logs-dispatcher images

### DIFF
--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: oci://ghcr.io/kube-logging/helm-charts
-  version: 4.9.0
-digest: sha256:6c06a155e62a3716a1d549187a29e4fa8cdf59ddcf3bddec58e2abcb07ffa27d
-generated: "2024-08-15T16:08:40.297734358+10:00"
+  version: 4.9.1
+digest: sha256:26b05aafbf9e1d92adfd10664ac225d8f07adc00e497369d563c4b12d445c108
+generated: "2024-09-02T11:31:43.731650736+10:00"

--- a/charts/lagoon-logging/Chart.lock
+++ b/charts/lagoon-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: logging-operator
   repository: oci://ghcr.io/kube-logging/helm-charts
-  version: 4.6.1
-digest: sha256:e746740d59c5de0162b79dbffbe5696f1e5204e122abad3ac76bc6a22bd3fb7b
-generated: "2024-05-28T15:19:59.540195358+10:00"
+  version: 4.9.0
+digest: sha256:6c06a155e62a3716a1d549187a29e4fa8cdf59ddcf3bddec58e2abcb07ffa27d
+generated: "2024-08-15T16:08:40.297734358+10:00"

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,16 +19,16 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.83.0
+version: 0.84.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
-appVersion: 4.6.1
+appVersion: 4.9.0
 
 dependencies:
 - name: logging-operator
   repository: oci://ghcr.io/kube-logging/helm-charts
-  version: 4.6.1
+  version: 4.9.0
   condition: logging-operator.enabled
 
 # This section is used to collect a changelog for artifacthub.io
@@ -38,4 +38,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
-      description: update logging-operator from 4.2.3 to 4.6.1 and use oci registry
+      description: update logging-operator from 4.6.1 to 4.9.0

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -39,3 +39,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update logging-operator from 4.6.1 to 4.9.0
+    - kind: changed
+      description: update uselagoon/logs-dispatcher from v3.6.0 to v3.7.0

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -23,12 +23,12 @@ version: 0.84.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
-appVersion: 4.9.0
+appVersion: 4.9.1
 
 dependencies:
 - name: logging-operator
   repository: oci://ghcr.io/kube-logging/helm-charts
-  version: 4.9.0
+  version: 4.9.1
   condition: logging-operator.enabled
 
 # This section is used to collect a changelog for artifacthub.io
@@ -38,6 +38,6 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
-      description: update logging-operator from 4.6.1 to 4.9.0
+      description: update logging-operator from 4.6.1 to 4.9.1
     - kind: changed
       description: update uselagoon/logs-dispatcher from v3.6.0 to v3.7.0

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -30,6 +30,8 @@ spec:
     # At the time of writing this just hits the metrics endpoint.
     # https://github.com/banzaicloud/logging-operator/blob/master/pkg/sdk/logging/api/v1beta1/logging_types.go#L452-L467
     livenessDefaultCheck: true
+    filterKubernetes:
+      namespace_labels: {{ default "Off" .Values.fluentbitNamespaceLabels | quote }}
   {{- if .Values.fluentbitPrivileged }}
     security:
       securityContext:

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -19,7 +19,7 @@ logsDispatcher:
     repository: uselagoon/logs-dispatcher
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is "latest".
-    tag: "v3.6.0"
+    tag: "v3.7.0"
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -121,7 +121,7 @@ cdnLogsCollector:
     repository: uselagoon/logs-dispatcher
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is "latest".
-    tag: "v3.6.0"
+    tag: "v3.7.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -250,6 +250,10 @@ consolidateServiceIndices: false
 # sent to a third-party service and not to a central elasticsearch.
 enableDefaultForwarding: true
 
+# Set this to "On" for the default behavior including kubernetes_namespace_name
+# labels. In router-logs this could be confusing, but may be useful for debug.
+fluentbitNamespaceLabels: "Off"
+
 # Set how many Fluentd log forwarder pods should be running
 fluentdReplicaCount: 3
 

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.49.0
+version: 0.50.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -27,6 +27,4 @@ version: 0.49.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update uselagoon/logs-concentrator from v3.2.0 to v3.4.0
-    - kind: changed
-      description: increase resource requests for logs-concentrator statefulset
+      description: update uselagoon/logs-concentrator from v3.4.0 to v3.5.0

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: uselagoon/logs-concentrator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is "latest".
-  tag: "v3.4.0"
+  tag: "v3.5.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Currently, this PR updates the charts to 4.9.1 which includes https://github.com/kube-logging/logging-operator/pull/1794

