### PR TITLE
chore: add dedicated label to docker-host services

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -40,5 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: fix storage-calculator role for secret requests
+    - kind: added
+      description: dedicated label to docker-host services

--- a/charts/lagoon-remote/templates/docker-host.service.yaml
+++ b/charts/lagoon-remote/templates/docker-host.service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: docker-host
   labels:
+    dockerhost.lagoon.sh/dedicated: "false"
     {{- include "lagoon-remote.dockerHost.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.dockerHost.service.type }}
@@ -30,6 +31,7 @@ kind: Service
 metadata:
   name: docker-host-{{ $index0 }}
   labels:
+    dockerhost.lagoon.sh/dedicated: "true"
 {{ $labels | indent 4 }}
 spec:
   type: {{ $stype }}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

To make selecting from the individual docker hosts with their direct services, this adds a dedicated label to be able to select only the direct services in the cluster.
