### PR TITLE
Updates to core, remote, and test to lagoon 2.26.0

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -27,7 +27,7 @@ version: 1.53.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.25.0
+appVersion: v2.26.0
 
 dependencies:
 - name: nats
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: renamed broker flag-enable job to bootstrap
+      description: update lagoon appVersion to 2.26.0

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update lagoon appVersion to 2.26.0
+    - kind: changed
+      description: update insights-handler to v0.0.8

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.53.0
+version: 1.54.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -667,7 +667,7 @@ insightsHandler:
     repository: uselagoon/insights-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.0.7"
+    tag: "v0.0.8"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.34.2
+  version: 0.35.0
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
   version: 0.3.1
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.2.11
-digest: sha256:94df2af0b25f20587633d854fe16d08c8ead672e7f84f8fc5dfecb06a5a8aab1
-generated: "2025-05-08T10:40:53.648666414+10:00"
+digest: sha256:47e5fa816a573c369f8e625b90b044666e38522e0fba2d627a1d2673c6d38495
+generated: "2025-06-27T16:32:13.210856599+12:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.98.1
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.34.0
+  version: ~0.35.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dbaas-operator

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.98.1
+version: 0.92.0
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.92.0
+version: 0.99.0
 
 dependencies:
 - name: lagoon-build-deploy

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -40,5 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: insights-remote broker tls flag
+    - kind: changed
+      description: update build-deploy dependency to 0.35.0

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.65.0
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.25.0
+appVersion: v2.26.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -29,6 +29,4 @@ appVersion: v2.25.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon appVersion to 2.25.0
-    - kind: changed
-      description: Lagoon Workflows subsystem removed
+      description: update lagoon appVersion to 2.26.0

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.65.0
+version: 0.66.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.


### PR DESCRIPTION
lagoon charts release for Lagoon Core 2.26.0