### PR TITLE
chore: remove unused banzaicloud-stable repo

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,7 +10,6 @@ jobs:
       uses: actions/checkout@v4
     - name: Add dependency chart repos
       run: |
-        helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
         helm repo add lagoon https://uselagoon.github.io/lagoon-charts/
         helm repo add amazeeio https://amazeeio.github.io/charts/
         helm repo add nats https://nats-io.github.io/k8s/helm/charts/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,6 @@ jobs:
 
     - name: Add dependency chart repos
       run: |
-        helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
         helm repo add lagoon https://uselagoon.github.io/lagoon-charts/
         helm repo add amazeeio https://amazeeio.github.io/charts/
         helm repo add nats https://nats-io.github.io/k8s/helm/charts/

--- a/default.ct.yaml
+++ b/default.ct.yaml
@@ -5,7 +5,6 @@ target-branch: main
 chart-dirs:
 - charts
 chart-repos:
-- banzaicloud-stable=https://kubernetes-charts.banzaicloud.com
 - lagoon=https://uselagoon.github.io/lagoon-charts/
 - amazeeio=https://amazeeio.github.io/charts/
 - nats=https://nats-io.github.io/k8s/helm/charts/


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

We don't appear to use `banzaicloud-stable` anymore for anything, and they are currently experiencing DNS issues that are causing tests to fail. The crds referenced in `lagoon-logging` are installed by kube-logging operator now.

The README in the `lagoon-logging` chart probably needs updating. This just removes banzaicloud-stable from the actions to allow tests to pass.