### PR TITLE
feat: make storageclass and -size configurable for apiDB, broker and …

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.62.3
+version: 1.63.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/api-db.statefulset.yaml
@@ -95,5 +95,9 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ .Values.apiDB.storageSize | quote }}
+          storage: {{ ( default .Values.apiDB.storage.size .Values.apiDB.storageSize ) | quote }}
+
+      {{- with .Values.apiDB.storage.className }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
 {{- end}}

--- a/charts/lagoon-core/templates/broker.statefulset.yaml
+++ b/charts/lagoon-core/templates/broker.statefulset.yaml
@@ -137,4 +137,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 8Gi
+          storage: {{ .Values.broker.storage.size | quote }}
+      {{- with .Values.broker.storage.className }}
+      storageClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
+++ b/charts/lagoon-core/templates/keycloak-db.statefulset.yaml
@@ -97,5 +97,8 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 16Gi
+          storage: {{ .Values.keycloakDB.storage.size | quote }}
+      {{- with .Values.keycloakDB.storage.className }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
 {{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -204,7 +204,25 @@ apiDB:
   additionalEnvs:
   #   FOO: Bar
 
-  storageSize: 128Gi
+  # use storage.size below
+  # storageSize: 128Gi
+
+  storage:
+    size: 128Gi
+    # className sets the storageClassName for the docker-host PVC. This is
+    # useful if the docker-host requires a specific storage class for features
+    # such as increased IOPS.
+    #
+    # WARNING: On platforms such as AKS not all storage volume classes can be
+    # bound to all node types. So if you configure a storage class that can't
+    # be bound to any nodes in the cluster it will cause the docker-host pod to
+    # fail to schedule. For example AKS requires Premium Storage suport on the
+    # node for the managed-premium storage class.
+    #
+    # If className is not defined the chart will not set any specify storage
+    # class on the PVC, effectively falling back to the cluster default.
+    #
+    # className: managed-premium
 
   terminationGracePeriodSeconds: 30
 
@@ -374,6 +392,23 @@ keycloakDB:
       command:
       - /usr/share/container-scripts/mysql/readiness-probe.sh
 
+  storage:
+    size: 16Gi
+    # className sets the storageClassName for the docker-host PVC. This is
+    # useful if the docker-host requires a specific storage class for features
+    # such as increased IOPS.
+    #
+    # WARNING: On platforms such as AKS not all storage volume classes can be
+    # bound to all node types. So if you configure a storage class that can't
+    # be bound to any nodes in the cluster it will cause the docker-host pod to
+    # fail to schedule. For example AKS requires Premium Storage suport on the
+    # node for the managed-premium storage class.
+    #
+    # If className is not defined the chart will not set any specify storage
+    # class on the PVC, effectively falling back to the cluster default.
+    #
+    # className: managed-premium
+
 broker:
   replicaCount: 1
   image:
@@ -475,6 +510,23 @@ broker:
     # If the TLS secret is created outside the lagoon-core chart, it should be
     # named lagoon-core-broker-tls. This secret should contain fields ca.crt, tls.crt and
     # tls.key, and the certificate should be issued by a public authority.
+
+  storage:
+    size: 8Gi
+    # className sets the storageClassName for the docker-host PVC. This is
+    # useful if the docker-host requires a specific storage class for features
+    # such as increased IOPS.
+    #
+    # WARNING: On platforms such as AKS not all storage volume classes can be
+    # bound to all node types. So if you configure a storage class that can't
+    # be bound to any nodes in the cluster it will cause the docker-host pod to
+    # fail to schedule. For example AKS requires Premium Storage suport on the
+    # node for the managed-premium storage class.
+    #
+    # If className is not defined the chart will not set any specify storage
+    # class on the PVC, effectively falling back to the cluster default.
+    #
+    # className: managed-premium
 
 authServer:
   replicaCount: 2


### PR DESCRIPTION
…keycloakDB

The lagoon-remote chart offers a convenient way to define both storage size and class for the docker-host StatefulSet:

```
dockerHost:
  storage:
    create: true
    size: 750Gi
    # className: managed-premium
```

The lagoon-core chart offers only a setting for `apiDB.storageSize`, but no definition of the Storage Class. For broker and keycloak-db the storage size is even hardcoded and cannot be changed at all.

This PR adopts similar settings as in lagoon-remote for api-db, broker and keycloak-db while still taking `apiDB.storageSize` into account if the "new" values are not used.

The default value for each setting is the current hardcoded value.

```
apiDB:
  storage:
    size: 128Gi
    # className: managed-premium

keycloakDB:
  storage:
    size: 16Gi
    # className: managed-premium

broker:
  storage:
    size: 8Gi
    # className: managed-premium
```

<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
