### PR TITLE
chore: update lagoon-build-deploy subchart to v0.36.0

### DIFF
--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.35.0
+  version: 0.36.0
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
-  version: 0.3.1
+  version: 0.3.3
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.2.11
-digest: sha256:47e5fa816a573c369f8e625b90b044666e38522e0fba2d627a1d2673c6d38495
-generated: "2025-06-27T16:32:13.210856599+12:00"
+digest: sha256:a8d95b79e82cff5d551f610ba199078c9d1dad6b904c3f1b1e69ed096f06a3f0
+generated: "2025-08-01T12:57:56.962757965+10:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.99.1
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.35.0
+  version: ~0.36.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dbaas-operator
@@ -44,3 +44,5 @@ annotations:
       description: change nats tls certificate secret to allow for setting only the ca certificate
     - kind: changed
       description: pass extraEnvs directly from values
+    - kind: changed
+      description: update lgaoon-build-deploy chart to v0.36.0


### PR DESCRIPTION
Update the lagoon-build-deploy subchart version to v0.36.0