### PR TITLE
Exclude logging for a configurable list of namespaces (via regexp)

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.92.0
+version: 0.93.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -38,4 +38,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Extend support for external secrets for forward and rabbitmq.
+      description: Support for excluding a list of namespaces from logging collection.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -442,6 +442,20 @@ data:
           </exclude>
         </or>
       </filter>
+      {{- with .Values.excludeNamespaceRegexps }}
+      #
+      # Drop logs from namespaces matching the configured regex patterns
+      #
+      <filter lagoon.**>
+        @type grep
+        {{- range . }}
+        <exclude>
+          key $.kubernetes.namespace_name
+          pattern {{ . }}
+        </exclude>
+        {{- end }}
+      </filter>
+      {{- end }}
       #
       # forward all to logs-concentrator
       #

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -230,6 +230,13 @@ extraExcludeNamespaces: []
 # - extra-namespace-0
 # - extra-namespace-1
 
+# Regex patterns to exclude namespaces from log forwarding.
+# Logs from namespaces whose name matches any of these patterns are dropped
+# before being forwarded. Uses Ruby regex syntax (Fluentd grep filter).
+# A single pattern covers all log types (container, router, application).
+excludeNamespaceRegexps: []
+# - "^myproject"
+
 # Configure the cluster output buffer.
 # This may require tweaking to handle high volumes of logs.
 clusterOutputBuffer:


### PR DESCRIPTION
This PR will add a configurable list of regexp exclusions so that Fluentd can ignore any namespaces that match any of the configured regexp rules.

This is useful because, if we need to exclude a bunch of namespaces from logging (e.g., a particular client, project, or logging type), we can do so safely downstream of this chart without exposing information that might be sensitive.