### PR TITLE
feat: add v1beta2 crd and update remote-controller verison

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -165,8 +165,8 @@ jobs:
       if: failure()
       run: |
         kubectl get pods -A --selector=app.kubernetes.io/name=lagoon-test
-        kubectl describe pods --namespace=lagoon --selector=app.kubernetes.io/name=lagoon-test
-        kubectl logs --namespace=lagoon --prefix --timestamps --tail=-1 --all-containers --selector=app.kubernetes.io/name=lagoon-test
+        kubectl describe pods --namespace=lagoon-core --selector=app.kubernetes.io/name=lagoon-test
+        kubectl logs --namespace=lagoon-core --prefix --timestamps --tail=-1 --all-containers --selector=app.kubernetes.io/name=lagoon-test
 
     - name: Inspect lagoon-remote and lagoon-build-deploy pods
       if: failure()
@@ -179,8 +179,8 @@ jobs:
       if: failure()
       run: |
         kubectl get pods -A --selector=app.kubernetes.io/instance=lagoon-core
-        kubectl describe pods --namespace=lagoon --selector=app.kubernetes.io/instance=lagoon-core
-        kubectl logs --namespace=lagoon --prefix --timestamps --tail=-1  --all-containers --selector=app.kubernetes.io/instance=lagoon-core
+        kubectl describe pods --namespace=lagoon-core --selector=app.kubernetes.io/instance=lagoon-core
+        kubectl logs --namespace=lagoon-core --prefix --timestamps --tail=-1  --all-containers --selector=app.kubernetes.io/instance=lagoon-core
 
     - name: Inspect any remaining CI namespaces
       if: failure()

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,15 +16,36 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.29.0
+version: 0.30.0
 
-appVersion: v0.15.7
+appVersion: v0.20.1
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update values for local development
+      description: update controller to v0.20.1
+    - kind: added
+      description: add new lagoonbuild and lagoontask v1beta2 crd versions
     - kind: changed
-      description: bump minimum Kubernetes version to 1.25
-    - kind: changed
-      description: bump remote-controller to v0.15.7
+      description: deprecate lagoonbuild and lagoontask v1beta1 crd versions
+  artifacthub.io/crds: |
+    - kind: LagoonBuild
+      version: v1beta2
+      name: lagoonbuild
+      displayName: LagoonBuild
+      description: This is the CRD used for managing LagoonBuilds
+    - kind: LagoonTask
+      version: v1beta2
+      name: lagoontask
+      displayName: LagoonTask
+      description: This is the CRD used for managing LagoonTasks
+    - kind: LagoonBuild
+      version: v1beta1
+      name: lagoonbuild
+      displayName: LagoonBuild
+      description: Deprecated: Use the newer v1beta2 resource
+    - kind: LagoonTask
+      version: v1beta1
+      name: lagoontask
+      displayName: LagoonTask
+      description: Deprecated: Use the newer v1beta2 resource

