### PR TITLE
feat: add support for external secrets to the opensearch-sync service

### DIFF
--- a/charts/lagoon-core/templates/opensearch-sync.deployment.yaml
+++ b/charts/lagoon-core/templates/opensearch-sync.deployment.yaml
@@ -39,11 +39,6 @@ spec:
         {{- end }}
         - name: API_DB_ADDRESS
           value: {{ include "lagoon-core.apiDB.fullname" . }}
-        - name: API_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "lagoon-core.apiDB.fullname" . }}
-              key: API_DB_PASSWORD
         - name: KEYCLOAK_BASE_URL
           {{- if .Values.keycloakFrontEndURL }}
           value: {{ .Values.keycloakFrontEndURL }}/
@@ -54,15 +49,29 @@ spec:
           {{- end }}
         - name: KEYCLOAK_CLIENT_ID
           value: lagoon-opensearch-sync
+        - name: OPENSEARCH_BASE_URL
+          value: {{ required "A valid .Values.elasticsearchURL required!" .Values.elasticsearchURL | quote }}
+        - name: OPENSEARCH_DASHBOARDS_BASE_URL
+          value: {{ required "A valid .Values.kibanaURL required!" .Values.kibanaURL | quote }}
+        {{- if .Values.opensearchSync.externalSecrets.enabled }}
+        {{- range .Values.opensearchSync.externalSecrets.references }}
+        - name: {{ coalesce .envVar .key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .name }}
+              key: {{ .key }}
+        {{- end }}
+        {{- else }}
+        - name: API_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.apiDB.fullname" . }}
+              key: API_DB_PASSWORD
         - name: KEYCLOAK_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: {{ include "lagoon-core.keycloak.fullname" . }}
               key: KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET
-        - name: OPENSEARCH_BASE_URL
-          value: {{ required "A valid .Values.elasticsearchURL required!" .Values.elasticsearchURL | quote }}
-        - name: OPENSEARCH_DASHBOARDS_BASE_URL
-          value: {{ required "A valid .Values.kibanaURL required!" .Values.kibanaURL | quote }}
         - name: OPENSEARCH_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -73,6 +82,7 @@ spec:
             secretKeyRef:
               name: {{ include "lagoon-core.opensearchSync.fullname" . }}
               key: OPENSEARCH_CA_CERTIFICATE
+        {{- end }}
       {{- range $key, $val := .Values.opensearchSync.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/lagoon-core/templates/opensearch-sync.secret.yaml
+++ b/charts/lagoon-core/templates/opensearch-sync.secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.opensearchSync.enabled -}}
+{{- if and .Values.opensearchSync.enabled (not .Values.opensearchSync.externalSecrets.enabled) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -1037,6 +1037,21 @@ sshPortalAPI:
 
 opensearchSync:
   enabled: false
+  externalSecrets:
+    # If externalSecrets is enabled, the chart will not template a secret.
+    # Instead, secrets with the given names and keys must be created externally.
+    enabled: false
+    references:
+    - key: API_DB_PASSWORD
+      name: lagoon-core-api-db-external
+    - key: KEYCLOAK_LAGOON_OPENSEARCH_SYNC_CLIENT_SECRET
+      name: lagoon-core-keycloak-external
+      envVar: KEYCLOAK_CLIENT_SECRET
+    - key: LOGSDB_ADMIN_PASSWORD
+      name: lagoon-core-api-external
+      envVar: OPENSEARCH_ADMIN_PASSWORD
+    - key: OPENSEARCH_CA_CERTIFICATE
+      name: lagoon-core-opensearch-sync-external
   image:
     repository: ghcr.io/uselagoon/lagoon-opensearch-sync
     pullPolicy: IfNotPresent


### PR DESCRIPTION
This experimental change adds support for external secrets to the opensearch-sync service.

External secrets support defaults to disabled, but you can enable it via:

```yaml
opensearchSync:
  externalSecrets:
    enabled: true
```

If external secrets are enabled, then the chart will no longer template a `Secret` object for the opensearch-sync service, and instead expects externally managed `Secret` objects to be created for it to consume.

The current chart errs on the side of a single source of truth for secrets shared between services. So, for example, the opensearch-sync service consumes the `API_DB_PASSWORD` out of the `api-db` secret, and the `KEYCLOAK_CLIENT_SECRET` out of the `keycloak` secret. The external secrets support in this PR defaults to the same design of having multiple services reference a single secret, but if a different design is easier to use for external secrets then that can be changed. For example maybe a single secret per service with duplicated secret values when they are shared between services makes sense, since the external secret store is the actual source of truth??

Also I assume you would need something like Stakater reloader to restart pods when secrets updated.

Feedback welcome. Including just closing this if you don't actually want to support external secrets this way :smile: 