### PR TITLE
chore: move harbor credential into secret

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -23,7 +23,7 @@ appVersion: v0.22.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: re-add deprecated v1beta1 crd version in unserved state
+      description: move harbor credentials into secret
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -40,8 +40,6 @@ spec:
         - "--leader-elect=true"
         {{- if .Values.harbor.enabled }}
         - "--enable-harbor=true"
-        - "--harbor-password={{ .Values.harbor.adminPassword }}"
-        - "--harbor-username={{ .Values.harbor.adminUser }}"
         - "--harbor-url={{ .Values.harbor.host }}"
         - "--harbor-api={{ .Values.harbor.host }}/api"
         {{- if .Values.harbor.rotationCron }}
@@ -253,6 +251,18 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-build-deploy.fullname" . }}
               key: RABBITMQ_USERNAME
+        {{- if .Values.harbor.enabled }}
+        - name: HARBOR_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-build-deploy.fullname" . }}
+              key: HARBOR_PASSWORD
+        - name: HARBOR_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-build-deploy.fullname" . }}
+              key: HARBOR_USERNAME
+        {{- end }}
         - name: NAMESPACE_PREFIX
           value: {{ .Values.namespacePrefix | quote }}
         - name: CONTROLLER_NAMESPACE

--- a/charts/lagoon-build-deploy/templates/secret.yaml
+++ b/charts/lagoon-build-deploy/templates/secret.yaml
@@ -11,3 +11,7 @@ metadata:
 stringData:
   RABBITMQ_PASSWORD: {{ required "A valid rabbitMQPassword required!" $rabbitMQPassword | quote }}
   RABBITMQ_USERNAME: {{ required "A valid rabbitMQUsername required!" $rabbitMQUsername | quote }}
+{{- if .Values.harbor.enabled }}
+  HARBOR_PASSWORD: {{ .Values.harbor.adminPassword | quote }}
+  HARBOR_USERNAME: {{ .Values.harbor.adminUser | quote }}
+{{- end }}


### PR DESCRIPTION
Moves the harbor username and password into the secret to match rabbitmq credentials