--- a/charts/lagoon-build-deploy/README.md
+++ b/charts/lagoon-build-deploy/README.md
@@ -11,6 +11,29 @@ See the comments in `values.yaml`, and the [Lagoon Remote Controller](https://gi
 For simple use of Lagoon, you shouldn't install this chart directly.
 Instead it is configured as a dependency of the [Lagoon Remote](https://github.com/uselagoon/lagoon-charts/tree/main/charts/lagoon-remote) chart.
 
+## Custom Resource Definitions (CRDs)
+
+When additions or changes are made to the CRDs, you will need to install the changes before installing the newer chart version. 
+
+### lagoon-remote
+
+If you're installing `lagoon-remote` you can use the following to update or install the latest CRDs
+
+```
+helm show crds lagoon/lagoon-build-deploy --version \
+    $(curl -s "https://raw.githubusercontent.com/uselagoon/lagoon-charts/lagoon-remote-${LAGOON_REMOTE_CHART_VERSION}/charts/lagoon-remote/Chart.lock" \
+    | grep -A2 "lagoon-build-deploy" \
+    | grep "version" \
+    | awk '{print $2}')
+```
+### lagoon-build-deploy
+
+If you're installing `lagoon-build-deploy` as its own component, then the following can be used
+
+```
+helm show crds lagoon/lagoon-build-deploy --version ${LAGOON_BUILD_DEPLOY_CHART_VERSION}
+```
+
 ## ServiceAccounts
 
 This chart installs a single service account with a `cluster-admin` `ClusterRoleBinding`.

--- a/charts/lagoon-build-deploy/crds/crd.lagoon.sh_lagoonbuilds.yaml
+++ b/charts/lagoon-build-deploy/crds/crd.lagoon.sh_lagoonbuilds.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: lagoonbuilds.crd.lagoon.sh
 spec:
   group: crd.lagoon.sh
@@ -15,20 +14,27 @@ spec:
     singular: lagoonbuild
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: use lagoonbuilds.crd.lagoon.sh/v1beta2
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: LagoonBuild is the Schema for the lagoonbuilds API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -176,14 +182,15 @@ spec:
             description: LagoonBuildStatus defines the observed state of LagoonBuild
             properties:
               conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
                 items:
                   description: LagoonBuildConditions defines the observed conditions
                     of build pods.
                   properties:
                     lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    reason:
                       type: string
                     status:
                       type: string
@@ -192,6 +199,8 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object
@@ -205,7 +214,8 @@ spec:
               for re-sending.
             properties:
               buildLogMessage:
-                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                description: |-
+                  LagoonLog is used to sendToLagoonLogs messaging queue
                   this is general logging information
                 properties:
                   event:
@@ -236,6 +246,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -298,8 +334,9 @@ spec:
                     type: string
                 type: object
               environmentMessage:
-                description: LagoonMessage is used for sending build info back to
-                  Lagoon messaging queue to update the environment or deployment
+                description: |-
+                  LagoonMessage is used for sending build info back to Lagoon
+                  messaging queue to update the environment or deployment
                 properties:
                   meta:
                     description: LagoonLogMeta is the metadata that is used by logging
@@ -325,6 +362,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -385,7 +448,8 @@ spec:
                     type: string
                 type: object
               statusMessage:
-                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                description: |-
+                  LagoonLog is used to sendToLagoonLogs messaging queue
                   this is general logging information
                 properties:
                   event:
@@ -416,6 +480,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -478,7 +568,8 @@ spec:
                     type: string
                 type: object
               taskLogMessage:
-                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                description: |-
+                  LagoonLog is used to sendToLagoonLogs messaging queue
                   this is general logging information
                 properties:
                   event:
@@ -509,6 +600,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -573,10 +690,248 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: Status of the LagoonBuild
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: The build step of the LagoonBuild
+      jsonPath: .status.conditions[?(@.type == "BuildStep")].reason
+      name: BuildStep
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: LagoonBuild is the Schema for the lagoonbuilds API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LagoonBuildSpec defines the desired state of LagoonBuild
+            properties:
+              branch:
+                description: Branch contains the branch name used for a branch deployment.
+                properties:
+                  name:
+                    type: string
+                type: object
+              build:
+                description: Build contains the type of build, and the image to use
+                  for the builder.
+                properties:
+                  bulkId:
+                    type: string
+                  ci:
+                    type: string
+                  image:
+                    type: string
+                  priority:
+                    type: integer
+                  type:
+                    type: string
+                required:
+                - type
+                type: object
+              gitReference:
+                type: string
+              project:
+                description: Project contains the project information from lagoon.
+                properties:
+                  deployTarget:
+                    type: string
+                  environment:
+                    type: string
+                  environmentId:
+                    type: integer
+                  environmentIdling:
+                    type: integer
+                  environmentType:
+                    type: string
+                  gitUrl:
+                    type: string
+                  id:
+                    type: integer
+                  key:
+                    format: byte
+                    type: string
+                  monitoring:
+                    description: Monitoring contains the monitoring information for
+                      the project in Lagoon.
+                    properties:
+                      contact:
+                        type: string
+                      statuspageID:
+                        type: string
+                    type: object
+                  name:
+                    type: string
+                  namespacePattern:
+                    type: string
+                  organization:
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    type: object
+                  productionEnvironment:
+                    type: string
+                  projectIdling:
+                    type: integer
+                  projectSecret:
+                    type: string
+                  registry:
+                    type: string
+                  routerPattern:
+                    type: string
+                  standbyEnvironment:
+                    type: string
+                  storageCalculator:
+                    type: integer
+                  subfolder:
+                    type: string
+                  uiLink:
+                    type: string
+                  variables:
+                    description: Variables contains the project and environment variables
+                      from lagoon.
+                    properties:
+                      environment:
+                        format: byte
+                        type: string
+                      project:
+                        format: byte
+                        type: string
+                    type: object
+                required:
+                - deployTarget
+                - environment
+                - environmentType
+                - gitUrl
+                - key
+                - monitoring
+                - name
+                - productionEnvironment
+                - projectSecret
+                - standbyEnvironment
+                - variables
+                type: object
+              promote:
+                description: Promote contains the information for a promote deployment.
+                properties:
+                  sourceEnvironment:
+                    type: string
+                  sourceProject:
+                    type: string
+                type: object
+              pullrequest:
+                description: Pullrequest contains the information for a pullrequest
+                  deployment.
+                properties:
+                  baseBranch:
+                    type: string
+                  baseSha:
+                    type: string
+                  headBranch:
+                    type: string
+                  headSha:
+                    type: string
+                  number:
+                    type: string
+                  title:
+                    type: string
+                type: object
+            required:
+            - build
+            - gitReference
+            - project
+            type: object
+          status:
+            description: LagoonBuildStatus defines the observed state of LagoonBuild
+            properties:
+              conditions:
+                description: |-
+                  Conditions provide a standard mechanism for higher-level status reporting from a controller.
+                  They are an extension mechanism which allows tools and other controllers to collect summary information about
+                  resources without needing to understand resource-specific status details.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                type: string
+            type: object
+        type: object
+    served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources: {}

--- a/charts/lagoon-build-deploy/crds/crd.lagoon.sh_lagoontasks.yaml
+++ b/charts/lagoon-build-deploy/crds/crd.lagoon.sh_lagoontasks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: lagoontasks.crd.lagoon.sh
 spec:
   group: crd.lagoon.sh
@@ -15,20 +14,27 @@ spec:
     singular: lagoontask
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: use lagoontasks.crd.lagoon.sh/v1beta2
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: LagoonTask is the Schema for the lagoontasks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -67,8 +73,6 @@ spec:
                 - project
                 type: object
               key:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file'
                 type: string
               misc:
                 description: LagoonMiscInfo defines the resource or backup information
@@ -158,14 +162,18 @@ spec:
             description: LagoonTaskStatus defines the observed state of LagoonTask
             properties:
               conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 items:
                   description: LagoonTaskConditions defines the observed conditions
                     of task pods.
                   properties:
                     lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    reason:
                       type: string
                     status:
                       type: string
@@ -174,6 +182,8 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object
@@ -187,7 +197,8 @@ spec:
               for re-sending.
             properties:
               buildLogMessage:
-                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                description: |-
+                  LagoonLog is used to sendToLagoonLogs messaging queue
                   this is general logging information
                 properties:
                   event:
@@ -218,6 +229,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -280,8 +317,9 @@ spec:
                     type: string
                 type: object
               environmentMessage:
-                description: LagoonMessage is used for sending build info back to
-                  Lagoon messaging queue to update the environment or deployment
+                description: |-
+                  LagoonMessage is used for sending build info back to Lagoon
+                  messaging queue to update the environment or deployment
                 properties:
                   meta:
                     description: LagoonLogMeta is the metadata that is used by logging
@@ -307,6 +345,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -367,7 +431,8 @@ spec:
                     type: string
                 type: object
               statusMessage:
-                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                description: |-
+                  LagoonLog is used to sendToLagoonLogs messaging queue
                   this is general logging information
                 properties:
                   event:
@@ -398,6 +463,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -460,7 +551,8 @@ spec:
                     type: string
                 type: object
               taskLogMessage:
-                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                description: |-
+                  LagoonLog is used to sendToLagoonLogs messaging queue
                   this is general logging information
                 properties:
                   event:
@@ -491,6 +583,32 @@ spec:
                         type: string
                       environmentId:
                         type: integer
+                      environmentServices:
+                        items:
+                          description: EnvironmentService  is based on the Lagoon
+                            API type.
+                          properties:
+                            containers:
+                              items:
+                                description: ServiceContainer  is based on the Lagoon
+                                  API type.
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            created:
+                              type: string
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            updated:
+                              type: string
+                          type: object
+                        type: array
                       jobName:
                         type: string
                       jobStatus:
@@ -555,10 +673,225 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: Status of the LagoonTask
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: LagoonTask is the Schema for the lagoontasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LagoonTaskSpec defines the desired state of LagoonTask
+            properties:
+              advancedTask:
+                description: LagoonAdvancedTaskInfo defines what an advanced task
+                  can use for the creation of the pod.
+                properties:
+                  JSONPayload:
+                    type: string
+                  deployerToken:
+                    type: boolean
+                  runnerImage:
+                    type: string
+                  sshKey:
+                    type: boolean
+                type: object
+              environment:
+                description: LagoonTaskEnvironment defines the lagoon environment
+                  information.
+                properties:
+                  environmentType:
+                    type: string
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  project:
+                    type: string
+                required:
+                - environmentType
+                - name
+                - project
+                type: object
+              key:
+                description: |-
+                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                type: string
+              misc:
+                description: LagoonMiscInfo defines the resource or backup information
+                  for a misc task.
+                properties:
+                  backup:
+                    description: LagoonMiscBackupInfo defines the information for
+                      a backup.
+                    properties:
+                      backupId:
+                        type: string
+                      id:
+                        type: string
+                      source:
+                        type: string
+                    required:
+                    - backupId
+                    - id
+                    - source
+                    type: object
+                  id:
+                    type: string
+                  miscResource:
+                    format: byte
+                    type: string
+                  name:
+                    type: string
+                required:
+                - id
+                type: object
+              project:
+                description: LagoonTaskProject defines the lagoon project information.
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  namespacePattern:
+                    type: string
+                  organization:
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    type: object
+                  variables:
+                    description: Variables contains the project and environment variables
+                      from lagoon.
+                    properties:
+                      environment:
+                        format: byte
+                        type: string
+                      project:
+                        format: byte
+                        type: string
+                    type: object
+                required:
+                - name
+                type: object
+              task:
+                description: LagoonTaskInfo defines what a task can use to communicate
+                  with Lagoon via SSH/API.
+                properties:
+                  apiHost:
+                    type: string
+                  command:
+                    type: string
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  service:
+                    type: string
+                  sshHost:
+                    type: string
+                  sshPort:
+                    type: string
+                  taskName:
+                    type: string
+                required:
+                - id
+                type: object
+            type: object
+          status:
+            description: LagoonTaskStatus defines the observed state of LagoonTask
+            properties:
+              conditions:
+                description: |-
+                  Conditions provide a standard mechanism for higher-level status reporting from a controller.
+                  They are an extension mechanism which allows tools and other controllers to collect summary information about
+                  resources without needing to understand resource-specific status details.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                type: string
+            type: object
+        type: object
+    served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources: {}


### PR DESCRIPTION
Updates the remote-controller to v0.20.0 which introduces the v1beta2 API, deprecating the v1beta1 API.

v1beta1 builds will still be processed and actioned, but once completed the CR will be deleted, which paves the way for the removal of the v1beta1 API in a future release.

Installing this version of the `lagoon-build-deploy` chart will require the CRD to be updated, the chart README has been updated to include some instructions on how to do this.