### PR TITLE
chore: bump chart versions for release

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.55.0
+version: 1.56.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.27.0
+appVersion: v2.28.0
 
 dependencies:
 - name: nats
@@ -50,3 +50,5 @@ annotations:
       description: update opensearch-sync to v0.9.1
     - kind: changed
       description: update insights-handler to v0.0.9
+    - kind: changed
+      description: bump chart version for release

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to run a lagoon-remote
 home: https://github.com/uselagoon/lagoon-charts
 icon: https://raw.githubusercontent.com/uselagoon/lagoon-charts/main/icon.png
 maintainers:
-- name: schnitzel
-  email: michael@amazee.com
+- name: shreddedbacon
+  email: ben.jackson@amazee.io
   url: https://amazee.io
 - name: smlx
   email: scott.leggett@amazee.io
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.100.0
+version: 0.101.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -50,3 +50,5 @@ annotations:
       description: update storage-calculator to v0.8.2
     - kind: changed
       description: update lagoon-build-deploy subchart to v0.37.0
+    - kind: changed
+      description: bump chart version for release

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.66.0
+version: 0.67.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.26.0
+appVersion: v2.28.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -29,4 +29,4 @@ appVersion: v2.26.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon appVersion to 2.26.0
+      description: update lagoon appVersion to 2.28.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
