### PR TITLE
fix: fix job securitycontext usage in lagoon-core

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.62.3
+version: 1.63.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/api-db.secret-migratejob.yaml
+++ b/charts/lagoon-core/templates/api-db.secret-migratejob.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       restartPolicy: Never
       securityContext:
-          {{- toYaml .Values.api.securityContext | nindent 8 }}
+        {{- toYaml (coalesce .Values.apiDB.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
       terminationGracePeriodSeconds: 120
       containers:
       - name: api-migratedb

--- a/charts/lagoon-core/templates/broker.bootstrap.job.yaml
+++ b/charts/lagoon-core/templates/broker.bootstrap.job.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       restartPolicy: Never
       securityContext:
-          {{- toYaml .Values.broker.securityContext | nindent 8 }}
+        {{- toYaml (coalesce .Values.broker.podSecurityContext .Values.podSecurityContext) | nindent 8 }}
       terminationGracePeriodSeconds: 120
       containers:
       - name: broker-job


### PR DESCRIPTION
Currently, defining a securityContext for either broker or api breaks the corresponding jobs created on helm updates in all but the most simple cases.

The reason being that `api.securityContext` is used as a container Security Context for the api deployment, but both as pod Security Context and container Security Context for api-db.secret-migration job.

For broker the situation is similar with the broker.bootstrap job.

This PR fixes that by using the respective securityContext setting for the container only and using podSecurityContext for the pod Security Context.
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->
<!--
Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
