### PR TITLE
Only expose metrics for enabled CDN logs collector

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.87.1
+version: 0.87.2
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -37,5 +37,5 @@ dependencies:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: expose cdn-logs-collector metrics
+    - kind: fixed
+      description: only expose cdn-logs-collector metrics when component is enabled

--- a/charts/lagoon-logging/templates/cdn-logs-collector-metrics.service.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector-metrics.service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cdnLogsCollector.metrics.enabled -}}
+{{- if and .Values.cdnLogsCollector.enabled .Values.cdnLogsCollector.metrics.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
This only creates the service for metrics of the CDN logs collector component, introduced in #791, when the component itself is enabled.