### PR TITLE
feat: support disabling nats remote tls certs if required

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -134,6 +134,7 @@ jobs:
         helm repo add metallb https://metallb.github.io/metallb
         helm repo add jetstack https://charts.jetstack.io
         helm repo add jouve https://jouve.github.io/charts/
+        helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
 
     - name: Install gojq
       if: |

--- a/charts/lagoon-build-deploy/ci/linter-values.yaml
+++ b/charts/lagoon-build-deploy/ci/linter-values.yaml
@@ -7,11 +7,6 @@ sshPortalPort: 22
 lagoonTokenHost: lagoon-core-token.lagoon-core.svc
 lagoonTokenPort: 22
 lagoonAPIHost: http://lagoon-core-api.lagoon-core.svc:80
-extraArgs:
-  - "--skip-tls-verify=true"
 broker:
   tls:
     enabled: true
-  tlsCA:
-    enabled: true
-    secretName: lagoon-remote-broker-tls

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -46,3 +46,5 @@ annotations:
       description: update storage-calculator to v0.9.0
     - kind: changed
       description: allow configuration of docker host pod annotations
+    - kind: changed
+      description: allow nats remote tls certificates to be disabled if not required

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -5,9 +5,6 @@ global:
   broker:
     tls:
       enabled: true
-    tlsCA:
-      enabled: true
-      secretName: lagoon-remote-broker-tls
 
 lagoon-build-deploy:
   enabled: true
@@ -50,7 +47,7 @@ nats:
 natsConfig:
   coreURL: "tls://ci-ssh-portal:ci-password@lagoon-core-nats-concentrator.lagoon-core.svc:7422"
   tls:
-    caOnly: true
+    enableCerts: false
 
 sshPortal:
   enabled: true

--- a/charts/lagoon-remote/templates/nats.secret.yaml
+++ b/charts/lagoon-remote/templates/nats.secret.yaml
@@ -36,6 +36,7 @@ stringData:
       remotes: [
         {
           url: {{ .Values.natsConfig.coreURL | quote }}
+          {{- if .Values.natsConfig.tls.enabled }}
           tls: {
             ca_file: "/etc/nats-ca-cert/ca.crt"
             {{- if not .Values.natsConfig.tls.caOnly }}
@@ -43,6 +44,7 @@ stringData:
             key_file: "/etc/nats-certs/leafnodes/tls.key"
             {{- end }}
           }
+          {{- end }}
         }
       ]
     }

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -441,6 +441,10 @@ natsConfig:
   # use this if you're only providing the ca certificate to nats.
   # this can be used if you've got lagoon-core leafnode tls verify disabled
   tls:
+    # this enables the tls block in the nats secret. if your nats is configured to use a public certificate
+    # and you are not using client certificates, you can set this to `false`.
+    # this value needs to be `true` if `caOnly` is also `true`
+    enableCerts: true
     caOnly: false
     # If the lagoon-remote-nats-tls secret should be created by the
     # lagoon-remote chart, certificate values can be specified directly in

--- a/test-suite.ca-bundle.yaml
+++ b/test-suite.ca-bundle.yaml
@@ -1,0 +1,13 @@
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: public-bundle-lagoon-test-ca
+spec:
+  sources:
+  - useDefaultCAs: true
+  - secret:
+      name: lagoon-test-secret
+      key: "ca.crt"
+  target:
+    configMap:
+      key: "ca-certificates.crt"

--- a/test-suite.certmanager-issuer-ss.yaml
+++ b/test-suite.certmanager-issuer-ss.yaml
@@ -1,37 +1,6 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: selfsigned-issuer
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: lagoon-testing-ca
-  namespace: cert-manager
-spec:
-  isCA: true
-  commonName: lagoon.test
-  subject:
-    organizations:
-      - Lagoon Testing Inc
-    organizationalUnits:
-      - Lagoon
-  dnsNames:
-    - lagoon.test
-  secretName: lagoon-test-secret
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-  issuerRef:
-    name: selfsigned-issuer
-    kind: ClusterIssuer
-    group: cert-manager.io
----
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
   name: lagoon-testing-issuer
 spec:
   ca:

--- a/test-suite.gatekeeper-ca-volume.yaml
+++ b/test-suite.gatekeeper-ca-volume.yaml
@@ -1,0 +1,75 @@
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: trust-ca-volume
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
+      kinds: ["Pod"]
+    excludedNamespaces: ["kube-system", "gatekeeper-system", "cert-manager", "ingress-nginx"]
+  location: "spec.volumes[name:cluster-ca-certs]"
+  parameters:
+    assign:
+      value:
+        name: cluster-ca-certs
+        configMap:
+          name: public-bundle-lagoon-test-ca
+          defaultMode: 0644
+          optional: false
+          items:
+          - key: ca-certificates.crt
+            path: ca-certificates.crt
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: trust-ca-volumemount
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
+      kinds: ["Pod"]
+    excludedNamespaces: ["kube-system", "gatekeeper-system", "cert-manager", "ingress-nginx"]
+  # All containers in a pod mounting to volumeMount named "cluster-ca-certs"
+  location: "spec.containers[name:*].volumeMounts[name:cluster-ca-certs]"
+  parameters:
+    assign:
+      value:
+        mountPath: /etc/ssl/certs/
+        name: cluster-ca-certs
+        readOnly: true
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: ModifySet
+metadata:
+  name: trust-ca-envvar
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
+      kinds: ["Pod"]
+    excludedNamespaces: ["kube-system", "gatekeeper-system", "cert-manager", "ingress-nginx"]
+  # All containers in a pod mounting envvar named "NODE_EXTRA_CA_CERTS" for node applications to use
+  location: "spec.containers[name:*].env"
+  parameters:
+    operation: merge
+    values:
+      fromList:
+        - name: NODE_EXTRA_CA_CERTS
+          value: /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
This changes the configuration for nats in remote to have the option to not add the tls certificate configuration section. This can be useful if you're using trusted public certificates with no client/mutual tls.

Additionally, this changes the local-stack setup to install trust-manager and gatekeeper. This allows the local-stack rootca to be loaded into a certificate bundle, and using gatekeeper, this bundle can be added to every pod.

This means that any certificates generated by cert-manager in the local-stack can be trusted by pods running inside the stack so that insecure certificate warnings are not encountered.