### PR TITLE
feat: add sysctl configure daemonset

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update dbaas-operator chart dependency to 0.3.1
+    - kind: added
+      description: daemonset to manage node sysctl changes

--- a/charts/lagoon-remote/templates/_helpers.tpl
+++ b/charts/lagoon-remote/templates/_helpers.tpl
@@ -273,3 +273,39 @@ app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-remote.insightsRemote.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+{{/*
+Create the name of the service account to use for sysctlConfigure.
+*/}}
+{{- define "lagoon-remote.sysctlConfigure.serviceAccountName" -}}
+{{- default (include "lagoon-remote.sysctlConfigure.fullname" .) .Values.sysctlConfigure.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for sysctlConfigure.
+*/}}
+{{- define "lagoon-remote.sysctlConfigure.fullname" -}}
+{{- include "lagoon-remote.fullname" . }}-sysctl-configure
+{{- end }}
+
+{{/*
+Common labels sysctlConfigure.
+*/}}
+{{- define "lagoon-remote.sysctlConfigure.labels" -}}
+helm.sh/chart: {{ include "lagoon-remote.chart" . }}
+{{ include "lagoon-remote.sysctlConfigure.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels sysctlConfigure.
+*/}}
+{{- define "lagoon-remote.sysctlConfigure.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-remote.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-remote.sysctlConfigure.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/lagoon-remote/templates/sysctl-configure.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/sysctl-configure.clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.sysctlConfigure.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.sysctlConfigure.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.sysctlConfigure.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+{{- end }}

--- a/charts/lagoon-remote/templates/sysctl-configure.clusterrolebinding.yaml
+++ b/charts/lagoon-remote/templates/sysctl-configure.clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.sysctlConfigure.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-remote.sysctlConfigure.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.sysctlConfigure.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.sysctlConfigure.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-remote.sysctlConfigure.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/lagoon-remote/templates/sysctl-configure.daemonset.yaml
+++ b/charts/lagoon-remote/templates/sysctl-configure.daemonset.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.sysctlConfigure.enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "lagoon-remote.sysctlConfigure.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.sysctlConfigure.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lagoon-remote.sysctlConfigure.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      name: {{ include "lagoon-remote.sysctlConfigure.fullname" . }}
+      labels:
+        {{- include "lagoon-remote.sysctlConfigure.selectorLabels" . | nindent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.lagoon.sh/sysctl-configured
+                operator: DoesNotExist
+      serviceAccount: {{ include "lagoon-remote.sysctlConfigure.serviceAccountName" . }}
+      containers:
+      - name: sysctl
+        image: "{{ .Values.sysctlConfigure.image.repository }}:{{ .Values.sysctlConfigure.image.tag | default .Chart.AppVersion}}"
+        imagePullPolicy: {{ .Values.sysctlConfigure.image.pullPolicy }}
+        command:
+        env:
+        - name: THIS_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - sh
+        - -c
+        - |
+          set -xe
+          {{- $index := 0 }}
+          {{- range $sys, $value := .Values.sysctlConfigure.sysctl }}
+          CURRENT{{ $index }}=$(sysctl -n {{ $sys }})
+          if [ "{{ $value }}" -gt "$CURRENT{{ $index }}" ]; then
+            sysctl -w {{ $sys }}={{ $value }}
+          fi
+          {{- $index = add $index 1 }}
+          {{- end }}
+          kubectl label node "$THIS_NODE_NAME" k8s.lagoon.sh/sysctl-configured=$(date +%s)
+        securityContext:
+          runAsUser: 0
+          privileged: true
+{{- end }}

--- a/charts/lagoon-remote/templates/sysctl-configure.serviceaccount.yaml
+++ b/charts/lagoon-remote/templates/sysctl-configure.serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.sysctlConfigure.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lagoon-remote.sysctlConfigure.serviceAccountName" . }}
+  labels:
+    {{- include "lagoon-remote.sysctlConfigure.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -449,3 +449,25 @@ storageCalculator:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: v0.6.0
+
+# sysctlConfigure is used  to configure sysctl options on nodes for use by elasticsearch/opensearch pods used in lagoon
+# https://github.com/uselagoon/lagoon/issues/2588
+# the elasticsearch/opensearch templates in the `build-deploy-tool` currently run a privileged init container
+# https://github.com/uselagoon/build-deploy-tool/blob/d2508efa74871cabe4c477e44bbe87e339d99f5d/internal/servicetypes/opensearch.go#L75-L96
+# which will be removed in a future release
+sysctlConfigure:
+  enabled: false
+  serviceAccount:
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name:
+
+  # this is only used for the max_map_count, but could support more
+  sysctl:
+    vm.max_map_count: 262144
+
+  image:
+    repository: alpine/k8s
+    pullPolicy: IfNotPresent
+    tag: 1.25.3


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

To remove https://github.com/uselagoon/build-deploy-tool/blob/d2508efa74871cabe4c477e44bbe87e339d99f5d/internal/servicetypes/opensearch.go#L75-L96 from the opensearch and elasticsearch templates so that no containers require the `privileged: true` value. There needs to be some option to configure any sysctl values as required in `lagoon-remote`.

This adds a `DaemonSet` that allows for setting this value, and potentially other values. This is disabled by default.

Ideally the underlying instances that run kubernetes should have the values updated to remove the need for this, but in cases where it isn't possible to do so, this `DaemonSet` provides the capability.

Linked to https://github.com/uselagoon/build-deploy-tool/pull/395