### PR TITLE
feat: additional support for project cloning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ OVERRIDE_BUILD_DEPLOY_DIND_IMAGE =
 # if OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE is not set, it will fall back to the
 # controller default (uselagoon/task-activestandby:${lagoonVersion}).
 OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE =
+# if OVERRIDE_PROJECTCLONE_TASK_IMAGE is not set, it will fall back to the
+# controller default (uselagoon/task-projectclone:${lagoonVersion}).
+OVERRIDE_PROJECTCLONE_TASK_IMAGE =
 # Overrides the image tag for amazeeio/lagoon-builddeploy whose default is
 # the lagoon-build-deploy chart appVersion.
 OVERRIDE_REMOTE_CONTROLLER_IMAGETAG =
@@ -607,6 +610,7 @@ endif
 		$$(if [ $(INSTALL_STABLE_CORE) = true ]; then echo '--values https://raw.githubusercontent.com/uselagoon/lagoon-charts/refs/tags/lagoon-core-$(STABLE_CORE_CHART_VERSION)/charts/lagoon-core/ci/linter-values.yaml'; else echo '--values ./charts/lagoon-core/ci/linter-values.yaml'; fi) \
 		$$([ $(IMAGE_TAG) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set imageTag=$(IMAGE_TAG)') \
 		$$([ $(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set overwriteActiveStandbyTaskImage=$(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE)') \
+		$$([ $(OVERRIDE_PROJECTCLONE_TASK_IMAGE) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set overwriteProjectcloneTaskImage=$(OVERRIDE_PROJECTCLONE_TASK_IMAGE)') \
 		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set buildDeployImage.default.image=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
 		--set api.additionalEnvs.ENABLE_SAVED_HISTORY_EXPORT="true" \
 		--set "keycloakFrontEndURL=$$([ $(LAGOON_CORE_USE_HTTPS) = true ] && echo "https" || echo "http")://lagoon-keycloak.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io" \

--- a/Makefile
+++ b/Makefile
@@ -867,6 +867,7 @@ endif
 		$$([ $(INSTALL_UNAUTHENTICATED_REGISTRY) = true ] && echo --set "unauthenticatedRegistry=registry.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io") \
 		$$([ $(OVERRIDE_REMOTE_CONTROLLER_IMAGETAG) ] && [ $(INSTALL_STABLE_BUILDDEPLOY) = false ] && echo '--set image.tag=$(OVERRIDE_REMOTE_CONTROLLER_IMAGETAG)') \
 		$$([ $(OVERRIDE_REMOTE_CONTROLLER_IMAGE_REPOSITORY) ] && [ $(INSTALL_STABLE_BUILDDEPLOY) = false ] && echo '--set image.repository=$(OVERRIDE_REMOTE_CONTROLLER_IMAGE_REPOSITORY)') \
+		--set image.pullPolicy=Always \
 		$$([ $(REMOTE_CONTROLLER_ROOTLESS_BUILD_PODS) ] && echo '--set rootlessBuildPods=true') \
 		$$([ $(LAGOON_FEATURE_FLAG_DEFAULT_ROOTLESS_WORKLOAD) ] && echo '--set lagoonFeatureFlagDefaultRootlessWorkload=$(LAGOON_FEATURE_FLAG_DEFAULT_ROOTLESS_WORKLOAD)') \
 		$$([ $(LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY) ] && echo '--set lagoonFeatureFlagDefaultIsolationNetworkPolicy=$(LAGOON_FEATURE_FLAG_DEFAULT_ISOLATION_NETWORK_POLICY)') \

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -23,7 +23,7 @@ appVersion: v0.29.1
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update remote-controller to v0.29.1
+      description: update LagoonTask CRD with volume mount support
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2

--- a/charts/lagoon-build-deploy/crds/crd.lagoon.sh_lagoontasks.yaml
+++ b/charts/lagoon-build-deploy/crds/crd.lagoon.sh_lagoontasks.yaml
@@ -162,6 +162,8 @@ spec:
                     type: string
                   sshKey:
                     type: boolean
+                  volumeMounts:
+                    type: boolean
                 type: object
               environment:
                 description: LagoonTaskEnvironment defines the lagoon environment

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: removed
       description: vestiges of harbor support
+    - kind: added
+      description: add support for project cloning task image

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -157,6 +157,10 @@ spec:
         - name: OVERWRITE_ACTIVESTANDBY_TASK_IMAGE
           value: {{ . | quote }}
         {{- end }}
+        {{- with .Values.overwriteProjectcloneTaskImage }}
+        - name: OVERWRITE_PROJECTCLONE_TASK_IMAGE
+          value: {{ . | quote }}
+        {{- end }}
         - name: PROJECTSEED
           valueFrom:
             secretKeyRef:

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -10,6 +10,7 @@
 
 # These values are optional.
 # overwriteActiveStandbyTaskImage:
+# overwriteProjectcloneTaskImage:
 
 # appspecific discovery.json settings
 # This should point to the publicly accessible ssh endpoint as a schema-less

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -29,4 +29,4 @@ appVersion: v2.30.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon appVersion to 2.30.0
+      description: update tests with support for project cloning

--- a/charts/lagoon-test/templates/local-git.deployment.yaml
+++ b/charts/lagoon-test/templates/local-git.deployment.yaml
@@ -39,6 +39,9 @@ spec:
         - name: ssh
           containerPort: 22
           protocol: TCP
+        - name: http
+          containerPort: 8080
+          protocol: TCP
         livenessProbe:
           tcpSocket:
             port: ssh

--- a/charts/lagoon-test/templates/local-git.service.yaml
+++ b/charts/lagoon-test/templates/local-git.service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: ssh
       protocol: TCP
       name: ssh
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
   selector:
     {{- include "lagoon-test.localGit.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

This adds the required functionality to support project cloning in https://github.com/uselagoon/lagoon/pull/4072.