### PR TITLE
feat: auto-generated hostkeys for lagoon-remote ssh-portal

### DIFF
--- a/charts/lagoon-remote/Chart.yaml
+++ b/charts/lagoon-remote/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: use correct value name for enabling nats tls block
+    - kind: added
+      description: automatically generate lagoon-remote ssh-portal hostkeys unless defined

--- a/charts/lagoon-remote/templates/ssh-portal.secret.yaml
+++ b/charts/lagoon-remote/templates/ssh-portal.secret.yaml
@@ -1,21 +1,57 @@
 {{- if .Values.sshPortal.enabled -}}
+{{- $fullName := include "lagoon-remote.sshPortal.fullname" . }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $fullName }}
+
+{{/* ed25519 */}}
+{{- $ed25519Key := .Values.sshPortal.hostKeys.ed25519 }}
+{{- if and (not $ed25519Key) .Values.sshPortal.hostKeys.generateEd25519 }}
+  {{- $existing := dig "data" "HOST_KEY_ED25519" "" $existingSecret }}
+  {{- if $existing }}
+    {{- $ed25519Key = $existing | b64dec }}
+  {{- else }}
+    {{- $ed25519Key = genPrivateKey "ed25519" }}
+  {{- end }}
+{{- end }}
+
+{{/* ecdsa */}}
+{{- $ecdsaKey := .Values.sshPortal.hostKeys.ecdsa }}
+{{- if and (not $ecdsaKey) .Values.sshPortal.hostKeys.generateEcdsa }}
+  {{- $existing := dig "data" "HOST_KEY_ECDSA" "" $existingSecret }}
+  {{- if $existing }}
+    {{- $ecdsaKey = $existing | b64dec }}
+  {{- else }}
+    {{- $ecdsaKey = genPrivateKey "ecdsa" }}
+  {{- end }}
+{{- end }}
+
+{{/* rsa */}}
+{{- $rsaKey := .Values.sshPortal.hostKeys.rsa }}
+{{- if and (not $rsaKey) .Values.sshPortal.hostKeys.generateRsa }}
+  {{- $existing := dig "data" "HOST_KEY_RSA" "" $existingSecret }}
+  {{- if $existing }}
+    {{- $rsaKey = $existing | b64dec }}
+  {{- else }}
+    {{- $rsaKey = genPrivateKey "rsa" }}
+  {{- end }}
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "lagoon-remote.sshPortal.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "lagoon-remote.sshPortal.labels" . | nindent 4 }}
 stringData:
-  {{- with .Values.sshPortal.hostKeys.ecdsa }}
-  HOST_KEY_ECDSA: |-
-    {{- . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.sshPortal.hostKeys.ed25519 }}
+  {{- with $ed25519Key }}
   HOST_KEY_ED25519: |-
     {{- . | nindent 4 }}
   {{- end }}
-  {{- with .Values.sshPortal.hostKeys.rsa }}
+  {{- with $ecdsaKey }}
+  HOST_KEY_ECDSA: |-
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with $rsaKey }}
   HOST_KEY_RSA: |-
     {{- . | nindent 4 }}
   {{- end }}

--- a/charts/lagoon-remote/values.yaml
+++ b/charts/lagoon-remote/values.yaml
@@ -179,6 +179,9 @@ sshPortal:
     ecdsa: ""
     ed25519: ""
     rsa: ""
+    generateEd25519: true
+    generateEcdsa: false
+    generateRsa: false
 
   # Log access via SSH is disabled by default.
   # Uncomment this line to enable log access via SSH.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->

This enables automatically generated hostkeys for lagoon-remote ssh-portal. If ones are already defined in the values, they will be used. If automatically generated ones are created, they will also be re-used on updates.

Only `ed25519` will be generated by default, `rsa` and `ecdsa` are optional.