### PR TITLE
Add optional mTLS for CDN logs collector

### DIFF
--- a/charts/lagoon-logging/Chart.yaml
+++ b/charts/lagoon-logging/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.96.0
+version: 0.97.0
 
 # AppVersion is set here the same as the logging-operator chart version to
 # autopopulate the post-install CRD message.
@@ -38,4 +38,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Adds support for Traefik ingresses for router logs collection.
+      description: Allow optional mTLS for the CDN logs collector.

--- a/charts/lagoon-logging/ci/linter-values.yaml
+++ b/charts/lagoon-logging/ci/linter-values.yaml
@@ -73,6 +73,7 @@ cdnLogsCollector:
     type: ClusterIP
     annotations:
       sh.lagoon.chart.testKey: lagoonTestValue
+  mTLS: true
   tls:
     caCert: |-
       -----BEGIN CERTIFICATE-----

--- a/charts/lagoon-logging/templates/cdn-logs-collector.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.fluent-conf.configmap.yaml
@@ -35,16 +35,25 @@ data:
         private_key_path /fluentd/tls/server.key
         client_cert_auth true
       </transport>
-      {{- else }}
-      <security>
-        self_hostname "#{ENV['LOGS_FORWARD_SELF_HOSTNAME']}"
-        shared_key "#{ENV['LOGS_FORWARD_SHARED_KEY']}"
-      </security>
       {{- end }}
       <parse>
         @type json
       </parse>
     </source>
+
+    {{- if not .Values.cdnLogsCollector.mTLS }}
+    <filter lagoon.cdn>
+      @type grep
+      <regexp>
+        key auth_token
+        pattern "^#{ENV['CDN_LOGS_AUTH_TOKEN']}$"
+      </regexp>
+    </filter>
+    <filter lagoon.cdn>
+      @type record_modifier
+      remove_keys auth_token
+    </filter>
+    {{- end }}
 
     # uncomment to debug
     # <filter lagoon.**>

--- a/charts/lagoon-logging/templates/cdn-logs-collector.fluent-conf.configmap.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.fluent-conf.configmap.yaml
@@ -28,12 +28,19 @@ data:
       @id   in_tcp
       tag   "lagoon.cdn"
       port  5140
+      {{- if .Values.cdnLogsCollector.mTLS }}
       <transport tls>
         ca_path /fluentd/tls/ca.crt
         cert_path /fluentd/tls/server.crt
         private_key_path /fluentd/tls/server.key
         client_cert_auth true
       </transport>
+      {{- else }}
+      <security>
+        self_hostname "#{ENV['LOGS_FORWARD_SELF_HOSTNAME']}"
+        shared_key "#{ENV['LOGS_FORWARD_SHARED_KEY']}"
+      </security>
+      {{- end }}
       <parse>
         @type json
       </parse>

--- a/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
@@ -14,3 +14,19 @@ stringData:
   server.key: |
     {{- required "A valid .Values.cdnLogsCollector.tls.serverKey required!" .Values.cdnLogsCollector.tls.serverKey | nindent 4 }}
 {{- end }}
