### PR TITLE
fix: use correct variable for broker tls in insights-remote

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.98.0
+version: 0.98.1
 
 dependencies:
 - name: lagoon-build-deploy
@@ -40,17 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: this change intentionally left blank
-    - kind: added
-      description: dedicated label to docker-host services
-    - kind: added
-      description: added extraEnvs to insights remote values
-    - kind: changed
-      description: tls support for rabbitmq
-    - kind: changed
-      description: update lagoon-build-deploy subchart to v0.34.2
-    - kind: changed
-      description: update uselagoon/docker-host to v3.6.0
-    - kind: changed
-      description: update uselagoon/insights-remote to v0.0.13
+    - kind: fixed
+      description: insights-remote broker tls flag

--- a/charts/lagoon-remote/templates/insights-remote.deployment.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.deployment.yaml
@@ -61,7 +61,7 @@ spec:
               value: "TRUE"
           {{- end }}
           {{- if $rabbitMQTLSEnabled }}
-            - name: RABBITMQ_ENABLED
+            - name: RABBITMQ_TLS
               value: "TRUE"
           {{- end }}
             - name: RABBITMQ_ADDRESS


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Fixes the variable used for insights-remote to enable broker TLS (https://github.com/uselagoon/insights-remote/blob/v0.0.13/cmd/main.go#L229)