### PR TITLE
chore: ignore chart version bump, dont publish charts if tag exists

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -104,6 +104,18 @@ jobs:
       run: ct install --config ./default.ct.yaml  --helm-extra-args "--timeout 30m" --all
       if: ${{ contains(github.event.pull_request.labels.*.name, 'next-release') || contains(github.event.pull_request.labels.*.name, 'needs-testing') }}
 
+  linter-artifacthub:
+    runs-on: ubuntu-latest
+    container:
+      image: artifacthub/ah
+      options: --user root
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run ah lint
+        working-directory: ./charts/
+        run: ah lint
+
   artifacthub-changelog:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,3 +30,5 @@ jobs:
       uses: helm/chart-releaser-action@v1.6.0
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        # don't upload a chart if an existing tag exists
+        CR_SKIP_EXISTING: "true"

--- a/default.ct.yaml
+++ b/default.ct.yaml
@@ -11,3 +11,4 @@ chart-repos:
 - kube-logging=https://kube-logging.github.io/helm-charts
 excluded-charts:
 - lagoon-test
+check-version-increment: false


### PR DESCRIPTION
Currently our process to skirt the chart increment requirement is to create a feature branch in this repository (eg #694), then make changes to other repositories (eg https://github.com/uselagoon/lagoon/pull/3826). Once this feature branch is merged, we have to revert the changes in other repositories (eg https://github.com/uselagoon/lagoon/pull/3842). This is quite frustrating, and has lead to issues after a release when tests start failing because of some reference that wasn't reverted, or was reverted incorrectly. All could have been avoided if we just continued merging to main and released the chart when we were ready to do so.

The govuk team have described similar frustrations with this enforcement [here](https://github.com/alphagov/govuk-helm-charts/commit/cfa1a475b52a672d976bb56c0ff1e5fa1d13a045). While they said they're using ArgoCD, this appears to be similar to how we're consuming the `main` branch of charts in the `uselagoon/lagoon` repository where the version of the chart does not matter.

What these changes allow us to do is:
* increase the number of people in the team that can perform releases without having to manage complex feature branch changes across repositories
* continue to merge to main leaving other repositories alone
* not re-publish any existing chart versions even though changes are merged
* choose when to release the charts by bumping the version in the chart in a separate pull request, when a lagoon-core release is ready.

The act of bumping a chart version will still create and publish that chart. This means when it makes sense to release, or the changes are small patches that can be released in isolation, the existing process can still be followed.

Additionally included a (hopefully working) artifacthub linter, to try and catch issues relating to formatting in the artifacthub change logs that bit us recently.