### PR TITLE
chore: remove kube-rbac-proxy from lagoon-build-deploy

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,14 +16,14 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.30.3
+version: 0.31.0
 
-appVersion: v0.20.3
+appVersion: v0.21.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update controller to v0.20.3
+      description: update controller to v0.21.0
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -25,21 +25,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-      - name: kube-rbac-proxy
-        securityContext:
-          {{- toYaml .Values.kubeRBACProxy.securityContext | nindent 10 }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-        resources:
-          {{- toYaml .Values.kubeRBACProxy.resources | nindent 10 }}
       - name: manager
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -48,11 +33,11 @@ spec:
         command:
         - /manager
         ports:
-        - containerPort: 9912
-          name: metrics
+        - containerPort: 8443
+          name: https
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election=true"
+        - "--metrics-bind-address=:8443"
+        - "--leader-elect=true"
         {{- if .Values.harbor.enabled }}
         - "--enable-harbor=true"
         - "--harbor-password={{ .Values.harbor.adminPassword }}"

--- a/charts/lagoon-build-deploy/templates/service.yaml
+++ b/charts/lagoon-build-deploy/templates/service.yaml
@@ -13,18 +13,3 @@ spec:
     name: https
   selector:
     {{- include "lagoon-build-deploy.selectorLabels" . | nindent 4 }}
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: {{ include "lagoon-build-deploy.fullname" . }}-metrics
-  labels:
-    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
-spec:
-  ports:
-  - name: metrics
-    protocol: TCP
-    port: 9912
-    targetPort: metrics
-  selector:
-    {{- include "lagoon-build-deploy.selectorLabels" . | nindent 4 }}

--- a/charts/lagoon-build-deploy/templates/servicemonitor.yaml
+++ b/charts/lagoon-build-deploy/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
     - interval: {{ .Values.metrics.interval }}
-      port: metrics
+      port: https
   namespaceSelector:
     matchNames:
       - lagoon

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -196,14 +196,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-# this is a sidecar in the same pod as the lagoonBuildDeploy container
-kubeRBACProxy:
-  image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    pullPolicy: IfNotPresent
-    tag: v0.4.1
-
-  securityContext: {}
-
-  resources: {}


### PR DESCRIPTION
Updates the `lagoon-build-deploy` chart to support the removal of the kube-rbac-proxy from the remote-controller https://github.com/uselagoon/remote-controller/pull/272