### PR TITLE
ssh and broker service settings

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -48,3 +48,5 @@ annotations:
       description: update lagoon-opensearch-sync image to v0.8.3
     - kind: changed
       description: update ssh-portal-api and ssh-token options
+    - kind: changed
+      description: ssh, ssh-token and broker service configuration options

--- a/charts/lagoon-core/templates/broker.service.yaml
+++ b/charts/lagoon-core/templates/broker.service.yaml
@@ -51,8 +51,19 @@ metadata:
   name: {{ include "lagoon-core.broker.fullname" . }}-amqp-ext
   labels:
     {{- include "lagoon-core.broker.labels" . | nindent 4 }}
+  {{- with .Values.broker.service.amqpExternal.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.broker.service.amqpExternal.type }}
+  {{- with .Values.broker.service.amqpExternal.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.broker.service.amqpExternal.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
   - port: {{ .Values.broker.service.amqpExternal.port }}
     targetPort: amqp

--- a/charts/lagoon-core/templates/ssh-token.service.yaml
+++ b/charts/lagoon-core/templates/ssh-token.service.yaml
@@ -5,8 +5,19 @@ metadata:
   name: {{ include "lagoon-core.sshToken.fullname" . }}
   labels:
     {{- include "lagoon-core.sshToken.labels" . | nindent 4 }}
+  {{- with .Values.sshToken.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.sshToken.service.type }}
+  {{- with .Values.sshToken.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}  
+  {{- with .Values.sshToken.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
   - port: {{ .Values.sshToken.service.ports.sshserver }}
     targetPort: sshserver

--- a/charts/lagoon-core/templates/ssh.service.yaml
+++ b/charts/lagoon-core/templates/ssh.service.yaml
@@ -11,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.ssh.service.type }}
+  {{- with .Values.ssh.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}  
+  {{- with .Values.ssh.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
     - port: {{ .Values.ssh.service.port }}
       targetPort: ssh

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -359,6 +359,9 @@ broker:
       enabled: false
       type: LoadBalancer
       port: 5672
+      annotations: {}
+      # externalTrafficPolicy: ""
+      # loadBalancerSourceRanges: []
 
   serviceMonitor:
     enabled: true
@@ -774,6 +777,8 @@ ssh:
     type: ClusterIP
     port: 2020
     annotations: {}
+    # externalTrafficPolicy: ""
+    # loadBalancerSourceRanges: []
 
   autoscaling:
     enabled: false
@@ -1072,6 +1077,9 @@ sshToken:
 
   service:
     type: LoadBalancer
+    annotations: {}
+    # externalTrafficPolicy: ""
+    # loadBalancerSourceRanges: []
     ports:
       sshserver: 22
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -46,3 +46,5 @@ annotations:
       description: update ssh-portal image to v0.42.0
     - kind: fixed
       description: fix storage-calculator role
+    - kind: changed
+      description: ssh-portal service configuration options

--- a/charts/lagoon-remote/templates/ssh-portal.service.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.service.yaml
@@ -11,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.sshPortal.service.type }}
+  {{- with .Values.sshPortal.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}  
+  {{- with .Values.sshPortal.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
   - port: {{ .Values.sshPortal.service.ports.sshserver }}
     targetPort: sshserver

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -133,6 +133,8 @@ sshPortal:
     ports:
       sshserver: 22
     annotations: {}
+    # externalTrafficPolicy: ""
+    # loadBalancerSourceRanges: []
 
   metricsService:
     type: ClusterIP


### PR DESCRIPTION
This change allows adding annotations, externalTrafficPolicy, loadBalancerSourceRanges for ssh and broker services. 

I'll do a chart version bump if this gets picked up, to avoid version clashes in case something else gets merged first.