### PR TITLE
fix: add missing build image override to webhook-handler

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -40,15 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: backup-handler no longer requires rabbitmq connections
-    - kind: removed
-      description: removed webhooks2tasks as no longer used
-    - kind: changed
-      description: update build-deploy-image to core-v2.33.0
-    - kind: changed
-      description: update beta-ui version to v0.2.0
-    - kind: changed
-      description: update lagoon appVersion to 2.33.0
-    - kind: changed
-      description: update opensearch-sync to v0.15.0
+    - kind: fixed
+      description: add missing build image override logic to webhook-handler

--- a/charts/lagoon-core/templates/webhook-handler.deployment.yaml
+++ b/charts/lagoon-core/templates/webhook-handler.deployment.yaml
@@ -55,6 +55,16 @@ spec:
               key: JWTSECRET
         - name: GRAPHQL_ENDPOINT
           value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}/graphql
+        - name: DEFAULT_BUILD_DEPLOY_IMAGE
+        {{- with dig "default" "image" nil .Values.buildDeployImage }}
+          value: {{ . }}
+        {{- else }}
+          value: {{ print "uselagoon/build-deploy-image:core-" .Chart.AppVersion }}
+        {{- end }}
+      {{- if dig "edge" "enabled" nil .Values.buildDeployImage }}
+        - name: EDGE_BUILD_DEPLOY_IMAGE
+          value: {{ coalesce .Values.buildDeployImage.edge.image (print "uselagoon/build-deploy-image:edge-v" (semver .Chart.AppVersion).Major "." (semver .Chart.AppVersion).Minor ".x") }}
+      {{- end }}
       {{- range $key, $val := .Values.webhookHandler.additionalEnvs }}
         - name: {{ $key }}
           value: {{ $val | quote }}


### PR DESCRIPTION
In #858 the build image override was missing in the webhook-handler. This adds it back in