### PR TITLE
fix: local-stack installation of k8up on ARM systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ endif
 # install k8up versions for backup upgrade path verifications if requested
 ifeq ($(INSTALL_K8UP),true)
 ifeq ($(REMOTE_CONTROLLER_K8UP_VERSION), v1)
-install-lagoon-dependencies: install-k8upv1
+install-lagoon-dependencies: install-k8upv1 install-k8upv2
 else
 install-lagoon-dependencies: install-k8upv2
 endif 

--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,11 @@ install-lagoon-dependencies: install-mongodb
 endif
 # install k8up versions for backup upgrade path verifications if requested
 ifeq ($(INSTALL_K8UP),true)
-install-lagoon-dependencies: install-k8upv1 install-k8upv2
+ifeq ($(REMOTE_CONTROLLER_K8UP_VERSION), v1)
+install-lagoon-dependencies: install-k8upv1
+else
+install-lagoon-dependencies: install-k8upv2
+endif 
 endif
 
 # this installs lagoon-core, lagoon-remote, and lagoon-build-deploy, and if dependencies required will install them too


### PR DESCRIPTION
# Description

By default, the local-stack installs k8upv1alpha1 ("v1"), but this does not support ARM systems. This makes it impossible to build the local-stack directly with backups enabled using `make k3d/local-stack INSTALL_K8UP=true` without manually removing the offending make target dependency.

This PR changes the installation so that v1 is only installed if explicitly enabled via the `REMOTE_CONTROLLER_K8UP_VERSION` variable.
