### PR TITLE
fix: only use the configured hostname for opensearch output

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update uselagoon/logs-concentrator image from v3.6.0 to v3.7.0
+    - kind: changed
+      description: enforce use of configured hostname for fluentd output

--- a/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
+++ b/charts/lagoon-logs-concentrator/templates/fluent-conf.configmap.yaml
@@ -74,7 +74,9 @@ data:
       password "#{ENV['LOGSDB_ADMIN_PASSWORD']}"
       # endpoint error handling
       reconnect_on_error true
-      reload_on_failure true
+      # never reload - always use the configured host only
+      reload_on_failure false
+      reload_connections false
       request_timeout 600s
       slow_flush_log_threshold 300s
       log_es_400_reason true


### PR DESCRIPTION
The reload_* options tell fluentd to ask the Opensearch Nodes API for
endpoint IP addresses to add to the round-robin pool for outbound
connections. This behaviour is never correct in our configuration
because we use TLS, and the certificate only has the configured
hostname, not the pod IPs.

So this change configures fluentd to only use the configured hostname.
