### PR TITLE
fix: lagoon-build-deploy servicemonitor for new metrics endpoint

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,14 +16,14 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.31.0
+version: 0.31.1
 
 appVersion: v0.21.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update controller to v0.21.0
+      description: fix servicemonitor for lagoon build metrics
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/templates/servicemonitor.yaml
+++ b/charts/lagoon-build-deploy/templates/servicemonitor.yaml
@@ -8,7 +8,12 @@ metadata:
 spec:
   endpoints:
     - interval: {{ .Values.metrics.interval }}
+      path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   namespaceSelector:
     matchNames:
       - lagoon


### PR DESCRIPTION
After #704 was introduced, the `ServiceMonitor` wasn't updated to include the required fields for authentication. This updates the `ServiceMonitor` with the required changes for authentication.