### PR TITLE
chore: bump remote-controller version

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,14 +16,16 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.35.0
+version: 0.36.0
 
-appVersion: v0.24.0
+appVersion: v0.25.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: pass extraEnvs directly from values
+    - kind: changed
+      description: update remote-controller to v0.25.0
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2


### PR DESCRIPTION
Bump the remote-controller version to v0.25.0 in preparation for upcoming release of lagoon-remote chart