### PR TITLE
chore: enable email notifications in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ INSTALL_MONGODB_PROVIDER = true
 LOGS2SLACK_DISABLED = false
 LOGS2EMAIL_DISABLED = false
 LOGS2ROCKETCHAT_DISABLED = true
-LOGS2EMAIL_DISABLED = true
+LOGS2EMAIL_DISABLED = false
 LOGS2MICROSOFTTEAMS_DISABLED = true
 
 # install k8up v1 (backup.appuio.ch/v1alpah1) and v2 (k8up.io/v1)
@@ -468,7 +468,7 @@ endif
 		--set keycloakDB.vendor=$(CORE_DATABASE_VENDOR) \
 		$$([ $(IMAGE_REGISTRY) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set logs2notifications.image.repository=$(IMAGE_REGISTRY)/logs2notifications') \
 		$$([ $(INSTALL_MAILPIT) = true ] && echo '--set logs2notifications.additionalEnvs.EMAIL_HOST=mailpit-smtp.mailpit.svc') \
-		$$([ $(INSTALL_MAILPIT) = true ] && echo '--set logs2notifications.additionalEnvs.EMAIL_PORT="25"') \
+		$$([ $(INSTALL_MAILPIT) = true ] && echo '--set logs2notifications.additionalEnvs.EMAIL_PORT=25') \
 		--set logs2notifications.logs2email.disabled=$(LOGS2EMAIL_DISABLED) \
 		--set logs2notifications.logs2microsoftteams.disabled=$(LOGS2MICROSOFTTEAMS_DISABLED) \
 		--set logs2notifications.logs2rocketchat.disabled=$(LOGS2ROCKETCHAT_DISABLED) \


### PR DESCRIPTION
Enable email notifications in development, and fix the port setting used for the logs2notifcation email service.

This is to support https://github.com/uselagoon/lagoon/pull/3920 in local development