### PR TITLE
fix: seeding not waiting for keycloak before creating user

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -40,13 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: add support for s3 files bucket to actions-handler
-    - kind: changed
-      description: add servicemonitor for keycloak
     - kind: fixed
-      description: support for s3 files bucket to actions-handler
-    - kind: added
-      description: add support for setting seed user or organization upon initial install
-    - kind: changed
-      description: update lagoon appVersion to 2.27.0
+      description: fix chart seeding not waiting for keycloak to be ready


### PR DESCRIPTION
The existing script does not wait for Keycloak to start and be ready, which leads to scenarios where keycloak returns a 503, and the user never gets created.

This was happening to me on my lagoon cluster on my homeserver.

This PR fixes it by waiting until keycloak returns `200` on the `/auth/admin/realm/master` path.
