### PR TITLE
Allow exceptions to disabling namespace regexps

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.93.0
+version: 0.94.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -38,4 +38,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Support for excluding a list of namespaces from logging collection.
+      description: Support for excluding a list of namespaces from having logging collection turned off.

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -448,11 +448,25 @@ data:
       #
       <filter lagoon.**>
         @type grep
+        {{- $exceptions := $.Values.exceptNamespaceRegexps }}
         {{- range . }}
+        {{- if $exceptions }}
+        <and>
+          <exclude>
+            key $.kubernetes.namespace_name
+            pattern {{ . }}
+          </exclude>
+          <regexp>
+            key $.kubernetes.namespace_name
+            pattern ^(?!({{ join "|" $exceptions }}))
+          </regexp>
+        </and>
+        {{- else }}
         <exclude>
           key $.kubernetes.namespace_name
           pattern {{ . }}
         </exclude>
+        {{- end }}
         {{- end }}
       </filter>
       {{- end }}

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -237,6 +237,12 @@ extraExcludeNamespaces: []
 excludeNamespaceRegexps: []
 # - "^myproject"
 
+# Regex patterns to exempt specific namespaces from exclusion.
+# Namespaces matching any of these patterns will NOT be dropped even if they
+# match an excludeNamespaceRegexps pattern. Uses Ruby regex syntax.
+exceptNamespaceRegexps: []
+# - "^myproject-special$"
+
 # Configure the cluster output buffer.
 # This may require tweaking to handle high volumes of logs.
 clusterOutputBuffer:


### PR DESCRIPTION
This PR will allow Fluentd configuration to exempt certain namespace regexp patterns from logging disablement, for when specific edge cases need to be configured on a case-by-case basis.