### PR TITLE
Exclude configured lagoon-logs-*

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.94.0
+version: 0.95.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -38,4 +38,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: fixed
-      description: Exclusion namespace matching syntax error
+      description: Prevent the inclusion of lagoon-logs-* for configured exclusion rules

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -453,6 +453,17 @@ data:
           pattern {{ join "|" . }}
         </exclude>
       </filter>
+      #
+      # Drop lagoon-logs (broker logs) where the project matches the same patterns.
+      # lagoon.*.lagoon records have no kubernetes.namespace_name; they use record['project'].
+      #
+      <filter lagoon.*.lagoon>
+        @type grep
+        <exclude>
+          key $.project
+          pattern {{ join "|" . }}
+        </exclude>
+      </filter>
       {{- end }}
       #
       # forward all to logs-concentrator

--- a/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/logs-dispatcher.fluent-conf.configmap.yaml
@@ -456,12 +456,18 @@ data:
       #
       # Drop lagoon-logs (broker logs) where the project matches the same patterns.
       # lagoon.*.lagoon records have no kubernetes.namespace_name; they use record['project'].
+      # Namespace patterns have a trailing "-" (e.g. "^myproject-") which won't match the bare
+      # project name, so trim trailing "-" from each pattern before matching.
       #
       <filter lagoon.*.lagoon>
         @type grep
         <exclude>
           key $.project
-          pattern {{ join "|" . }}
+          {{- $projectPatterns := list -}}
+          {{- range . -}}
+            {{- $projectPatterns = append $projectPatterns (trimSuffix "-" .) -}}
+          {{- end }}
+          pattern {{ join "|" $projectPatterns }}
         </exclude>
       </filter>
       {{- end }}


### PR DESCRIPTION
This MR will exclude lagoon-logs-* from the configured exclusion regexes (of namespaces) so that lagoon build logs will also not be included in logging collection based on regexp. So, if you need to enable a specific environment/project collection, there is still a good way to do that at a low scale.

Plans for a broader scale approach have been made and can be included if that becomes a legitimate use case.

Now ready for review, this has been tested thoroughly and validated on a test cluster.
Internally, this relates to PLAT-1270.