### PR TITLE
chore: update remote-controller to v0.23.0

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,9 +16,9 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.33.0
+version: 0.34.0
 
-appVersion: v0.22.0
+appVersion: v0.23.0
 
 annotations:
   artifacthub.io/changes: |
@@ -26,6 +26,8 @@ annotations:
       description: move harbor credentials into secret
     - kind: changed
       description: tls support for rabbitmq
+    - kind: changed
+      description: update remote-controller to v0.23.0
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2


### PR DESCRIPTION
Update `remote-controller` to v0.23.0 and release the chart.