+{{- if and (.Values.cdnLogsCollector.enabled) (not .Values.cdnLogsCollector.mTLS) }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-env
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+stringData:
+{{- if .Values.enableDefaultForwarding }}
+  # self hostname should match the CN on the client certificate
+  LOGS_FORWARD_SELF_HOSTNAME: {{ required "A valid .Values.forward.selfHostname required!" .Values.forward.selfHostname }}
+  LOGS_FORWARD_SHARED_KEY: {{ required "A valid .Values.forward.sharedKey required!" .Values.forward.sharedKey }}
+{{- end }}
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-auth
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-env
   labels:
     {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
 stringData:

--- a/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
@@ -14,19 +14,3 @@ stringData:
   server.key: |
     {{- required "A valid .Values.cdnLogsCollector.tls.serverKey required!" .Values.cdnLogsCollector.tls.serverKey | nindent 4 }}
 {{- end }}
-{{- if and (.Values.cdnLogsCollector.enabled) (not .Values.cdnLogsCollector.mTLS) }}
----
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-env
-  labels:
-    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
-stringData:
-{{- if .Values.enableDefaultForwarding }}
-  # self hostname should match the CN on the client certificate
-  LOGS_FORWARD_SELF_HOSTNAME: {{ required "A valid .Values.forward.selfHostname required!" .Values.forward.selfHostname }}
-  LOGS_FORWARD_SHARED_KEY: {{ required "A valid .Values.forward.sharedKey required!" .Values.forward.sharedKey }}
-{{- end }}
-{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cdnLogsCollector.enabled -}}
+{{- if and .Values.cdnLogsCollector.enabled .Values.cdnLogsCollector.mTLS -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.secret.yaml
@@ -14,3 +14,15 @@ stringData:
   server.key: |
     {{- required "A valid .Values.cdnLogsCollector.tls.serverKey required!" .Values.cdnLogsCollector.tls.serverKey | nindent 4 }}
 {{- end }}
+{{- if and (.Values.cdnLogsCollector.enabled) (not .Values.cdnLogsCollector.mTLS) }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-auth
+  labels:
+    {{- include "lagoon-logging.cdnLogsCollector.labels" . | nindent 4 }}
+stringData:
+  CDN_LOGS_AUTH_TOKEN: {{ required "A valid .Values.cdnLogsCollector.authToken required! (or enable .Values.cdnLogsCollector.mTLS instead)" .Values.cdnLogsCollector.authToken | quote }}
+{{- end }}

--- a/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
@@ -42,6 +42,9 @@ spec:
           {{- toYaml .Values.cdnLogsCollector.securityContext | nindent 10 }}
         image: "{{ .Values.cdnLogsCollector.image.repository }}:{{ coalesce .Values.cdnLogsCollector.image.tag .Values.imageTag "latest" }}"
         imagePullPolicy: {{ .Values.cdnLogsCollector.image.pullPolicy }}
+        envFrom:
+        - secretRef:
+            name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-env
         ports:
         - containerPort: 5140
           protocol: TCP

--- a/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         imagePullPolicy: {{ .Values.cdnLogsCollector.image.pullPolicy }}
         envFrom:
         - secretRef:
-            name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-env
+            name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-env
         ports:
         - containerPort: 5140
           protocol: TCP

--- a/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         {{- if not .Values.cdnLogsCollector.mTLS }}
         envFrom:
         - secretRef:
-            name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-auth
+            name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-env
         {{- end }}
         ports:
         - containerPort: 5140

--- a/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
@@ -42,9 +42,11 @@ spec:
           {{- toYaml .Values.cdnLogsCollector.securityContext | nindent 10 }}
         image: "{{ .Values.cdnLogsCollector.image.repository }}:{{ coalesce .Values.cdnLogsCollector.image.tag .Values.imageTag "latest" }}"
         imagePullPolicy: {{ .Values.cdnLogsCollector.image.pullPolicy }}
+        {{- if not .Values.cdnLogsCollector.mTLS }}
         envFrom:
         - secretRef:
-            name: {{ include "lagoon-logging.logsDispatcher.fullname" . }}-env
+            name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-auth
+        {{- end }}
         ports:
         - containerPort: 5140
           protocol: TCP

--- a/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
+++ b/charts/lagoon-logging/templates/cdn-logs-collector.statefulset.yaml
@@ -63,8 +63,10 @@ spec:
         - mountPath: /fluentd/etc/fluent.conf
           name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
           subPath: fluent.conf
+        {{- if .Values.cdnLogsCollector.mTLS }}
         - mountPath: /fluentd/tls/
           name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
+        {{- end }}
         resources:
           {{- toYaml .Values.cdnLogsCollector.resources | nindent 10 }}
       {{- with .Values.cdnLogsCollector.nodeSelector }}
@@ -87,10 +89,12 @@ spec:
             path: fluent.conf
           name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
         name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-fluent-conf
+      {{- if .Values.cdnLogsCollector.mTLS }}
       - secret:
           defaultMode: 420
           secretName: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
         name: {{ include "lagoon-logging.cdnLogsCollector.fullname" . }}-tls
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: buffer

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -175,6 +175,9 @@ cdnLogsCollector:
   # If TLS configuration not required disable mTLS.
   # mTLS: false
 
+  # Required when mTLS is disabled.
+  authToken: ""
+
   # TLS configuration is required
   # These should be server certificates, and the CDN should be configured to
   # present client certificates with the same trust root.

--- a/charts/lagoon-logging/values.yaml
+++ b/charts/lagoon-logging/values.yaml
@@ -172,6 +172,9 @@ cdnLogsCollector:
     type: LoadBalancer
     annotations: {}
 
+  # If TLS configuration not required disable mTLS.
+  # mTLS: false
+
   # TLS configuration is required
   # These should be server certificates, and the CDN should be configured to
   # present client certificates with the same trust root.


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
The CDN logs collector can authenticate with a shared key defined in the fluentd.conf without custom TLS certificates and a custom CA. Certificates generated from a publicly trusted CA via a ClusterIssuer removes the need for the custom CA certificate but keeps TLS transport in place.