### PR TITLE
fix: storage-calculator cluster role

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.97.0
+version: 0.97.1
 
 dependencies:
 - name: lagoon-build-deploy
@@ -40,19 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: update lagoon-build-deploy to 0.33.0
-    - kind: changed
-      description: update storage-calculator metrics role
-    - kind: changed
-      description: update ssh-portal image to v0.42.0
     - kind: fixed
-      description: fix storage-calculator role
-    - kind: changed
-      description: ssh-portal service configuration options
-    - kind: changed
-      description: update storage-calculator to v0.8.0
-    - kind: changed
-      description: update insights-remote to v0.0.12
-    - kind: changed
-      description: update nats to v1.2.11
+      description: fix storage-calculator role for secret requests

--- a/charts/lagoon-remote/templates/storage-calculator.clusterrole.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.clusterrole.yaml
@@ -9,20 +9,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - persistentvolumeclaims
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

After the secret changes were added to storage calculator, the role wasn't updated to reflect the requests to get the secret. This fixes the role so that the calculator can retrieve secrets.