### PR TITLE
fix: use correct value for lagoon-remote nats tls block

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -40,9 +40,5 @@ dependencies:
 # Valid supported kinds are added, changed, deprecated, removed, fixed and security
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: update insights-remote to v0.0.19
-    - kind: changed
-      description: update storage-calculator to v0.9.4
-    - kind: changed
-      description: update lagoon-build-deploy subchart to v0.42.0
+    - kind: fixed
+      description: use correct value name for enabling nats tls block

--- a/charts/lagoon-remote/ci/linter-values.yaml
+++ b/charts/lagoon-remote/ci/linter-values.yaml
@@ -47,7 +47,7 @@ nats:
 natsConfig:
   coreURL: "tls://ci-ssh-portal:ci-password@lagoon-core-nats-concentrator.lagoon-core.svc:7422"
   tls:
-    enableCerts: false
+    enabled: false
 
 sshPortal:
   enabled: true

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -450,7 +450,7 @@ natsConfig:
     # this enables the tls block in the nats secret. if your nats is configured to use a public certificate
     # and you are not using client certificates, you can set this to `false`.
     # this value needs to be `true` if `caOnly` is also `true`
-    enableCerts: true
+    enabled: true
     caOnly: false
     # If the lagoon-remote-nats-tls secret should be created by the
     # lagoon-remote chart, certificate values can be specified directly in


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

Fixes the incorrect value in lagoon-remote for enabling the NATS tls block options.

closes #934 