### PR TITLE
Pass extraEnvs to environment variables directly from values

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,14 +16,14 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.36.0
+version: 0.35.0
 
 appVersion: v0.24.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: allow valueFrom for environment variables
+      description: update remote-controller to v0.24.0
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -23,7 +23,7 @@ appVersion: v0.24.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller to v0.24.0
+      description: pass extraEnvs directly from values
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,14 +16,14 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.35.0
+version: 0.36.0
 
 appVersion: v0.24.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller to v0.24.0
+      description: allow valueFrom for environment variables
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -174,15 +174,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
-        {{- range .Values.extraEnvs }}
-        - name: {{ .name }}
-          {{- with .value }}
-          value: {{ . | quote }}
-          {{- end }}
-          {{- with .valueFrom }}
-          valueFrom:
-          {{- toYaml . | nindent 8 }}
-          {{- end}}
+        {{- with .Values.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: LAGOON_TARGET_NAME
           value: {{ required "A valid .Values.lagoonTargetName required!" .Values.lagoonTargetName | quote }}

--- a/charts/lagoon-build-deploy/templates/deployment.yaml
+++ b/charts/lagoon-build-deploy/templates/deployment.yaml
@@ -174,9 +174,15 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
-        {{- range $name, $value := .Values.extraEnvs }}
+        {{- range .Values.extraEnvs }}
         - name: {{ .name }}
-          value: {{ .value | quote }}
+          {{- with .value }}
+          value: {{ . | quote }}
+          {{- end }}
+          {{- with .valueFrom }}
+          valueFrom:
+          {{- toYaml . | nindent 8 }}
+          {{- end}}
         {{- end }}
         - name: LAGOON_TARGET_NAME
           value: {{ required "A valid .Values.lagoonTargetName required!" .Values.lagoonTargetName | quote }}

--- a/charts/lagoon-docker-host/Chart.yaml
+++ b/charts/lagoon-docker-host/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.4.0
+version: 0.5.0
 
 appVersion: v3.5.0
 
@@ -26,4 +26,4 @@ appVersion: v3.5.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: changed docker-host to statefulset from deployment
+      description: allow valueFrom for environment variables

--- a/charts/lagoon-docker-host/Chart.yaml
+++ b/charts/lagoon-docker-host/Chart.yaml
@@ -26,4 +26,4 @@ appVersion: v3.5.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: changed docker-host to statefulset from deployment
+      description: pass extraEnvs directly from values

--- a/charts/lagoon-docker-host/Chart.yaml
+++ b/charts/lagoon-docker-host/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.5.0
+version: 0.4.0
 
 appVersion: v3.5.0
 
@@ -26,4 +26,4 @@ appVersion: v3.5.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: allow valueFrom for environment variables
+      description: changed docker-host to statefulset from deployment

--- a/charts/lagoon-docker-host/Chart.yaml
+++ b/charts/lagoon-docker-host/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.4.0
+version: 0.5.0
 
 appVersion: v3.5.0
 

--- a/charts/lagoon-docker-host/templates/docker-host.statefulset.yaml
+++ b/charts/lagoon-docker-host/templates/docker-host.statefulset.yaml
@@ -32,15 +32,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-        {{- range .Values.extraEnvs }}
-        - name: {{ .name }}
-          {{- with .value }}
-          value: {{ . | quote }}
-          {{- end }}
-          {{- with .valueFrom }}
-          valueFrom:
-          {{- toYaml . | nindent 8 }}
-          {{- end}}
+        {{- with .Values.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.httpProxy }}
         - name: HTTP_PROXY

--- a/charts/lagoon-docker-host/templates/docker-host.statefulset.yaml
+++ b/charts/lagoon-docker-host/templates/docker-host.statefulset.yaml
@@ -32,9 +32,15 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-        {{- range $name, $value := .Values.extraEnvs }}
+        {{- range .Values.extraEnvs }}
         - name: {{ .name }}
-          value: {{ .value | quote }}
+          {{- with .value }}
+          value: {{ . | quote }}
+          {{- end }}
+          {{- with .valueFrom }}
+          valueFrom:
+          {{- toYaml . | nindent 8 }}
+          {{- end}}
         {{- end }}
         {{- with .Values.httpProxy }}
         - name: HTTP_PROXY

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.100.0
+version: 0.99.1
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: allow valueFrom for environment variables
+      description: update ssh-portal to v0.43.0

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.99.1
+version: 0.100.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update ssh-portal to v0.43.0
+      description: allow valueFrom for environment variables

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -41,4 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update ssh-portal to v0.43.0
+      description: pass extraEnvs directly from values

--- a/charts/lagoon-remote/templates/docker-host.statefulset.yaml
+++ b/charts/lagoon-remote/templates/docker-host.statefulset.yaml
@@ -32,7 +32,7 @@ spec:
         image: "{{ .Values.dockerHost.image.repository }}:{{ coalesce .Values.dockerHost.image.tag .Values.imageTag "latest" }}"
         imagePullPolicy: {{ .Values.dockerHost.image.pullPolicy }}
         env:
-        {{- with .Values.extraEnvs }}
+        {{- with .Values.dockerHost.extraEnvs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.dockerHost.httpProxy }}

--- a/charts/lagoon-remote/templates/docker-host.statefulset.yaml
+++ b/charts/lagoon-remote/templates/docker-host.statefulset.yaml
@@ -32,9 +32,15 @@ spec:
         image: "{{ .Values.dockerHost.image.repository }}:{{ coalesce .Values.dockerHost.image.tag .Values.imageTag "latest" }}"
         imagePullPolicy: {{ .Values.dockerHost.image.pullPolicy }}
         env:
-        {{- range $name, $value := .Values.dockerHost.extraEnvs }}
+        {{- range .Values.dockerHost.extraEnvs }}
         - name: {{ .name }}
-          value: {{ .value | quote }}
+          {{- with .value }}
+          value: {{ . | quote }}
+          {{- end }}
+          {{- with .valueFrom }}
+          valueFrom:
+          {{- toYaml . | nindent 8 }}
+          {{- end}}
         {{- end }}
         {{- with .Values.dockerHost.httpProxy }}
         - name: HTTP_PROXY

--- a/charts/lagoon-remote/templates/docker-host.statefulset.yaml
+++ b/charts/lagoon-remote/templates/docker-host.statefulset.yaml
@@ -32,15 +32,8 @@ spec:
         image: "{{ .Values.dockerHost.image.repository }}:{{ coalesce .Values.dockerHost.image.tag .Values.imageTag "latest" }}"
         imagePullPolicy: {{ .Values.dockerHost.image.pullPolicy }}
         env:
-        {{- range .Values.dockerHost.extraEnvs }}
-        - name: {{ .name }}
-          {{- with .value }}
-          value: {{ . | quote }}
-          {{- end }}
-          {{- with .valueFrom }}
-          valueFrom:
-          {{- toYaml . | nindent 8 }}
-          {{- end}}
+        {{- with .Values.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.dockerHost.httpProxy }}
         - name: HTTP_PROXY

--- a/charts/lagoon-remote/templates/insights-remote.deployment.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.deployment.yaml
@@ -52,8 +52,8 @@ spec:
           image: "{{ .Values.insightsRemote.image.repository }}:{{ coalesce .Values.insightsRemote.image.tag .Values.imageTag "latest" }}"
           imagePullPolicy: {{ .Values.insightsRemote.image.pullPolicy }}
           env:
-          {{- with .Values.extraEnvs }}
-          {{- toYaml . | nindent 10 }}
+          {{- with .Values.insightsRemote.extraEnvs }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.insightsRemote.burnAfterReading }}
             - name: BURN_AFTER_READING

--- a/charts/lagoon-remote/templates/insights-remote.deployment.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.deployment.yaml
@@ -52,15 +52,8 @@ spec:
           image: "{{ .Values.insightsRemote.image.repository }}:{{ coalesce .Values.insightsRemote.image.tag .Values.imageTag "latest" }}"
           imagePullPolicy: {{ .Values.insightsRemote.image.pullPolicy }}
           env:
-          {{- range .Values.dockerHost.extraEnvs }}
-          - name: {{ .name }}
-            {{- with .value }}
-            value: {{ . | quote }}
-            {{- end }}
-            {{- with .valueFrom }}
-            valueFrom:
-            {{- toYaml . | nindent 8 }}
-            {{- end}}
+          {{- with .Values.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- if .Values.insightsRemote.burnAfterReading }}
             - name: BURN_AFTER_READING

--- a/charts/lagoon-remote/templates/insights-remote.deployment.yaml
+++ b/charts/lagoon-remote/templates/insights-remote.deployment.yaml
@@ -52,9 +52,15 @@ spec:
           image: "{{ .Values.insightsRemote.image.repository }}:{{ coalesce .Values.insightsRemote.image.tag .Values.imageTag "latest" }}"
           imagePullPolicy: {{ .Values.insightsRemote.image.pullPolicy }}
           env:
-          {{- range $name, $value := .Values.insightsRemote.extraEnvs }}
-            - name: {{ .name }}
-              value: {{ .value | quote }}
+          {{- range .Values.dockerHost.extraEnvs }}
+          - name: {{ .name }}
+            {{- with .value }}
+            value: {{ . | quote }}
+            {{- end }}
+            {{- with .valueFrom }}
+            valueFrom:
+            {{- toYaml . | nindent 8 }}
+            {{- end}}
           {{- end }}
           {{- if .Values.insightsRemote.burnAfterReading }}
             - name: BURN_AFTER_READING

--- a/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
@@ -62,9 +62,15 @@ spec:
         - containerPort: 8443
           name: https
         env:
-        {{- range $name, $value := .Values.storageCalculator.extraEnvs }}
+        {{- range .Values.storageCalculator.extraEnvs }}
         - name: {{ .name }}
-          value: {{ .value | quote }}
+          {{- with .value }}
+          value: {{ . | quote }}
+          {{- end }}
+          {{- with .valueFrom }}
+          valueFrom:
+          {{- toYaml . | nindent 8 }}
+          {{- end}}
         {{- end }}
         {{- with .Values.storageCalculator.cronjob }}
         - name: CALCULATOR_CRON

--- a/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - containerPort: 8443
           name: https
         env:
-        {{- with .Values.extraEnvs }}
+        {{- with .Values.storageCalculator.extraEnvs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.storageCalculator.cronjob }}

--- a/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
+++ b/charts/lagoon-remote/templates/storage-calculator.deployment.yaml
@@ -62,15 +62,8 @@ spec:
         - containerPort: 8443
           name: https
         env:
-        {{- range .Values.storageCalculator.extraEnvs }}
-        - name: {{ .name }}
-          {{- with .value }}
-          value: {{ . | quote }}
-          {{- end }}
-          {{- with .valueFrom }}
-          valueFrom:
-          {{- toYaml . | nindent 8 }}
-          {{- end}}
+        {{- with .Values.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.storageCalculator.cronjob }}
         - name: CALCULATOR_CRON


### PR DESCRIPTION
Adds support of `valueFrom` field when adding environment variables in a container by passing `extraEnvs` to environment variables directly from values.

Related issue: https://amazeeio.atlassian.net/browse/PLAT-571
