### PR TITLE
chore: use k8up.io/v1 schedule if available

### DIFF
--- a/charts/lagoon-core/templates/k8up.schedule.yaml
+++ b/charts/lagoon-core/templates/k8up.schedule.yaml
@@ -1,3 +1,34 @@
+{{- if .Capabilities.APIVersions.Has "k8up.io/v1/Schedule" }}
+{{- $schedule := index (lookup "k8up.io/v1" "Schedule" .Release.Namespace (include "lagoon-core.fullname" . )) | default dict }}
+{{- $bucket := coalesce .Values.k8upBackupBucketName (dig "spec" "backend" "s3" "bucket" "" $schedule) (print "baas-" (include "lagoon-core.fullname" .) "-" (randAlphaNum 8 | lower)) }}
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: {{ include "lagoon-core.fullname" . }}
+  labels:
+    {{- include "lagoon-core.labels" . | nindent 4 }}
+spec:
+  backend:
+    repoPasswordSecretRef:
+      key: repo-pw
+      name: "{{ include "lagoon-core.fullname" . }}-baas-repo-pw"
+    s3:
+      bucket: {{ $bucket | quote }}
+      {{ with .Values.k8upS3Endpoint }}
+      endpoint: {{ . | quote }}
+      {{ end }}
+  backup:
+    schedule: '15 * * * *'
+  check:
+    schedule: '45 3 * * *'
+  prune:
+    retention:
+      keepHourly: 36
+      keepDaily: 30
+      keepWeekly: 12
+      keepMonthly: 12
+    schedule: '26 4 * * 0'
+{{- else }}
 {{- if .Capabilities.APIVersions.Has "backup.appuio.ch/v1alpha1/Schedule" }}
 {{- $schedule := index (lookup "backup.appuio.ch/v1alpha1" "Schedule" .Release.Namespace (include "lagoon-core.fullname" . )) | default dict }}
 {{- $bucket := coalesce .Values.k8upBackupBucketName (dig "spec" "backend" "s3" "bucket" "" $schedule) (print "baas-" (include "lagoon-core.fullname" .) "-" (randAlphaNum 8 | lower)) }}
@@ -28,4 +59,5 @@ spec:
       keepWeekly: 12
       keepMonthly: 12
     schedule: '26 4 * * 0'
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Since k8up.io (k8up 2.x) is supported by `lagoon-remote` and `lagoon-build-deploy` for workloads deployed by Lagoon, it makes sense to also have the chart for lagoon-core support k8up.io

Closes #707 