### PR TITLE
Updates remote-controller to v1 in lbd chart

### DIFF
--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -23,6 +23,10 @@ appVersion: v1.0.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
+      description: update LagoonTask CRD with volume mount support
+    - kind: changed
+      description: update LagoonBuild CRD with organization key support
+    - kind: changed
       description: update remote-controller to v1.0.0
   artifacthub.io/crds: |
     - kind: LagoonBuild

--- a/charts/lagoon-build-deploy/Chart.yaml
+++ b/charts/lagoon-build-deploy/Chart.yaml
@@ -16,16 +16,14 @@ kubeVersion: ">= 1.25.0-0"
 
 type: application
 
-version: 0.40.1
+version: 0.41.0
 
-appVersion: v0.29.1
+appVersion: v1.0.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update LagoonTask CRD with volume mount support
-    - kind: changed
-      description: update LagoonBuild CRD with organization key support
+      description: update remote-controller to v1.0.0
   artifacthub.io/crds: |
     - kind: LagoonBuild
       version: v1beta2


### PR DESCRIPTION
Updates the lagoon-build-deploy chart to consume the remote-controller v1.0.0