### PR TITLE
Add startup probe and allow configuration of probes

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.52.0
+version: 0.53.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release

--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -27,6 +27,4 @@ version: 0.53.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update uselagoon/logs-concentrator image from v3.6.0 to v3.7.0
-    - kind: changed
-      description: enforce use of configured hostname for fluentd output
+      description: make probes configurable

--- a/charts/lagoon-logs-concentrator/templates/statefulset.yaml
+++ b/charts/lagoon-logs-concentrator/templates/statefulset.yaml
@@ -59,12 +59,18 @@ spec:
           containerPort: 24231
           protocol: TCP
         {{- end }}
+        {{- with .Values.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.livenessProbe }}
         livenessProbe:
-          tcpSocket:
-            port: forward
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
         readinessProbe:
-          tcpSocket:
-            port: forward
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "lagoon-logs-concentrator.fullname" . }}-env

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -62,6 +62,17 @@ resources:
     cpu: "1"
     memory: 2Gi
 
+startupProbe:
+  failureThreshold: 10
+  tcpSocket:
+    port: forward
+livenessProbe:
+  tcpSocket:
+    port: forward
+readinessProbe:
+  tcpSocket:
+    port: forward
+
 autoscaling:
   enabled: true
   minReplicas: 2


### PR DESCRIPTION
With a full buffer the logs concentrator can take longer to start up
than the default liveness probe. Making the probes configurable allows
operators to adjust them as required according to the size of the
environment.