### PR TITLE
Make logging-operator images configurable

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.87.2
+version: 0.88.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -37,5 +37,5 @@ dependencies:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: fixed
-      description: only expose cdn-logs-collector metrics when component is enabled
+    - kind: added
+      description: allow configuration of container images used by the logging operator

--- a/charts/lagoon-logging/templates/logging.yaml
+++ b/charts/lagoon-logging/templates/logging.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   enableRecreateWorkloadOnImmutableFieldChange: true
   fluentd:
+  {{- with .Values.fluentdImage }}
+    image:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentdConfigHotReloadImage }}
+    configReloaderImage:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
     security:
       podSecurityContext:
         runAsUser: 100
@@ -32,6 +40,15 @@ spec:
     livenessDefaultCheck: true
     filterKubernetes:
       namespace_labels: {{ default "Off" .Values.fluentbitNamespaceLabels | quote }}
+  {{- with .Values.fluentbitImage }}
+    image:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbitConfigHotReloadImage }}
+    configHotReload:
+      image:
+      {{- toYaml . | nindent 8 }}
+  {{- end }}
   {{- if .Values.fluentbitPrivileged }}
     security:
       securityContext:

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -9,6 +9,21 @@ fullnameOverride: ""
 # on the service level, if not set it falls back to chart appVersion.
 imageTag: ""
 
+# Optionally reconfigure the container images to be used by the logging operator
+# logging-operator:
+#   image:
+#     repository: ghcr.io/kube-logging/logging-operator
+# fluentdImage:
+#   repository: ghcr.io/kube-logging/fluentd
+#   tag: v0.1.0
+# fluentbitImage:
+#   repository: docker.io/fluent/fluent-bit
+# fluentdConfigHotReloadImage:
+#   repository: ghcr.io/kube-logging/config-reloader
+#   pullPolicy: Always
+# fluentbitConfigHotReloadImage:
+#   repository: ghcr.io/kube-logging/config-reloader
+
 logsDispatcher:
 
   name: logs-dispatcher


### PR DESCRIPTION
In some setups it can be required to use an alternative container image
registry than those used by the operator.
