### PR TITLE
feat: tls support for lagoon-core broker

### DIFF
--- a/.github/workflows/lint-test-matrix.yaml
+++ b/.github/workflows/lint-test-matrix.yaml
@@ -48,17 +48,27 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 'needs-testing')) ||
         (contains(github.event.pull_request.labels.*.name, 'next-release'))
 
+    - name: Install broker certificates
+      run: |
+        helm repo add jetstack https://charts.jetstack.io
+        make INSTALL_CERTMANAGER_METALLB=false install-certmanager
+        make install-broker-certs CORE_NAMESPACE=lagoon-${{ github.event.pull_request.number }} REMOTE_NAMESPACE=lagoon-${{ github.event.pull_request.number }}
+      if: |
+        (steps.list-changed.outputs.changed == 'true') ||
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing')) ||
+        (contains(github.event.pull_request.labels.*.name, 'next-release'))
+
     - name: Run chart-testing (install changed only)
       run: |
-        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m"
+        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m" --namespace lagoon-${{ github.event.pull_request.number }}
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'next-release') && !contains(github.event.pull_request.labels.*.name, 'needs-testing') }}
 
     - name: Run chart-testing (install changed next-release only)
       run: |
         yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' ./charts/lagoon-core/ci/linter-values.yaml ./charts/lagoon-core/ci/testlagoon-main-override.yaml
-        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m"
+        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m" --namespace lagoon-${{ github.event.pull_request.number }}
       if: ${{ contains(github.event.pull_request.labels.*.name, 'next-release') }}
 
     - name: Run chart-testing (install all charts when required)
-      run: ct install --config ./default.ct.yaml  --helm-extra-args "--timeout 30m" --all
+      run: ct install --config ./default.ct.yaml  --helm-extra-args "--timeout 30m" --all --namespace lagoon-${{ github.event.pull_request.number }}
       if: ${{ contains(github.event.pull_request.labels.*.name, 'next-release') || contains(github.event.pull_request.labels.*.name, 'needs-testing') }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -85,15 +85,25 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 'needs-testing')) ||
         (contains(github.event.pull_request.labels.*.name, 'next-release'))
 
+    - name: Install broker certificates
+      run: |
+        helm repo add jetstack https://charts.jetstack.io
+        make INSTALL_CERTMANAGER_METALLB=false install-certmanager
+        make install-broker-certs CORE_NAMESPACE=lagoon-${{ github.event.pull_request.number }} REMOTE_NAMESPACE=lagoon-${{ github.event.pull_request.number }}
+      if: |
+        (steps.list-changed.outputs.changed == 'true') ||
+        (contains(github.event.pull_request.labels.*.name, 'needs-testing')) ||
+        (contains(github.event.pull_request.labels.*.name, 'next-release'))
+  
     - name: Run chart-testing (install changed only)
       run: |
-        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m"
+        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m" --namespace lagoon-${{ github.event.pull_request.number }}
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'next-release') && !contains(github.event.pull_request.labels.*.name, 'needs-testing') }}
 
     - name: Run chart-testing (install changed next-release only)
       run: |
         yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' ./charts/lagoon-core/ci/linter-values.yaml ./charts/lagoon-core/ci/testlagoon-main-override.yaml
-        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m"
+        ct install --config ./default.ct.yaml --helm-extra-args "--timeout 30m" --namespace lagoon-${{ github.event.pull_request.number }}
       if: ${{ contains(github.event.pull_request.labels.*.name, 'next-release') }}
 
     # - name: Run chart-testing (upgrade changed next-release only)
@@ -102,7 +112,7 @@ jobs:
     #   if: ${{ contains(github.event.pull_request.labels.*.name, 'next-release') }}
 
     - name: Run chart-testing (install all charts when required)
-      run: ct install --config ./default.ct.yaml  --helm-extra-args "--timeout 30m" --all
+      run: ct install --config ./default.ct.yaml  --helm-extra-args "--timeout 30m" --all --namespace lagoon-${{ github.event.pull_request.number }}
       if: ${{ contains(github.event.pull_request.labels.*.name, 'next-release') || contains(github.event.pull_request.labels.*.name, 'needs-testing') }}
 
   linter-artifacthub:

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ DOCKER_NETWORK = kind
 LAGOON_SSH_PORTAL_LOADBALANCER =
 CORE_DATABASE_VENDOR = mariadb
 
+# this should not need to be changed in regular instances, only used by lint tests at the moment
+# it is used to stop metallb from being installed when certmanager is installed for the tests
+INSTALL_CERTMANAGER_METALLB = true
+
 # install lagoon dependencies by default with the install-lagoon target
 INSTALL_LAGOON_DEPENDENCIES = true
 
@@ -148,7 +152,10 @@ install-metallb:
 # cert-manager is used to allow self-signed certificates to be generated automatically by ingress in the same way lets-encrypt would
 # this allows for the registry and other services to use certificates
 .PHONY: install-certmanager
-install-certmanager: generate-ca install-metallb
+ifeq ($(INSTALL_CERTMANAGER_METALLB),true)
+install-certmanager: install-metallb
+endif
+install-certmanager: generate-ca
 	$(HELM) upgrade \
 		--install \
 		--create-namespace \
@@ -397,8 +404,20 @@ install-lagoon: install-lagoon-dependencies
 endif
 install-lagoon: install-lagoon-core install-lagoon-remote install-lagoon-build-deploy
 
+# this is only used by lint tests at the moment
+.PHONY: install-broker-certs
+install-broker-certs: install-lagoon-core-broker-certs install-lagoon-remote-broker-certs
+
+# this should not need to be changed in regular instances, only used by lint tests at the moment
+CORE_NAMESPACE = lagoon-core
+.PHONY: install-lagoon-core-broker-certs
+install-lagoon-core-broker-certs:
+# create the namespace if it doesn't exist so we can request a certificate from our local testing CA for the broker
+	$(KUBECTL) create namespace $(CORE_NAMESPACE) 2>/dev/null || true
+	$(KUBECTL) -n $(CORE_NAMESPACE) apply -f broker-core-certificate-request.yaml
+
 .PHONY: install-lagoon-core
