### PR TITLE
change: set keycloak_frontend_url for external keycloak

### DIFF
--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -58,6 +58,14 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
               key: KEYCLOAK_API_CLIENT_SECRET
+        - name: KEYCLOAK_FRONTEND_URL
+          {{- if .Values.keycloakFrontEndURL }}
+          value: {{ .Values.keycloakFrontEndURL }}/auth
+          {{- else if .Values.keycloak.ingress.enabled }}
+          value: https://{{ index .Values.keycloak.ingress.hosts 0 "host" }}/auth
+          {{- else }}
+          value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/auth
+          {{- end }}
         - name: KEYCLOAK_URL
           value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}
         - name: REDIS_HOST
@@ -147,6 +155,14 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
               key: KEYCLOAK_API_CLIENT_SECRET
+        - name: KEYCLOAK_FRONTEND_URL
+          {{- if .Values.keycloakFrontEndURL }}
+          value: {{ .Values.keycloakFrontEndURL }}/auth
+          {{- else if .Values.keycloak.ingress.enabled }}
+          value: https://{{ index .Values.keycloak.ingress.hosts 0 "host" }}/auth
+          {{- else }}
+          value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/auth
+          {{- end }}
         - name: KEYCLOAK_URL
           value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}
         - name: KIBANA_URL


### PR DESCRIPTION
This adds the same `KEYCLOAK_FRONTEND_URL` variable that is used by keycloak itself to set the frontend, to inject into the API to be used in the `.well-known` discovery endpoint.

This adds the `/auth` path to this URL so that tools will be able to auto detect the correct path that keycloak is configured with correctly.

If in the future this `/auth` path is removed from being [hardcoded](https://github.com/uselagoon/lagoon/blob/main/services/keycloak/entrypoints/default-keycloak-entrypoint.sh#L10) as a path, tools will be able to rediscover keycloak without the relative path to `/auth`