### PR TITLE
chore: change rollout strategy for keycloak

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -44,3 +44,5 @@ annotations:
       description: vestiges of harbor support
     - kind: added
       description: add support for project cloning task image
+    - kind: changed
+      description: change keycloak rollout strategy to recreate

--- a/charts/lagoon-core/templates/keycloak.deployment.yaml
+++ b/charts/lagoon-core/templates/keycloak.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "lagoon-core.keycloak.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "lagoon-core.keycloak.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Small change to the keycloak deployment strategy to be `Recreate` instead of the default `Rollout` to prevent issues with upgrading versions of keycloak.

This does mean that during updates, keycloak *will* be unavailable until the new pod is started.
