### PR TITLE
chore: remove bitnami charts

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -107,7 +107,6 @@ jobs:
         helm repo add harbor https://helm.goharbor.io
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo add stable https://charts.helm.sh/stable
-        helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add amazeeio https://amazeeio.github.io/charts/
         helm repo add lagoon https://uselagoon.github.io/lagoon-charts/
         helm repo add nats https://nats-io.github.io/k8s/helm/charts/


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Since Bitnami changed all their stuff around, it has the potential for flow on issues for our charts and local testing. This removes all bitnami references and uses some charts that are relatively new that are mostly drop in replacements, but the key difference is they use upstream images from the providers, rather than bitnami images.

Cloudpirates.io has made charts available basically as bitnami alternatives, see their blog post https://www.cloudpirates.io/knowledge/blog/unsere-open-source-helm-charts-als-bitnami-alternative

As these charts are only used for CI/local development purposes, this is more than suitable for now.

Bonus, it looks like this allows mongodb to be used on ARM systems now as the [upstream mongo](https://hub.docker.com/_/mongo) image appears to provide this.