### PR TITLE
test: optionally install aergia for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,10 @@ install-aergia:
 		--timeout $(TIMEOUT) \
 		--set templates.enabled=false \
 		--set idling.enabled=true \
-		--set idling.serviceCron="5 * * * *" \
-		--set idling.podCheckInterval=30m \
+		--set idling.serviceCron="0\,15\,30\,45 * * * *" \
+		--set idling.podCheckInterval=5m \
+		--set idling.prometheusCheckInterval=5m \
+		--set idling.prometheusEndpoint="http://kube-prometheus-kube-prome-prometheus.kube-prometheus.svc:9090" \
 		$$([ $(INSTALL_PROMETHEUS) = true ] && echo '--set servicemonitor.enabled=true') \
 		$$([ $(INSTALL_PROMETHEUS) = true ] && echo '--set metrics.enabled=true') \
 		--set unidling.verifyRequests.enabled=false \
@@ -235,6 +237,9 @@ install-ingress: install-certmanager
 		--set controller.ingressClassResource.default=true \
 		--set controller.addHeaders.X-Lagoon="remote>ingress-nginx>$$namespace:$$service_name" \
 		$$([ $(INSTALL_AERGIA) = true ] && echo '--set controller.extraArgs.default-backend-service=aergia/aergia-backend') \
+		$$([ $(INSTALL_PROMETHEUS) = true ] && echo '--set controller.metrics.enabled=true') \
+		$$([ $(INSTALL_PROMETHEUS) = true ] && echo '--set controller.metrics.serviceMonitor.enabled=true') \
+		$$([ $(INSTALL_PROMETHEUS) = true ] && echo '--set controller.metrics.serviceMonitor.additionalLabels.release=kube-prometheus') \
 		--version=4.12.1 \
 		ingress-nginx \
 		ingress-nginx/ingress-nginx

--- a/ci/grafana-dashboards/aergia.yaml
+++ b/ci/grafana-dashboards/aergia.yaml
@@ -284,9 +284,11 @@ data:
           {
             "current": {
               "text": "All",
-              "value": "$__all"
+              "value": [
+                "$__all"
+              ]
             },
-            "definition": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+            "definition": "label_values(kube_pod_info, namespace)",
             "description": "This is used by the Ingress Idling Hits visualisation only",
             "includeAll": true,
             "label": "Namespace",
@@ -295,7 +297,7 @@ data:
             "options": [],
             "query": {
               "qryType": 5,
-              "query": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+              "query": "label_values(kube_pod_info, namespace)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
@@ -330,5 +332,5 @@ data:
       "timezone": "",
       "title": "Aergia",
       "uid": "943ZiuvSk",
-      "version": 4
+      "version": 5
     }

--- a/ci/grafana-dashboards/aergia.yaml
+++ b/ci/grafana-dashboards/aergia.yaml
@@ -1,0 +1,334 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aergia-dashboard
+  labels:
+    grafana_dashboard: "1"
+data:
+   aergia-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 32,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 5,
+          "panels": [],
+          "title": "Aergia Idling Stats",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Verifications: All requests to unidle an environment (bots, users, anything)\n\nAllowed: Only if the verification request is from a browser is it allowed to unidle the environment\n\nIdling Events: 4h after no hits to any ingress in the namespace reported in prometheus\n\nUnidling Events: Should mostly match the Allowed line",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "round(sum(increase(aergia_verification_required_requests[5m])))",
+              "instant": false,
+              "legendFormat": "Verifications",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "round(sum(increase(aergia_allowed_requests[5m])))",
+              "hide": false,
+              "legendFormat": "Allowed",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "round(sum(increase(aergia_idling_events[5m])))",
+              "hide": false,
+              "legendFormat": "Idling Events",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "round(sum(increase(aergia_unidling_events[5m])))",
+              "hide": false,
+              "legendFormat": "Unidling Events",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Aergia Stats",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
+          "id": 4,
+          "panels": [],
+          "title": "Ingress Idling Hits",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Pick a Namespace(s), and adjust the Idling Interval to the particular cluster idling schedule that is know (most likely 4h which is the default)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 12
+          },
+          "id": 3,
+          "options": {
+            "displayMode": "basic",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "left",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PJestz47z"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sort_desc(round(sum(increase(nginx_ingress_controller_requests{exported_namespace=~\"$namespace\",status=~\"2[0-9x]{2}\"}[$idleinterval])) by (exported_namespace,status)))",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "{{exported_namespace}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Ingress Hits ($idleinterval)",
+          "type": "bargauge"
+        }
+      ],
+      "preload": false,
+      "refresh": "",
+      "schemaVersion": 41,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "definition": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+            "description": "This is used by the Ingress Idling Hits visualisation only",
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "qryType": 5,
+              "query": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "4h",
+              "value": "4h"
+            },
+            "description": "This is used by the Ingress Idling Hits visualisation only",
+            "label": "Idle Interval",
+            "name": "idleinterval",
+            "options": [
+              {
+                "selected": true,
+                "text": "4h",
+                "value": "4h"
+              }
+            ],
+            "query": "4h",
+            "type": "textbox"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Aergia",
+      "uid": "943ZiuvSk",
+      "version": 4
+    }


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Support to optionally install aergia along side lagoon for local testing/verification of aergia functionality. It is disabled in charts-testing.

Associated PR that utilises this functionality https://github.com/uselagoon/lagoon/pull/3949