### PR TITLE
Release for Lagoon 2.33.0

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.61.0
+version: 1.62.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.32.0
+appVersion: v2.33.0
 
 dependencies:
 - name: nats
@@ -44,3 +44,11 @@ annotations:
       description: backup-handler no longer requires rabbitmq connections
     - kind: removed
       description: removed webhooks2tasks as no longer used
+    - kind: changed
+      description: update build-deploy-image to core-v2.33.0
+    - kind: changed
+      description: update beta-ui version to v0.2.0
+    - kind: changed
+      description: update lagoon appVersion to 2.33.0
+    - kind: changed
+      description: update opensearch-sync to v0.15.0

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -97,7 +97,7 @@ buildDeployImage:
   default:
     # when updating this chart, ensure that if there are any changes made to the build-deploy-tool repository
     # and a new image tag is released, that this image tag is updated to reference the new image version
-    image: uselagoon/build-deploy-image:core-v2.32.0
+    image: uselagoon/build-deploy-image:core-v2.33.0
   edge:
     enabled: false
 
@@ -1027,7 +1027,7 @@ opensearchSync:
     repository: ghcr.io/uselagoon/lagoon-opensearch-sync
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.14.2"
+    tag: "v0.15.0"
 
   # debug logging toggle
   debug: false
@@ -1111,7 +1111,7 @@ betaUI:
     pullPolicy: Always
     # when updating this chart, ensure that if there are any changes made to the lagoon-beta-ui repository
     # and a new image tag is released, that this image tag is updated to reference the new image version
-    tag: "v0.1.0"
+    tag: "v0.2.0"
 
   podAnnotations: {}
 

--- a/charts/lagoon-remote/Chart.lock
+++ b/charts/lagoon-remote/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: lagoon-build-deploy
   repository: https://uselagoon.github.io/lagoon-charts/
-  version: 0.41.0
+  version: 0.42.0
 - name: dbaas-operator
   repository: https://amazeeio.github.io/charts/
   version: 0.5.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.14
-digest: sha256:a724193388f8dbca7555a2d597587ab774a981b520e06ab1b9cd40417ae6717c
-generated: "2026-05-22T17:54:02.043778735Z"
+digest: sha256:1e928e8c4e337ee522383a023fd3f6e995a922f8b28c662a3ea7ea38b4252798
+generated: "2026-07-13T18:13:09.165526267-05:00"

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.106.0
 
 dependencies:
 - name: lagoon-build-deploy
-  version: ~0.41.0
+  version: ~0.42.0
   repository: https://uselagoon.github.io/lagoon-charts/
   condition: lagoon-build-deploy.enabled
 - name: dbaas-operator
@@ -42,3 +42,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: update insights-remote to v0.0.19
+    - kind: changed
+      description: update storage-calculator to v0.9.4
+    - kind: changed
+      description: update lagoon-build-deploy subchart to v0.42.0

--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.105.0
+version: 0.106.0
 
 dependencies:
 - name: lagoon-build-deploy
@@ -41,10 +41,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update insights-remote to v0.0.18
-    - kind: changed
-      description: update lagoon-build-deploy subchart to v0.41.0
-    - kind: changed
-      description: updates storage calculator to v0.9.3
-    - kind: changed
-      description: Update Helm release dbaas-operator to ~0.5.0
+      description: update insights-remote to v0.0.19

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -242,7 +242,7 @@ insightsRemote:
     repository: uselagoon/insights-remote
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.0.18"
+    tag: "v0.0.19"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -494,7 +494,7 @@ storageCalculator:
     repository: uselagoon/remote-calculator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.3
+    tag: v0.9.4
 
   broker:
     # enable if providing a custom CA for broker connections

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -29,4 +29,4 @@ appVersion: v2.33.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description:  update lagoon appVersion to 2.33.0
+      description: update lagoon appVersion to 2.33.0

--- a/charts/lagoon-test/Chart.yaml
+++ b/charts/lagoon-test/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.70.0
+version: 0.71.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using.
-appVersion: v2.30.0
+appVersion: v2.33.0
 
 # This section is used to collect a changelog for artifacthub.io
 # It should be started afresh for each release
@@ -29,4 +29,4 @@ appVersion: v2.30.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update tests with support for project cloning
+      description:  update lagoon appVersion to 2.33.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
Charts changes to release Lagoon v2.33.0 and related versions.