### PR TITLE
PLAT-1004: Add envExistingSecret support to lagoon-logs-concentrator

### DIFF
--- a/charts/lagoon-logs-concentrator/Chart.yaml
+++ b/charts/lagoon-logs-concentrator/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.56.0
+version: 0.57.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -27,4 +27,4 @@ version: 0.56.0
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: allow usage of existing secret for users
+      description: allow usage of existing secret for env

--- a/charts/lagoon-logs-concentrator/templates/secret.yaml
+++ b/charts/lagoon-logs-concentrator/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.envExistingSecret }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -9,6 +10,7 @@ stringData:
   FORWARD_SHARED_KEY: {{ required "A valid .Values.forwardSharedKey required!" .Values.forwardSharedKey }}
   LOGSDB_ADMIN_USER: {{ .Values.opensearchAdminUser }}
   LOGSDB_ADMIN_PASSWORD: {{ required "A valid .Values.opensearchAdminPassword required!" .Values.opensearchAdminPassword }}
+{{- end }}
 {{- if .Values.mTLS }}
 ---
 apiVersion: v1

--- a/charts/lagoon-logs-concentrator/templates/statefulset.yaml
+++ b/charts/lagoon-logs-concentrator/templates/statefulset.yaml
@@ -73,7 +73,11 @@ spec:
         {{- end }}
         envFrom:
         - secretRef:
+            {{- if .Values.envExistingSecret }}
+            name: {{ .Values.envExistingSecret }}
+            {{- else }}
             name: {{ include "lagoon-logs-concentrator.fullname" . }}-env
+            {{- end }}
         - configMapRef:
             name: {{ include "lagoon-logs-concentrator.fullname" . }}-env
         volumeMounts:

--- a/charts/lagoon-logs-concentrator/values.yaml
+++ b/charts/lagoon-logs-concentrator/values.yaml
@@ -104,6 +104,7 @@ buffer:
   size: 32Gi
   storageClassName: ""
 
+envExistingSecret: ""
 usersExistingSecret: ""
 
 # Sample data shown below.


### PR DESCRIPTION
## Summary

Adds support for using an existing external secret for the `-env` secret in `lagoon-logs-concentrator`.

## Changes

- **secret.yaml**: Wrapped the `-env` secret creation in a conditional so it is skipped when `envExistingSecret` is set.
- **statefulset.yaml**: Updated `secretRef` to use `envExistingSecret` when provided, falling back to the auto-generated secret.
- **values.yaml**: Added `envExistingSecret: ""` option.
- **Chart.yaml**: Bumped chart version from `0.56.0` to `0.57.0`.

## Usage

Set `envExistingSecret` to the name of a pre-existing secret containing `FORWARD_SHARED_KEY`, `LOGSDB_ADMIN_USER`, and `LOGSDB_ADMIN_PASSWORD`:

```yaml
envExistingSecret: "my-external-secret"

`Closes: #1004`