### PR TITLE
chore: remove leftover harbor configs in lagoon-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,6 @@ SKIP_INSTALL_REGISTRY =
 # This allows updating the fill-test-ci-values template only, without
 # installing any chart dependencies.
 SKIP_ALL_DEPS =
-# Set to `true` to use the disable harbor integration in lagoon-core
-DISABLE_CORE_HARBOR =
 # Ordinarily we shouldn't need to clear the API data as it's usually a first run. Set this
 # variable on a test run to clear (what's clearable) first
 CLEAR_API_DATA = false
@@ -610,7 +608,6 @@ endif
 		$$([ $(IMAGE_TAG) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set imageTag=$(IMAGE_TAG)') \
 		$$([ $(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set overwriteActiveStandbyTaskImage=$(OVERRIDE_ACTIVE_STANDBY_TASK_IMAGE)') \
 		$$([ $(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE) ] && [ $(INSTALL_STABLE_CORE) != true ] && echo '--set buildDeployImage.default.image=$(OVERRIDE_BUILD_DEPLOY_DIND_IMAGE)') \
-		$$([ $(DISABLE_CORE_HARBOR) ] && echo '--set api.additionalEnvs.DISABLE_CORE_HARBOR=$(DISABLE_CORE_HARBOR)') \
 		--set api.additionalEnvs.ENABLE_SAVED_HISTORY_EXPORT="true" \
 		--set "keycloakFrontEndURL=$$([ $(LAGOON_CORE_USE_HTTPS) = true ] && echo "https" || echo "http")://lagoon-keycloak.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io" \
 		--set "lagoonAPIURL=$$([ $(LAGOON_CORE_USE_HTTPS) = true ] && echo "https" || echo "http")://lagoon-api.$$($(KUBECTL) -n ingress-nginx get services ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io/graphql" \

--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -40,13 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: don't deploy any 'ui-beta' resources when not enabled
-    - kind: fixed
-      description: k8upv2 support for api-db/keycloak-db pods
-    - kind: added
-      description: configurable k8up backupcommand
-    - kind: changed
-      description: update ssh-portal to v0.47.1
-    - kind: changed
-      description: update insights-handler to v0.0.11
+    - kind: removed
+      description: vestiges of harbor support

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -1,9 +1,5 @@
 # Any values defined here are not used anywhere other than lint/CI.
 
-# To be deprecated - see uselagoon/lagoon#2907
-harborURL: http://disabled-only-use-harbor-via-deploy-controller.invalid
-harborAdminPassword: not-needed
-
 # used in api
 elasticsearchURL: http://opendistro-es-client-service.opendistro-es.svc.cluster.local:9200
 kibanaURL: http://opendistro-es-kibana-svc.opendistro-es.svc.cluster.local:443

--- a/charts/lagoon-core/templates/api.deployment.yaml
+++ b/charts/lagoon-core/templates/api.deployment.yaml
@@ -119,10 +119,6 @@ spec:
         - name: GITLAB_API_HOST
           value: {{ . | quote }}
         {{- end }}
-        - name: HARBOR_API_VERSION
-          value: {{ .Values.harborAPIVersion | quote }}
-        - name: HARBOR_URL
-          value: {{ required "A valid .Values.harborURL required!" .Values.harborURL | quote }}
         - name: JWTSECRET
           valueFrom:
             secretKeyRef:

--- a/charts/lagoon-core/templates/api.secret.yaml
+++ b/charts/lagoon-core/templates/api.secret.yaml
@@ -17,7 +17,6 @@ metadata:
 stringData:
   REDIS_PASSWORD: {{ $redisPassword | quote }}
   LOGSDB_ADMIN_PASSWORD: {{ $logsDBAdminPassword | quote }}
-  HARBOR_ADMIN_PASSWORD: {{ required "A valid .Values.harborAdminPassword required!" .Values.harborAdminPassword | quote }}
   S3_FILES_ACCESS_KEY_ID: {{ required "A valid .Values.s3FilesAccessKeyID required!" .Values.s3FilesAccessKeyID | quote }}
   S3_FILES_SECRET_ACCESS_KEY: {{ required "A valid .Values.s3FilesSecretAccessKey required!" .Values.s3FilesSecretAccessKey | quote }}
   S3_BAAS_ACCESS_KEY_ID: {{ required "A valid .Values.s3BAASAccessKeyID required!" .Values.s3BAASAccessKeyID | quote }}

--- a/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
+++ b/charts/lagoon-core/templates/webhooks2tasks.deployment.yaml
@@ -90,13 +90,6 @@ spec:
         - name: OVERWRITE_ACTIVESTANDBY_TASK_IMAGE
           value: {{ . | quote }}
         {{- end }}
-        - name: HARBOR_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "lagoon-core.api.fullname" . }}
-              key: HARBOR_ADMIN_PASSWORD
-        - name: HARBOR_BASE_API_URL
-          value: {{ required "A valid .Values.harborURL required!" .Values.harborURL }}/api/repositories/
         - name: LAGOON_VERSION
           value: {{ .Chart.AppVersion | replace "-" "." }}
         - name: PROJECTSEED

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -1,8 +1,6 @@
 # These values must be set on install, as they don't have sensible defaults.
 
-# harborAdminPassword:
 # elasticsearchURL:
-# harborURL:
 # s3BAASSecretAccessKey:
 # s3BAASAccessKeyID:
 # s3FilesAccessKeyID:
@@ -101,9 +99,6 @@ buildDeployImage:
     image: uselagoon/build-deploy-image:core-v2.31.0
   edge:
     enabled: false
-
-# Set to an empty string to support Harbor v1.x.x
-harborAPIVersion: v2.0
 
 # this default podSecurityContext is set for all services and can be overridden
 # on the service level.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
Harbor support in Lagoon core was removed in 2.20.x, this PR just removes leftover helm config, including required values that end up polluting values files with things like `harborAdminPassword: not-needed`.

Not bumping chart version since I expect other PRs to do that for the next release.