### PR TITLE
Lagoon insights updates

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -46,3 +46,7 @@ annotations:
       description: add support for project cloning task image
     - kind: changed
       description: change keycloak rollout strategy to recreate
+    - kind: changed
+      description: update trivy image to 0.70.0
+    - kind: changed
+      description: update insights-handler to v0.0.12

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -700,7 +700,7 @@ insightsHandler:
     repository: uselagoon/insights-handler
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.0.11"
+    tag: "v0.0.12"
 
   podAnnotations: {}
 
@@ -724,7 +724,7 @@ insightsHandler:
     enabled: false
     image:
       repository: aquasec/trivy
-      tag: 0.62.1
+      tag: 0.70.0
     service:
       type: ClusterIP
       port: 4954

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update lagoon-build-deploy subchart to v0.40.1
+    - kind: changed
+      description: update insights-remote to v0.0.18

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -242,7 +242,7 @@ insightsRemote:
     repository: uselagoon/insights-remote
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.0.17"
+    tag: "v0.0.18"
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
Updates versions of insights-core and remote, as well as the version of Trivy run in core for core-insight scanning. All in prep for new release of lagoon.