-install-lagoon-core:
+install-lagoon-core: install-lagoon-core-broker-certs
 ifneq ($(INSTALL_STABLE_CORE),true)
 	$(HELM) dependency build ./charts/lagoon-core/
 else
@@ -507,8 +526,17 @@ endif
 		$$(if [ $(INSTALL_STABLE_CORE) = true ]; then echo 'lagoon/lagoon-core'; else echo './charts/lagoon-core'; fi)
 	$(KUBECTL) -n lagoon-core patch deployment lagoon-core-api -p '{"spec":{"template":{"spec":{"containers":[{"name":"api","env":[{"name":"SSH_TOKEN_ENDPOINT","value":"lagoon-token.'$$($(KUBECTL) -n lagoon-core get services lagoon-core-ssh-token -o jsonpath='{.status.loadBalancer.ingress[0].ip}')'.nip.io"}]}]}}}}'
 
+# this should not need to be changed in regular instances, only used by lint tests at the moment
+REMOTE_NAMESPACE = lagoon
+.PHONY: install-lagoon-remote-broker-certs
+install-lagoon-remote-broker-certs:
+# create the namespace if it doesn't exist and add the CA certificate for the remote to use where required
+	$(KUBECTL) create namespace $(REMOTE_NAMESPACE) 2>/dev/null || true
+	$(KUBECTL) -n $(REMOTE_NAMESPACE) delete secret lagoon-remote-broker-tls 2>/dev/null || true
+	$(KUBECTL) -n $(REMOTE_NAMESPACE) create secret generic lagoon-remote-broker-tls --from-file=ca.crt=certs/rootCA.pem
+
 .PHONY: install-lagoon-remote
-install-lagoon-remote:
+install-lagoon-remote: install-lagoon-remote-broker-certs
 ifneq ($(INSTALL_STABLE_REMOTE),true)
 	$(HELM) dependency build ./charts/lagoon-remote/
 else
@@ -593,7 +621,6 @@ endif
 		$$([ $(INSTALL_STABLE_BUILDDEPLOY) = true ] && [ $(STABLE_BUILDDEPLOY_CHART_VERSION) ] && echo '--version=$(STABLE_BUILDDEPLOY_CHART_VERSION)') \
 		$$(if [ $(INSTALL_STABLE_BUILDDEPLOY) = true ]; then echo '--values https://raw.githubusercontent.com/uselagoon/lagoon-charts/refs/tags/lagoon-build-deploy-$(STABLE_BUILDDEPLOY_CHART_VERSION)/charts/lagoon-build-deploy/ci/linter-values.yaml'; else echo '--values ./charts/lagoon-build-deploy/ci/linter-values.yaml'; fi) \
 		--set "rabbitMQPassword=$$($(KUBECTL) -n lagoon-core get secret lagoon-core-broker -o json | $(JQ) -r '.data.RABBITMQ_PASSWORD | @base64d')" \
-		--set "rabbitMQHostname=lagoon-core-broker.lagoon-core.svc" \
 		--set "lagoonFeatureFlagEnableQoS=true" \
 		$$([ $(LAGOON_SSH_PORTAL_LOADBALANCER) ] && echo "--set sshPortalHost=$$($(KUBECTL) -n lagoon get services lagoon-remote-ssh-portal -o jsonpath='{.status.loadBalancer.ingress[0].ip}')") \
 		$$([ $(LAGOON_SSH_PORTAL_LOADBALANCER) ] && echo "--set sshPortalPort=$$($(KUBECTL) -n lagoon get services lagoon-remote-ssh-portal -o jsonpath='{.spec.ports[0].port}')") \
@@ -610,9 +637,9 @@ endif
 		$$([ $(INSTALL_UNAUTHENTICATED_REGISTRY) = false ] && echo --set "harbor.adminUser=admin") \
 		$$([ $(INSTALL_UNAUTHENTICATED_REGISTRY) = false ] && echo --set "harbor.host=https://registry.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io") \
 		$$([ $(INSTALL_UNAUTHENTICATED_REGISTRY) = true ] && echo --set "unauthenticatedRegistry=registry.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io") \
-		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && [ ! $(INSTALL_STABLE_BUILDDEPLOY) ] && echo '--set overrideBuildDeployImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
-		$$([ $(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG) ] && [ ! $(INSTALL_STABLE_BUILDDEPLOY) ] && echo '--set image.tag=$(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG)') \
-		$$([ $(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY) ] && [ ! $(INSTALL_STABLE_BUILDDEPLOY) ] && echo '--set image.repository=$(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY)') \
+		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && [ $(INSTALL_STABLE_BUILDDEPLOY) = false ] && echo '--set overrideBuildDeployImage=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
+		$$([ $(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG) ] && [ $(INSTALL_STABLE_BUILDDEPLOY) = false ] && echo '--set image.tag=$(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGETAG)') \
+		$$([ $(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY) ] && [ $(INSTALL_STABLE_BUILDDEPLOY) = false ] && echo '--set image.repository=$(OVERRIDE_BUILD_DEPLOY_CONTROLLER_IMAGE_REPOSITORY)') \
 		$$([ $(BUILD_DEPLOY_CONTROLLER_ROOTLESS_BUILD_PODS) ] && echo '--set rootlessBuildPods=true') \
 		$$([ $(LAGOON_FEATURE_FLAG_DEFAULT_ROOTLESS_WORKLOAD) ] && echo '--set lagoonFeatureFlagDefaultRootlessWorkload=$(LAGOON_FEATURE_FLAG_DEFAULT_ROOTLESS_WORKLOAD)') \
 		$$([ $(LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY) ] && echo '--set lagoonFeatureFlagDefaultIsolationNetworkPolicy=$(LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY)') \

