### PR TITLE
chore: add support for lagoon-ui-oidc client values

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -47,3 +47,5 @@ annotations:
           url: https://github.com/uselagoon/lagoon-ssh-portal/releases
     - kind: changed
       description: update NATS chart dependency to v1.2.x
+    - kind: changed
+      description: add KEYCLOAK_LAGOON_UI_OIDC_CLIENT_SECRET variable to keycloak and ui deployment

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -10,6 +10,7 @@ This somewhat complex logic is intended to:
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
 {{- $keycloakServiceAPIClientSecret := coalesce .Values.keycloakServiceAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_SERVICE_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_SERVICE_API_CLIENT_SECRET" | empty)) }}
+{{- $keycloakLagoonUIOIDCClientSecret := coalesce .Values.keycloakLagoonUIOIDCClientSecret (ternary uuidv4 (index $data "KEYCLOAK_LAGOON_UI_OIDC_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_UI_OIDC_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonOpensearchSyncClientSecret := coalesce .Values.keycloakLagoonOpensearchSyncClientSecret (ternary uuidv4 (index $data "KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonAdminPassword := coalesce .Values.keycloakLagoonAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | empty)) }}
 {{/* set the variable globally for access in NOTES */}}
@@ -27,5 +28,6 @@ stringData:
   KEYCLOAK_API_CLIENT_SECRET: {{ $keycloakAPIClientSecret }}
   KEYCLOAK_AUTH_SERVER_CLIENT_SECRET: {{ $keycloakAuthServerClientSecret | quote }}
   KEYCLOAK_SERVICE_API_CLIENT_SECRET: {{ $keycloakServiceAPIClientSecret | quote }}
+  KEYCLOAK_LAGOON_UI_OIDC_CLIENT_SECRET: {{ $keycloakLagoonUIOIDCClientSecret | quote }}
   KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET: {{ $keycloakLagoonOpensearchSyncClientSecret | quote }}
   KEYCLOAK_LAGOON_ADMIN_PASSWORD: {{ $keycloakLagoonAdminPassword | quote }}

--- a/charts/lagoon-core/templates/ui.deployment.yaml
+++ b/charts/lagoon-core/templates/ui.deployment.yaml
@@ -52,6 +52,11 @@ spec:
           {{- else }}
           value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/auth
           {{- end }}
+        - name: KEYCLOAK_LAGOON_UI_OIDC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_LAGOON_UI_OIDC_CLIENT_SECRET
         - name: WEBHOOK_URL
           {{- if .Values.lagoonWebhookURL }}
           value: {{ .Values.lagoonWebhookURL | quote }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -45,6 +45,7 @@
 # keycloakAdminPassword:
 # keycloakAPIClientSecret:
 # keycloakAuthServerClientSecret:
+# keycloakLagoonUIOIDCClientSecret:
 # keycloakDBPassword:
 # keycloakLagoonAdminPassword:
 # logsDBAdminPassword:


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Support for https://github.com/uselagoon/lagoon/pull/3803

CI will fail because no chart version bumps done, this is intended to be merged into #694  in preparation for a release.