### PR TITLE
chore: update lagoon-core to v2.26.1

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.54.0
+version: 1.54.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.26.0
+appVersion: v2.26.1
 
 dependencies:
 - name: nats
@@ -41,6 +41,8 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon appVersion to 2.26.0
+      description: update lagoon appVersion to 2.26.1
     - kind: changed
-      description: update insights-handler to v0.0.8
+      description: update lagoon ui to 2.26.1
+    - kind: changed
+      description: kept build-deploy-image at 2.26.0

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -71,6 +71,10 @@ keycloakAdminUser: admin
 # keycloakAdminEmail: admin@example.com
 
 buildDeployImage:
+  default:
+    # when updating this chart, ensure that if there are any changes made to the build-deploy-tool repository
+    # and a new image tag is released, that this image tag is updated to reference the new image version
+    image: uselagoon/build-deploy-image:core-v2.26.0
   edge:
     enabled: false
 
@@ -553,8 +557,9 @@ ui:
   image:
     repository: uselagoon/ui
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+    # when updating this chart, ensure that if there are any changes made to the lagoon-ui repository
+    # and a new image tag is released, that this image tag is updated to reference the new image version
+    tag: "core-v2.26.1"
 
   podAnnotations: {}
 


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Update `lagoon-core` to v2.26.1. This includes a bump to the `lagoon-ui` to the same version.

Excluded from this are changes to the `build-deploy-image` as there have been no changes to this image in this patch release. This keeps the `build-deploy-image` locked to v2.26.0

Will need to merge docs afterwards https://github.com/uselagoon/lagoon/pull/3936