--- a/broker-core-certificate-request.yaml
+++ b/broker-core-certificate-request.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lagoon-core-broker
+spec:
+  secretName: lagoon-core-broker-tls
+  isCA: false
+  usages:
+    - server auth
+    - client auth
+  commonName: "lagoon-core-broker"
+  dnsNames:
+    - "lagoon-core-broker"
+    - "lagoon-core-broker.lagoon-core.svc"
+  issuerRef:
+    kind: ClusterIssuer
+    name: lagoon-testing-issuer

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -24,6 +24,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: move harbor credentials into secret
+    - kind: changed
+      description: tls support for rabbitmq
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/ci/linter-values.yaml
+++ b/charts/lagoon-build-deploy/ci/linter-values.yaml
@@ -9,8 +9,9 @@ lagoonTokenPort: 22
 lagoonAPIHost: http://lagoon-core-api.lagoon-core.svc:80
 extraArgs:
   - "--skip-tls-verify=true"
-amqp:
-  tlsCA:
-    enabled: true
+broker:
   tls:
     enabled: true
+  tlsCA:
+    enabled: true
+    secretName: lagoon-remote-broker-tls

--- a/charts/lagoon-build-deploy/ci/linter-values.yaml
+++ b/charts/lagoon-build-deploy/ci/linter-values.yaml
@@ -1,6 +1,6 @@
 rabbitMQUsername: lagoon
 rabbitMQPassword: ci
-rabbitMQHostname: lagoon-core-broker.lagoon-core.svc
+rabbitMQHostname: lagoon-core-broker.lagoon-core.svc:5671
 lagoonTargetName: ci-local-control-k8s
 sshPortalHost: lagoon-remote-ssh-portal.lagoon.svc
 sshPortalPort: 22
@@ -9,3 +9,8 @@ lagoonTokenPort: 22
 lagoonAPIHost: http://lagoon-core-api.lagoon-core.svc:80
 extraArgs:
   - "--skip-tls-verify=true"
+amqp:
+  tlsCA:
+    enabled: true
+  tls:
+    enabled: true

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         args:
         - "--metrics-bind-address=:8443"
         - "--leader-elect=true"
+        {{- if .Values.amqp.tls.enabled }}
+        - "--rabbitmq-tls"
+        {{- end }}
         {{- if .Values.harbor.enabled }}
         - "--enable-harbor=true"
         - "--harbor-url={{ .Values.harbor.host }}"
@@ -241,6 +244,12 @@ spec:
           value: {{ .Values.pendingMessageCron | quote }}
         - name: RABBITMQ_HOSTNAME
           value: {{ required "A valid rabbitMQHostname required!" $rabbitMQHostname | quote }}
+        {{- if .Values.amqp.tlsCA.enabled }}
+        - name: RABBITMQ_CACERT
+          value: "/ca.crt"
+        {{- end }}
+        - name: RABBITMQ_VERIFY
+          value: {{ .Values.amqp.tls.verifyPeer | quote }}
         - name: RABBITMQ_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -269,8 +278,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        volumeMounts:
