### PR TITLE
update legacy UI pinned image to core-v2.32.0

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -50,3 +50,5 @@ annotations:
       description: update trivy image to 0.70.0
     - kind: changed
       description: update insights-handler to v0.0.12
+    - kind: changed
+      description: update legacy ui pinned image to core-v2.32.0

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -587,7 +587,7 @@ ui:
     pullPolicy: Always
     # when updating this chart, ensure that if there are any changes made to the lagoon-ui repository
     # and a new image tag is released, that this image tag is updated to reference the new image version
-    tag: "core-v2.29.0"
+    tag: "core-v2.32.0"
 
   podAnnotations: {}
 


### PR DESCRIPTION
This pull request updates the legacy UI image used in the Lagoon Core Helm chart to a newer version. The main change is pinning the UI image to version `core-v2.32.0`.

**UI Image Update:**

* Updated the legacy UI image tag from `core-v2.29.0` to `core-v2.32.0` in `charts/lagoon-core/values.yaml` to use the latest released version.
* Added a corresponding annotation in `charts/lagoon-core/Chart.yaml` to document the update of the legacy UI pinned image to `core-v2.32.0`.