### PR TITLE
chore: bump chart versions for lagoon v2.27.0 release

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.54.2
+version: 1.55.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.26.1
+appVersion: v2.27.0
 
 dependencies:
 - name: nats
@@ -48,3 +48,5 @@ annotations:
       description: support for s3 files bucket to actions-handler
     - kind: added
       description: add support for setting seed user or organization upon initial install
+    - kind: changed
+      description: update lagoon appVersion to 2.27.0

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -85,7 +85,7 @@ buildDeployImage:
   default:
     # when updating this chart, ensure that if there are any changes made to the build-deploy-tool repository
     # and a new image tag is released, that this image tag is updated to reference the new image version
-    image: uselagoon/build-deploy-image:core-v2.26.0
+    image: uselagoon/build-deploy-image:core-v2.27.0
   edge:
     enabled: false
 
@@ -575,7 +575,7 @@ ui:
     pullPolicy: Always
     # when updating this chart, ensure that if there are any changes made to the lagoon-ui repository
     # and a new image tag is released, that this image tag is updated to reference the new image version
-    tag: "core-v2.26.1"
+    tag: "core-v2.27.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.99.1
+version: 0.100.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -48,3 +48,5 @@ annotations:
       description: update lagoon-build-deploy chart to v0.36.0
     - kind: changed
       description: update storage calculator to v0.8.1
+    - kind: changed
+      description: bump chart version for release


### PR DESCRIPTION
This bumps the lagoon-core and lagoon-remote chart versions as part of the v2.27.0 release.