### PR TITLE
chore: bump lagoon-opensearch-sync version

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.61.0
+version: 1.62.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
@@ -40,21 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: removed
-      description: vestiges of harbor support
-    - kind: added
-      description: add support for project cloning task image
     - kind: changed
-      description: change keycloak rollout strategy to recreate
-    - kind: changed
-      description: update trivy image to 0.70.0
-    - kind: changed
-      description: update insights-handler to v0.0.12
-    - kind: changed
-      description: update legacy ui pinned image to core-v2.32.0
-    - kind: changed
-      description: changed build-deploy-image to core-v2.32.0
-    - kind: changed
-      description: fixed beta-ui version to v0.1.0
-    - kind: changed
-      description: update lagoon appVersion to 2.32.0
+      description: update lagoon-opensearch-sync to v0.15.0


### PR DESCRIPTION
The functional change in this release is more verbose debug logging for start/stop.

https://github.com/uselagoon/lagoon-opensearch-sync/releases/tag/v0.15.0
https://github.com/uselagoon/lagoon-opensearch-sync/issues/243