+        {{- if .Values.amqp.tlsCA.enabled }}
+        - mountPath: /ca.crt
+          name: {{ include "lagoon-build-deploy.fullname" . }}-amqp-tls
+          subPath: ca.crt
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+      volumes:
+      {{- if .Values.amqp.tlsCA.enabled }}
+      - name: {{ include "lagoon-build-deploy.fullname" . }}-amqp-tls
+        secret:
+          secretName: {{ .Values.amqp.tlsCA.secretName }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -1,4 +1,18 @@
 {{- $rabbitMQHostname := coalesce (.Values.global).rabbitMQHostname .Values.rabbitMQHostname }}
+{{- $rabbitMQTLSSecretName := coalesce (.Values.global.broker).tlsCA.secretName .Values.broker.tlsCA.secretName }}
+
+{{- $rabbitMQTLSEnabled := .Values.broker.tls.enabled }}
+{{- if (.Values.global.broker).tls.enabled }}
+{{- $rabbitMQTLSEnabled = (.Values.global.broker).tls.enabled }}
+{{- end }}
+{{- $rabbitMQTLSCAEnabled := .Values.broker.tlsCA.enabled }}
+{{- if (.Values.global.broker).tlsCA.enabled }}
+{{- $rabbitMQTLSCAEnabled = (.Values.global.broker).tlsCA.enabled }}
+{{- end }}
+{{- $rabbitMQTLSVerifyPeer := .Values.broker.tls.verifyPeer }}
+{{- if (.Values.global.broker).tls.verifyPeer }}
+{{- $rabbitMQTLSVerifyPeer = (.Values.global.broker).tlsCA.verifyPeer }}
+{{- end }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -38,7 +52,7 @@ spec:
         args:
         - "--metrics-bind-address=:8443"
         - "--leader-elect=true"
-        {{- if .Values.amqp.tls.enabled }}
+        {{- if $rabbitMQTLSEnabled }}
         - "--rabbitmq-tls"
         {{- end }}
         {{- if .Values.harbor.enabled }}
@@ -244,12 +258,12 @@ spec:
           value: {{ .Values.pendingMessageCron | quote }}
         - name: RABBITMQ_HOSTNAME
           value: {{ required "A valid rabbitMQHostname required!" $rabbitMQHostname | quote }}
-        {{- if .Values.amqp.tlsCA.enabled }}
+        {{- if $rabbitMQTLSCAEnabled }}
         - name: RABBITMQ_CACERT
           value: "/ca.crt"
         {{- end }}
         - name: RABBITMQ_VERIFY
-          value: {{ .Values.amqp.tls.verifyPeer | quote }}
+          value: {{ $rabbitMQTLSVerifyPeer | quote }}
         - name: RABBITMQ_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -279,7 +293,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         volumeMounts:
-        {{- if .Values.amqp.tlsCA.enabled }}
+        {{- if $rabbitMQTLSCAEnabled }}
         - mountPath: /ca.crt
           name: {{ include "lagoon-build-deploy.fullname" . }}-amqp-tls
           subPath: ca.crt
@@ -287,10 +301,10 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
-      {{- if .Values.amqp.tlsCA.enabled }}
+      {{- if $rabbitMQTLSCAEnabled }}
       - name: {{ include "lagoon-build-deploy.fullname" . }}-amqp-tls
         secret:
-          secretName: {{ .Values.amqp.tlsCA.secretName }}
+          secretName: {{ $rabbitMQTLSSecretName }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/lagoon-build-deploy/templates/secret.yaml
+++ b/charts/lagoon-build-deploy/templates/secret.yaml
@@ -15,17 +15,17 @@ stringData:
   HARBOR_PASSWORD: {{ .Values.harbor.adminPassword | quote }}
   HARBOR_USERNAME: {{ .Values.harbor.adminUser | quote }}
 {{- end }}
-{{- if .Values.amqp.tlsCA.secretData }}
+{{- if .Values.broker.tlsCA.secretData }}
 ---
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ .Values.amqp.tlsCA.secretName }}
+  name: {{ .Values.broker.tlsCA.secretName }}
   labels:
     {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
 stringData:
-  {{- with .Values.amqp.tlsCA.secretData }}
+  {{- with .Values.broker.tlsCA.secretData }}
   {{- . | toYaml | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/charts/lagoon-build-deploy/templates/secret.yaml
+++ b/charts/lagoon-build-deploy/templates/secret.yaml
@@ -15,3 +15,17 @@ stringData:
   HARBOR_PASSWORD: {{ .Values.harbor.adminPassword | quote }}
   HARBOR_USERNAME: {{ .Values.harbor.adminUser | quote }}
 {{- end }}
+{{- if .Values.amqp.tlsCA.secretData }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.amqp.tlsCA.secretName }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.amqp.tlsCA.secretData }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -197,15 +197,20 @@ tolerations: []
 
 affinity: {}
 
-amqp:
+broker:
   # enable if providing a custom CA for broker connections
   tlsCA:
     enabled: false
-    secretName: lagoon-remote-broker-tls
+    # if lagoon-build-deploy chart is installed as part of lagoon-remote
+    # then this secret name could be defined by the "global" configs for lagoon-remote instead of here.
+    # if this chart and lagoon-remote are installed in isolation, but in the same namespace
+    # then you can use the same secret that lagoon-remote may be using if lagoon-remote is also configured
+    # to use the "global" settings for broker by setting the secretName manually to "lagoon-remote-broker-tls".
+    # in other cases, you may need to create this secret manually if not defining the CA in values.
+    secretName: lagoon-remote-build-deploy-broker-tls
     # secretData:
     #   ca.crt: |
     #     ...
   tls:
     enabled: false
-    # https://www.rabbitmq.com/docs/ssl#enabling-tls for what these options can be set to
     verifyPeer: true

--- a/charts/lagoon-build-deploy/values.yaml
+++ b/charts/lagoon-build-deploy/values.yaml
@@ -196,3 +196,16 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+amqp:
+  # enable if providing a custom CA for broker connections
+  tlsCA:
+    enabled: false
+    secretName: lagoon-remote-broker-tls
+    # secretData:
+    #   ca.crt: |
+    #     ...
+  tls:
+    enabled: false
+    # https://www.rabbitmq.com/docs/ssl#enabling-tls for what these options can be set to
+    verifyPeer: true

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Lagoon Workflows subsystem removed
+    - kind: changed
+      description: tls support for rabbitmq

--- a/charts/lagoon-core/broker-tls/README.md
+++ b/charts/lagoon-core/broker-tls/README.md
@@ -1,0 +1,3 @@
+# Broker TLS
+
+This directory contains example configuration for generating certificates for broker connections.

--- a/charts/lagoon-core/broker-tls/ca-config.json
+++ b/charts/lagoon-core/broker-tls/ca-config.json
@@ -1,0 +1,25 @@
+{
+    "signing": {
+        "default": {
+            "expiry": "87600h"
+        },
+        "profiles": {
+            "server": {
+                "expiry": "87600h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ]
+            },
+            "client": {
+                "expiry": "87600h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
+            }
+        }
+    }
+}

--- a/charts/lagoon-core/broker-tls/ca-csr.json
+++ b/charts/lagoon-core/broker-tls/ca-csr.json
@@ -1,0 +1,13 @@
+{
+    "CN": "broker-ca.example.com",
+    "hosts": [
+        "broker-ca.example.com"
+    ],
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "ca": {
+      "expiry": "87600h"
+    }
+}

--- a/charts/lagoon-core/broker-tls/server.json
+++ b/charts/lagoon-core/broker-tls/server.json
@@ -1,0 +1,11 @@
+{
+  "hosts": [
+    "lagoon-core-broker",
+    "lagoon-core-broker.lagoon-core.svc"
+  ],
+  "CN": "lagoon-core-broker",
+  "key": {
+    "algo": "ecdsa",
+    "size": 256
+  }
+}

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -100,6 +100,8 @@ broker:
   resources:
     requests:
       cpu: "10m"
+  tls:
+    enabled: true
 
 authServer:
   replicaCount: 1

--- a/charts/lagoon-core/templates/broker.secret.yaml
+++ b/charts/lagoon-core/templates/broker.secret.yaml
@@ -16,3 +16,37 @@ metadata:
 stringData:
   RABBITMQ_PASSWORD: {{ $rabbitMQPassword | quote }}
   RABBITMQ_USERNAME: {{ required "A valid .Values.rabbitMQUsername required!" .Values.rabbitMQUsername | quote }}
+{{- if .Values.broker.tls.secretData }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.broker.tls.secretName }}
+  labels:
+    {{- include "lagoon-core.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.broker.tls.secretData }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.broker.tls.enabled }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-core.broker.fullname" . }}-tls-conf
+  labels:
+    {{- include "lagoon-core.broker.labels" . | nindent 4 }}
+stringData:
+  tls.conf: |
+    ## tls-listener configuration
+    listeners.ssl.default = {{ .Values.broker.service.ports.amqps }}
+    ## tls certificate configurations
+    ssl_options.cacertfile = /ca.crt
+    ssl_options.certfile   = /tls.crt
+    ssl_options.keyfile    = /tls.key
+    ssl_options.verify     = {{ .Values.broker.tls.verify }}
+    ssl_options.fail_if_no_peer_cert = {{ .Values.broker.tls.failIfNoPeerCert }}
+{{- end}}

--- a/charts/lagoon-core/templates/broker.service.yaml
+++ b/charts/lagoon-core/templates/broker.service.yaml
@@ -13,6 +13,9 @@ spec:
   - port: {{ .Values.broker.service.ports.amqp }}
     targetPort: amqp
     name: amqp
+  - port: {{ .Values.broker.service.ports.amqps }}
+    targetPort: amqps
+    name: amqps
   - port: {{ .Values.broker.service.ports.http }}
     targetPort: http
     name: http
@@ -35,6 +38,9 @@ spec:
   - port: {{ .Values.broker.service.ports.amqp }}
     targetPort: amqp
     name: amqp
+  - port: {{ .Values.broker.service.ports.amqps }}
+    targetPort: amqps
+    name: amqps
   - port: {{ .Values.broker.service.ports.http }}
     targetPort: http
     name: http
@@ -44,7 +50,7 @@ spec:
   selector:
     {{- include "lagoon-core.broker.selectorLabels" . | nindent 4 }}
 ---
-{{- if .Values.broker.service.amqpExternal.enabled -}}
+{{- if or (.Values.broker.service.amqpExternal.enabled) (.Values.broker.service.amqpsExternal.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -65,9 +71,16 @@ spec:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   ports:
+  {{- if .Values.broker.service.amqpExternal.enabled }}
   - port: {{ .Values.broker.service.amqpExternal.port }}
     targetPort: amqp
     name: amqp
+  {{- end }}
+  {{- if .Values.broker.service.amqpsExternal.enabled }}
+  - port: {{ .Values.broker.service.amqpsExternal.port }}
+    targetPort: amqps
+    name: amqps
+  {{- end }}
   selector:
     {{- include "lagoon-core.broker.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/lagoon-core/templates/broker.statefulset.yaml
+++ b/charts/lagoon-core/templates/broker.statefulset.yaml
@@ -63,16 +63,32 @@ spec:
       {{- end }}
         ports:
         - name: epmd
-          containerPort: 4396
+          containerPort: {{ .Values.broker.service.ports.epmd }}
         - name: amqp
-          containerPort: 5672
+          containerPort: {{ .Values.broker.service.ports.amqp }}
+        - name: amqps
+          containerPort: {{ .Values.broker.service.ports.amqps }}
         - name: http
-          containerPort: 15672
+          containerPort: {{ .Values.broker.service.ports.http }}
         - name: metrics
-          containerPort: 15692
+          containerPort: {{ .Values.broker.service.ports.metrics }}
         volumeMounts:
         - name: {{ include "lagoon-core.broker.fullname" . }}-data
           mountPath: /var/lib/rabbitmq
+        {{- if .Values.broker.tls.enabled }}
+        - mountPath: /ca.crt
+          name: {{ include "lagoon-core.broker.fullname" . }}-tls
+          subPath: ca.crt
+        - mountPath: /tls.crt
+          name: {{ include "lagoon-core.broker.fullname" . }}-tls
+          subPath: tls.crt
+        - mountPath: /tls.key
+          name: {{ include "lagoon-core.broker.fullname" . }}-tls
+          subPath: tls.key
+        - mountPath: /etc/rabbitmq/conf.d/15-tls.conf
+          name: {{ include "lagoon-core.broker.fullname" . }}-tls-conf
+          subPath: tls.conf
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: amqp
@@ -89,6 +105,18 @@ spec:
       - name: {{ include "lagoon-core.broker.fullname" . }}-data
         persistentVolumeClaim:
           claimName: {{ include "lagoon-core.broker.fullname" . }}-data
+      {{- if .Values.broker.tls.enabled }}
+      - name: {{ include "lagoon-core.broker.fullname" . }}-tls
+        secret:
+          secretName: {{ .Values.broker.tls.secretName }}
+      - name: {{ include "lagoon-core.broker.fullname" . }}-tls-conf
+        secret:
+          secretName: {{ include "lagoon-core.broker.fullname" . }}-tls-conf
+          defaultMode: 511
+          items:
+          - key: tls.conf
+            path: tls.conf
+      {{- end }}
       {{- with .Values.broker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -353,15 +353,25 @@ broker:
     ports:
       epmd: 4369
       amqp: 5672
+      amqps: 5671
       http: 15672
       metrics: 15692
     amqpExternal:
+      # amqpExternal is used to enable or disable the port on the external facing service.
+      # if used in conjunction with amqpsExternal, you will get both ports
+      # if used alone it will only be this port
       enabled: false
       type: LoadBalancer
       port: 5672
       annotations: {}
       # externalTrafficPolicy: ""
       # loadBalancerSourceRanges: []
+    amqpsExternal:
+      # amqpsExternal is used to enable or disable the TLS port on the external facing service.
+      # if used in conjunction with amqpExternal, you will get both ports
+      # the type is only consumed from amqpExternal, changing the type of the external loadbalancer should be done there
+      enabled: false
+      port: 5671
 
   serviceMonitor:
     enabled: true
@@ -411,6 +421,26 @@ broker:
     failureThreshold: 60
     tcpSocket:
       port: amqp
+
+  tls:
+    enabled: false
+    secretName: lagoon-core-broker-tls
+    # https://www.rabbitmq.com/docs/ssl#enabling-tls for what these options can be set to
+    verify: verify_none
+    failIfNoPeerCert: false
+    # If the lagoon-core-broker-tls secret should be created by the lagoon-core
+    # chart, certificate values can be specified directly in secretData.
+    # secretData:
+    #   ca.crt: |
+    #     ...
+    #   tls.crt: |
+    #     ...
+    #   tls.key: |
+    #     ...
+    #
+    # If the TLS secret is created outside the lagoon-core chart, it should be
+    # named lagoon-core-broker-tls. This secret should contain fields ca.crt, tls.crt and
+    # tls.key, and the certificate should be issued by a public authority.
 
 authServer:
   replicaCount: 2

--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -38,6 +38,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
-      description: update logging-operator from 4.10.0 to 4.11.4
-    - kind: changed
-      description: update uselagoon/logs-dispatcher image from v3.8.0 to v3.9.0
+      description: tls support for rabbitmq

--- a/charts/lagoon-logging/templates/logs-dispatcher.secret.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.secret.yaml
@@ -34,3 +34,17 @@ stringData:
   client.key: |
     {{- required "A valid .Values.tls.clientKey required!" .Values.tls.clientKey | nindent 4 }}
 {{- end }}
+{{- if .Values.lagoonLogs.broker.tlsCA.secretData }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.lagoonLogs.broker.tlsCA.secretName }}
+  labels:
+    {{- include "lagoon-build-deploy.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.lagoonLogs.broker.tlsCA.secretData }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-logging/templates/logs-dispatcher.source-lagoon.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.source-lagoon.configmap.yaml
@@ -22,5 +22,12 @@ data:
       routing_key   ""
       queue         "lagoon-logs:logs-dispatcher"
       durable       true
+      {{- if .Values.lagoonLogs.broker.tls.enabled }}
+      tls true
+      {{- if .Values.lagoonLogs.broker.tlsCA.enabled }}
+      tls_ca_certificates ["/lagoon-ca.crt"]
+      {{- end }}
+      verify_peer {{ .Values.lagoonLogs.tls.verifyPeer }}
+      {{- end }}
     </source>
 {{- end }}

--- a/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.statefulset.yaml
@@ -94,6 +94,11 @@ spec:
         - mountPath: /fluentd/tls/
           name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-tls
         {{- end }}
+        {{- if .Values.lagoonLogs.broker.tlsCA.enabled }}
+        - mountPath: /lagoon-ca.crt
+          name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-lagoon-broker-tls
+          subPath: ca.crt
+        {{- end }}
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -143,6 +148,11 @@ spec:
           defaultMode: 420
           secretName: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-tls
         name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-tls
+      {{- end }}
+      {{- if .Values.lagoonLogs.broker.tlsCA.enabled }}
+      - name: {{ include "lagoon-build-deploy.fullname" . }}-lagoon-broker-tls
+        secret:
+          secretName: {{ .Values.lagoonLogs.broker.tlsCA.secretName }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -236,6 +236,18 @@ logging-operator:
 # enabling this.
 lagoonLogs:
   enabled: false
+  broker:
+    # enable if providing a custom CA for broker connections
+    tlsCA:
+      enabled: false
+      secretName: lagoon-logging-broker-tls
+      # secretData:
+      #   ca.crt: |
+      #     ...
+    tls:
+      enabled: false
+      # https://www.rabbitmq.com/docs/ssl#enabling-tls for what these options can be set to
+      verifyPeer: true
 
 forward:
   verifyConnectionAtStartup: true

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -246,7 +246,6 @@ lagoonLogs:
       #     ...
     tls:
       enabled: false
-      # https://www.rabbitmq.com/docs/ssl#enabling-tls for what these options can be set to
       verifyPeer: true
 
 forward:

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: dedicated label to docker-host services
+    - kind: changed
+      description: tls support for rabbitmq

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -1,7 +1,13 @@
 global:
   rabbitMQUsername: lagoon
   rabbitMQPassword: ci
-  rabbitMQHostname: lagoon-core-broker.lagoon-core.svc
+  rabbitMQHostname: lagoon-core-broker.lagoon-core.svc:5671
+  broker:
+    tls:
+      enabled: true
+    tlsCA:
+      enabled: true
+      secretName: lagoon-remote-broker-tls
 
 lagoon-build-deploy:
   enabled: true
@@ -12,7 +18,7 @@ lagoon-build-deploy:
   # remove on next release
   rabbitMQUsername: lagoon
   rabbitMQPassword: ci
-  rabbitMQHostname: lagoon-core-broker.lagoon-core.svc
+  rabbitMQHostname: lagoon-core-broker.lagoon-core.svc:5671
 
 dockerHost:
   image:

--- a/charts/lagoon-remote/templates/global-broker.secret.yaml
+++ b/charts/lagoon-remote/templates/global-broker.secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.broker.tlsCA.secretData }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.global.broker.tlsCA.secretName }}
+  labels:
+    {{- include "lagoon-remote.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.global.broker.tlsCA.secretData }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/templates/insights-remote.deployment.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.deployment.yaml
@@ -1,6 +1,20 @@
 {{- if .Values.insightsRemote.enabled -}}
 
 {{- $rabbitMQHostname := coalesce .Values.global.rabbitMQHostname .Values.insightsRemote.rabbitMQHostname }}
+{{- $rabbitMQTLSSecretName := coalesce .Values.global.broker.tlsCA.secretName .Values.insightsRemote.broker.tlsCA.secretName }}
+
+{{- $rabbitMQTLSEnabled := .Values.insightsRemote.broker.tls.enabled }}
+{{- if .Values.global.broker.tls.enabled }}
+{{- $rabbitMQTLSEnabled = .Values.global.broker.tls.enabled }}
+{{- end }}
+{{- $rabbitMQTLSCAEnabled := .Values.insightsRemote.broker.tlsCA.enabled }}
+{{- if .Values.global.broker.tlsCA.enabled }}
+{{- $rabbitMQTLSCAEnabled = .Values.global.broker.tlsCA.enabled }}
+{{- end }}
+{{- $rabbitMQTLSVerifyPeer := .Values.insightsRemote.broker.tls.verifyPeer | quote }}
+{{- if .Values.global.broker.tls.verifyPeer }}
+{{- $rabbitMQTLSVerifyPeer = .Values.global.broker.tlsCA.verifyPeer | quote }}
+{{- end }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -38,12 +52,22 @@ spec:
           image: "{{ .Values.insightsRemote.image.repository }}:{{ coalesce .Values.insightsRemote.image.tag .Values.imageTag "latest" }}"
           imagePullPolicy: {{ .Values.insightsRemote.image.pullPolicy }}
           env:
-            {{- if .Values.insightsRemote.burnAfterReading }}
+          {{- if .Values.insightsRemote.burnAfterReading }}
             - name: BURN_AFTER_READING
               value: "TRUE"
-            {{- end }}
+          {{- end }}
+          {{- if $rabbitMQTLSEnabled }}
+            - name: RABBITMQ_ENABLED
+              value: "TRUE"
+          {{- end }}
             - name: RABBITMQ_ADDRESS
               value: {{ required "A valid rabbitMQHostname required!" $rabbitMQHostname | quote }}
+          {{- if $rabbitMQTLSCAEnabled }}
+            - name: RABBITMQ_CACERT
+              value: "/ca.crt"
+          {{- end }}
+            - name: RABBITMQ_VERIFY
+              value: {{ $rabbitMQTLSVerifyPeer | quote }}
             - name: RABBITMQ_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -59,12 +83,24 @@ spec:
                 secretKeyRef:
                   name: {{ include "lagoon-remote.insightsRemote.fullname" . }}
                   key: INSIGHTS_TOKEN_SECRET
+          volumeMounts:
+          {{- if $rabbitMQTLSCAEnabled }}
+            - mountPath: /ca.crt
+              name: {{ include "lagoon-remote.insightsRemote.fullname" . }}-amqp-tls
+              subPath: ca.crt
+          {{- end }}
           resources:
             {{- toYaml .Values.insightsRemote.resources | nindent 12 }}
           ports:
             - name: insights-ws
               containerPort: 8888
-              protocol: TCP            
+              protocol: TCP
+      volumes:
+      {{- if $rabbitMQTLSCAEnabled }}
+        - name: {{ include "lagoon-remote.insightsRemote.fullname" . }}-amqp-tls
+          secret:
+            secretName: {{ $rabbitMQTLSSecretName }}
+      {{- end }}
       {{- with .Values.insightsRemote.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lagoon-remote/templates/insights-remote.secrets.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.secrets.yaml
@@ -10,10 +10,26 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "lagoon-remote.insightsRemote.fullname" . }}
+  labels:
+    {{- include "lagoon-remote.insightsRemote.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   RABBITMQ_USERNAME: {{ required "A valid rabbitMQUsername required!" $rabbitMQUsername | quote }}
   RABBITMQ_PASSWORD: {{ required "A valid rabbitMQPassword required!" $rabbitMQPassword | quote }}
   INSIGHTS_TOKEN_SECRET: {{ $insightsTokenSecret | quote }}
 
+{{- end }}
+{{- if .Values.insightsRemote.broker.tlsCA.secretData }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.insightsRemote.broker.tlsCA.secretName }}
+  labels:
+    {{- include "lagoon-remote.insightsRemote.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.insightsRemote.broker.tlsCA.secretData }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
@@ -1,6 +1,20 @@
 {{- if .Values.storageCalculator.enabled -}}
 
 {{- $rabbitMQHostname := coalesce .Values.global.rabbitMQHostname .Values.storageCalculator.rabbitMQHostname }}
+{{- $rabbitMQTLSSecretName := coalesce .Values.global.broker.tlsCA.secretName .Values.storageCalculator.broker.tlsCA.secretName }}
+
+{{- $rabbitMQTLSEnabled := .Values.storageCalculator.broker.tls.enabled }}
+{{- if .Values.global.broker.tls.enabled }}
+{{- $rabbitMQTLSEnabled = .Values.global.broker.tls.enabled }}
+{{- end }}
+{{- $rabbitMQTLSCAEnabled := .Values.storageCalculator.broker.tlsCA.enabled }}
+{{- if .Values.global.broker.tlsCA.enabled }}
+{{- $rabbitMQTLSCAEnabled = .Values.global.broker.tlsCA.enabled }}
+{{- end }}
+{{- $rabbitMQTLSVerifyPeer := .Values.storageCalculator.broker.tls.verifyPeer | quote }}
+{{- if .Values.global.broker.tls.verifyPeer }}
+{{- $rabbitMQTLSVerifyPeer = .Values.global.broker.tlsCA.verifyPeer | quote }}
+{{- end }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -38,6 +52,9 @@ spec:
         - "--metrics-bind-address=:8443"
         - "--leader-elect=true"
         - "--prometheus-metrics=true"
+        {{- if $rabbitMQTLSEnabled }}
+        - "--rabbitmq-tls"
+        {{- end }}
         {{- with .Values.storageCalculator.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -59,6 +76,12 @@ spec:
         {{- end }}
         - name: RABBITMQ_HOSTNAME
           value: {{ required "A valid rabbitMQHostname required!" $rabbitMQHostname | quote }}
+        {{- if $rabbitMQTLSCAEnabled }}
+        - name: RABBITMQ_CACERT
+          value: "/ca.crt"
+        {{- end }}
+        - name: RABBITMQ_VERIFY
+          value: {{ $rabbitMQTLSVerifyPeer | quote }}
         - name: RABBITMQ_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -69,8 +92,20 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-remote.storageCalculator.fullname" . }}
               key: RABBITMQ_USERNAME
+        volumeMounts:
+        {{- if $rabbitMQTLSCAEnabled }}
+        - mountPath: /ca.crt
+          name: {{ include "lagoon-remote.storageCalculator.fullname" . }}-amqp-tls
+          subPath: ca.crt
+        {{- end }}
         resources:
           {{- toYaml .Values.storageCalculator.resources | nindent 10 }}
+      volumes:
+      {{- if $rabbitMQTLSCAEnabled }}
+      - name: {{ include "lagoon-remote.storageCalculator.fullname" . }}-amqp-tls
+        secret:
+          secretName: {{ $rabbitMQTLSSecretName }}
+      {{- end }}
       {{- with .Values.storageCalculator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lagoon-remote/templates/storage-calculator.secret.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.secret.yaml
@@ -14,3 +14,17 @@ stringData:
   RABBITMQ_PASSWORD: {{ required "A valid rabbitMQPassword required!" $rabbitMQPassword | quote }}
   RABBITMQ_USERNAME: {{ required "A valid rabbitMQUsername required!" $rabbitMQUsername | quote }}
 {{- end }}
+{{- if .Values.storageCalculator.broker.tlsCA.secretData }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.storageCalculator.broker.tlsCA.secretName }}
+  labels:
+    {{- include "lagoon-remote.storageCalculator.labels" . | nindent 4 }}
+stringData:
+  {{- with .Values.storageCalculator.broker.tlsCA.secretData }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -7,6 +7,18 @@ global:
   rabbitMQUsername: ""
   rabbitMQPassword: ""
   rabbitMQHostname: ""
+  broker:
+    # enable if providing a custom CA for broker connections
+    tlsCA:
+      enabled: false
+      secretName: lagoon-remote-broker-tls
+      # secretData:
+      #   ca.crt: |
+      #     ...
+    tls:
+      enabled: false
+      # https://www.rabbitmq.com/docs/ssl#enabling-tls for what these options can be set to
+      verifyPeer: true
 
 imagePullSecrets: []
 
@@ -296,6 +308,19 @@ insightsRemote:
     type: ClusterIP
     port: 80
 
+  broker:
+    # enable if providing a custom CA for broker connections
+    tlsCA:
+      enabled: false
+      # if you're definining configuration using the "global" broker settings, this secretName
+      # will not be used
+      secretName: lagoon-remote-insights-broker-tls
+      # secretData:
+      #   ca.crt: |
+      #     ...
+    tls:
+      enabled: false
+      verifyPeer: true
 
 # the nats chart is a subchart which is configured for use by lagoon-remote
 # nats subchart is configured for use by lagoon-remote
@@ -451,6 +476,20 @@ storageCalculator:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: v0.8.0
+
+  broker:
+    # enable if providing a custom CA for broker connections
+    tlsCA:
+      enabled: false
+      # if you're definining configuration using the "global" broker settings, this secretName
+      # will not be used
+      secretName: lagoon-remote-storage-broker-tls
+      # secretData:
+      #   ca.crt: |
+      #     ...
+    tls:
+      enabled: false
+      verifyPeer: true
 
 # sysctlConfigure is used  to configure sysctl options on nodes for use by elasticsearch/opensearch pods used in lagoon
 # https://github.com/uselagoon/lagoon/issues/2588


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Currently contains mostly support for configuring `lagoon-build-deploy` and `lagoon-core` via TLS. Will need to adapt to configure `storage-calculator` and `insights-remote` as well.

There aren't any changes required in `uselagoon/lagoon` to support TLS with broker, but there is some cleaning up required with the broker to remove some unused files, and maybe build in some development certificate generation as a fallback in the broker.

They all have pending pullrequests to support talking to broker via TLS
* https://github.com/uselagoon/remote-controller/pull/282
* https://github.com/uselagoon/insights-remote/pull/56
* https://github.com/uselagoon/storage-calculator/pull/22

As noted in https://github.com/uselagoon/lagoon-charts/pull/753#issuecomment-2843780022, this will need to have a follow up pullrequest once the `lagoon-build-deploy` chart is released with this support, so that `lagoon-remote` can be updated to include the new version subchart.

TLS is currently disabled by default, but may change to enabled by default in a future release.

## Lagoon Core

Communications for services inside `lagoon-core` will still be via the internal service non-TLS port. Only external connections will be via TLS. This is subject to change though.

When configuring the `lagoon-core` broker for TLS, the values to configure are under `broker.tls`. Currently, It supports using a pre-created secret containing the certificate which could be crafted manually or via cert-manager, or defining the values for the secret in the values file directly and having helm create the secret. The secret will be created as `lagoon-core-broker-tls` unless the secret name is changed. See the values file for notes.

To enable the external service port to expose the `amqps` port, you'll need to set `broker.service.amqpsExternal.enabled: true`. This is only required if you previously configured `broker.service.amqpExternal.enabled: true`. It is possible to expose both the TLS and non-TLS port externally to aid in a transition period for all lagoon-remotes to be updated. Once you're done, you can set `broker.service.amqpExternal.enabled: false` to disable the exposed non-TLS port.

## Lagoon Remote and Lagoon Build Deploy

To configure lagoon-remote and lagoon-build-deploy to use TLS is also pretty simple. It is possible to use `global.broker: {}` to enable TLS for all services in `lagoon-remote` (this includes `lagoon-build-deploy`). Otherwise each service will have a `broker` section for configuring TLS per service individually.

If the `global.broker` section is used, the secret will be `lagoon-remote-broker-tls`, otherwise each service will use its own secret name in the event that they are defined individually. See the values file in `lagoon-remote` for these options, and also similarly for `lagoon-build-deploy`

When setting the broker `rabbitMQHostname`, make sure you include the `amqps` port, which by default will be `5671`. Eg, `host.example.com:5671`.

## Lagoon Logging

This chart also supports some options under `lagoonLogs.broker` the same way as those in `lagoon-remote` are setup, see the values file as required.
