### PR TITLE
Syntax correction for namespace exclusion

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.93.0
+version: 0.94.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -37,5 +37,5 @@ dependencies:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: added
-      description: Support for excluding a list of namespaces from logging collection.
+    - kind: fixed
+      description: Exclusion namespace matching syntax error

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -107,6 +107,10 @@ cdnLogsCollector:
       xSz1hWx3HID81bhRijZ+icPvoJU0NpTXoQ==
       -----END EC PRIVATE KEY-----
 
+excludeNamespaceRegexps:
+- ^kube-system$
+- ^monitoring$
+
 extraExcludeNamespaces:
 - ci-fake-namespace-0
 - ci-fake-namespace-1

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -448,12 +448,10 @@ data:
       #
       <filter lagoon.**>
         @type grep
-        {{- range . }}
         <exclude>
           key $.kubernetes.namespace_name
-          pattern {{ . }}
+          pattern {{ join "|" . }}
         </exclude>
-        {{- end }}
       </filter>
       {{- end }}
       #


### PR DESCRIPTION
There was a minor compilation error in the feature added in 0.93.0 that lets you exclude a bunch of namespaces from having their logging collected. This will fix that syntax problem by simply using the pattern on a single line.

Configuration has been validated using a local Fluentd container.