### PR TITLE
Update lagoon-docker-host chart to v3.6.1 to consume newer image

### DIFF
--- a/charts/lagoon-docker-host/Chart.yaml
+++ b/charts/lagoon-docker-host/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.6.0
+version: 0.7.0
 
-appVersion: v3.5.0
+appVersion: v3.6.1
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -26,4 +26,4 @@ appVersion: v3.5.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: allow configuration of pod annotations
+      description: update docker-host from v3.5.0 to v3.6.1


### PR DESCRIPTION
Updated docker-host chart to consume the latest version of the docker-host service image
