### PR TITLE
chore: update storage-calc and insights-remote versions

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -50,3 +50,7 @@ annotations:
       description: fix storage-calculator role
     - kind: changed
       description: ssh-portal service configuration options
+    - kind: changed
+      description: update storage-calculator to v0.8.0
+    - kind: changed
+      description: update insights-remote to v0.0.12

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -221,7 +221,7 @@ insightsRemote:
     repository: uselagoon/insights-remote
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.0.11"
+    tag: "v0.0.12"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -450,7 +450,7 @@ storageCalculator:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.7.0
+    tag: v0.8.0
 
 # sysctlConfigure is used  to configure sysctl options on nodes for use by elasticsearch/opensearch pods used in lagoon
 # https://github.com/uselagoon/lagoon/issues/2588


### PR DESCRIPTION
Bump versions of
* storage-calculator 0.7.0 -> 0.8.0
* insights-remote 0.0.11 -> 0.0.12