### PR TITLE
fix: seeding job api references and organization name setup

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -50,3 +50,7 @@ annotations:
       description: update opensearch-sync to v0.9.1
     - kind: changed
       description: update insights-handler to v0.0.9
+    - kind: fixed
+      description: fix seeding job to use internal service names for connecting to api
+    - kind: fixed
+      description: fix seeding job to set safe organization name and friendlyname

--- a/charts/lagoon-core/templates/api.seeding.job.yaml
+++ b/charts/lagoon-core/templates/api.seeding.job.yaml
@@ -24,7 +24,7 @@ spec:
           args: 
             - |
               cat <<'JS' > /app/seed-core.js
-{{ .Files.Get "files/seed-core.js" | indent 14 }}
+              {{ .Files.Get "files/seed-core.js" | indent 14 }}
               JS
               node /app/seed-core.js || true
           env:
@@ -49,7 +49,7 @@ spec:
                 name: {{ include "lagoon-core.keycloak.fullname" . }}
                 key: KEYCLOAK_ADMIN_API_CLIENT_SECRET
           - name: KEYCLOAK_FRONTEND_URL
-            value: "{{ .Values.keycloakFrontEndURL }}"
+            value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/auth
           - name: LAGOON_API_URL
-            value: "{{ .Values.lagoonAPIURL }}"
+            value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}/graphql
 {{- end }}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Just some small adjustments to the seed user/org job. 

First is to set the organization name to be made "safe" and lowercase. While setting the full value as the friendly name.

Second adjusts the keycloak url to use the internal one if frontendurl is not provided, and prefer to use the internal lagoon api endpoint