### PR TITLE
chore: retry apt install due to locking

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -44,7 +44,12 @@ jobs:
         fetch-depth: "0"
 
     - name: Set up chart-testing dependencies
-      run: sudo apt-get -y install python3-wheel
+      run: |
+        for i in $(seq 1 10); do
+          sudo apt-get -y install python3-wheel && break
+          echo "dpkg lock is held, retrying in 10 seconds..."
+          sleep 10
+        done
 
     - name: Set up chart-testing
       uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0


### PR DESCRIPTION
Implement a retry logic around the apt install dependency to prevent the following from failing actions
```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2358 (apt-get)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```