### PR TITLE
chore: update storage-calculator and adjust metrics endpoint

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -46,3 +46,5 @@ annotations:
       description: daemonset to manage node sysctl changes
     - kind: changed
       description: update uselagoon/lagoon-ssh-portal/ssh-portal from v0.41.3 to v0.41.4
+    - kind: changed
+      description: update storage-calculator to v0.7.0 and adjust metrics endpoint

--- a/charts/lagoon-remote/templates/storage-calculator.clusterrolebinding.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.storageCalculator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}-leader-election
+  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}
   labels:
     {{- include "lagoon-remote.storageCalculator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}-leader-election
+  kind: ClusterRole
+  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "lagoon-remote.storageCalculator.serviceAccountName" . }}

--- a/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
@@ -35,14 +35,15 @@ spec:
         command:
         - /manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+        - "--metrics-bind-address=:8443"
+        - "--leader-elect=true"
         - "--prometheus-metrics=true"
         {{- with .Values.storageCalculator.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         ports:
-        - name: metrics
-          containerPort: 8080
+        - containerPort: 8443
+          name: https
         env:
         {{- range $name, $value := .Values.storageCalculator.extraEnvs }}
         - name: {{ .name }}

--- a/charts/lagoon-remote/templates/storage-calculator.role.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.role.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.storageCalculator.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-remote.storageCalculator.fullname" . }}-leader-election
+  labels:
+    {{- include "lagoon-remote.storageCalculator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end }}

--- a/charts/lagoon-remote/templates/storage-calculator.service.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.service.yaml
@@ -10,8 +10,9 @@ spec:
   type: {{ .Values.storageCalculator.metricsService.type }}
   ports:
   - port: {{ .Values.storageCalculator.metricsService.ports.metrics }}
-    targetPort: metrics
-    name: metrics
+    targetPort: https
+    protocol: TCP
+    name: https
   selector:
     {{- include "lagoon-remote.storageCalculator.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/lagoon-remote/templates/storage-calculator.servicemonitor.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "lagoon-remote.storageCalculator.labels" . | nindent 4 }}
 spec:
   endpoints:
-  - port: metrics
+  - port: https
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -439,7 +439,7 @@ storageCalculator:
   metricsService:
     type: ClusterIP
     ports:
-      metrics: 9912
+      metrics: 8443
 
   serviceMonitor:
     enabled: true
@@ -448,7 +448,7 @@ storageCalculator:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.6.0
+    tag: v0.7.0
 
 # sysctlConfigure is used  to configure sysctl options on nodes for use by elasticsearch/opensearch pods used in lagoon
 # https://github.com/uselagoon/lagoon/issues/2588


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Update to use metrics endpoint fixes in https://github.com/uselagoon/storage-calculator/pull/18